### PR TITLE
Improve README guidance and add bats coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,37 +4,100 @@ A lightweight MCP-inspired planner that wraps a local `llama.cpp` binary, ranks
 registered tools via ToolRAG, and executes them in either supervised (human
 confirmation) or unsupervised mode.
 
-## Features
+## Installation
 
-- Configurable model path, supervised flag, and verbosity via CLI flags or
-  environment variables.
-- Structured JSON logging for predictable parsing.
-- Tool registry covering OS navigation, project search (`fd`/`rg`), reminders,
-  a mail draft stub, and macOS-only AppleScript execution with defensive checks.
-- ToolRAG ranking that prefers llama.cpp scoring when available and falls back
-  to heuristics otherwise.
-- Planner/executor loop that collects a plan, confirms tool usage in supervised
-  mode, executes handlers, and summarizes results.
+The project ships with a Homebrew-based installer that bootstraps dependencies
+and installs the CLI binary:
 
-## Usage
+```bash
+./scripts/install
+```
+
+The installer will:
+
+1. Ensure Homebrew is available (installing it if missing).
+2. Install command-line dependencies (`llama.cpp`, `tesseract`, `pandoc`,
+   `poppler`, `yq`).
+3. Copy the `src/` contents into `/usr/local/do` and symlink the entrypoint to
+   `/usr/local/bin/do`.
+
+For manual setups, ensure `bash` 5+, `llama.cpp` (optional for heuristic mode),
+`fd`, and `rg` are on your `PATH`, then run the script directly with `./src/main.sh`.
+
+## Configuration
+
+Environment variables control runtime behavior and can be stored in an env file
+(such as `tests/fixtures/sample.env`):
+
+- `DO_MODEL_PATH`: Path to the llama.cpp model (default: `./models/llama.gguf`).
+- `DO_SUPERVISED`: `true`/`false` to toggle confirmation prompts (default:
+  `true`).
+- `DO_VERBOSITY`: `0` (quiet), `1` (info), `2` (debug). Overrides `-v`/`-q`.
+- `LLAMA_BIN`: llama.cpp binary to use (default: `llama`; can point to the mock
+  `tests/fixtures/mock_llama.sh` during testing).
+
+The included `tests/fixtures/sample.env` demonstrates a debug-friendly,
+unsupervised configuration that prefers the notes tool for reminder queries.
+Running with that config and a reminder request will emit a tool prompt where
+`notes` is scored highest, followed by a summary beginning with
+`[notes executed]`.
+
+## Modes
+
+- **Supervised** (default): prompts before executing each tool. Declining a tool
+  logs a skip and continues through the ranked list.
+- **Unsupervised**: executes ranked tools without prompts; enable with
+  `--unsupervised` or `DO_SUPERVISED=false`.
+
+## Tooling registry
+
+The planner registers the following tools:
+
+- `os_nav`: inspect the working directory (read-only).
+- `file_search`: search for files and contents using `fd`/`rg` fallbacks.
+- `notes`: append reminders under `~/.do/notes.txt`.
+- `mail_stub`: capture a mail draft without sending.
+- `applescript`: execute AppleScript snippets on macOS (no-op elsewhere).
+
+Ranking prefers llama.cpp scoring when `LLAMA_BIN` is available; otherwise a
+heuristic keyword overlap is used.
+
+## Usage examples
+
+Supervised run (default):
 
 ```bash
 ./src/main.sh -- "inspect project layout and search notes"
-./src/main.sh --unsupervised --model ./models/llama.gguf -- "save reminder"
+```
+
+Unsupervised run with a specific model:
+
+```bash
+DO_SUPERVISED=false ./src/main.sh --model ./models/llama.gguf -- "save reminder"
+```
+
+Using the sample configuration:
+
+```bash
+set -a
+. tests/fixtures/sample.env
+set +a
+./src/main.sh -- "capture reminder for tomorrow"
 ```
 
 Use `--help` to view all options. Pass `--verbose` for debug-level logs or
 `--quiet` to silence informational messages.
 
-## Testing
+## Testing and linting
 
-Run the Bats suite after formatting and linting:
+Run the formatting and lint targets before executing the Bats suite:
 
 ```bash
-shfmt -w src/main.sh tests/test_main.bats
-shellcheck src/main.sh tests/test_main.bats
-bats tests/test_main.bats
+shfmt -w src/main.sh tests/test_all.sh tests/test_main.bats
+shellcheck src/main.sh tests/test_all.sh tests/test_main.bats
+bats tests/test_all.sh
 ```
 
-`llama.cpp` is optional for tests; heuristic fallbacks keep runs fast when the
-binary is absent.
+The Bats suite covers CLI help/version output, supervised prompts, deterministic
+mock scoring via `tests/fixtures/mock_llama.sh`, and graceful handling when
+`LLAMA_BIN` is missing.

--- a/src/main.sh
+++ b/src/main.sh
@@ -406,7 +406,7 @@ execute_tool() {
 	fi
 
 	if ! confirm_tool "${tool_name}"; then
-		return 0
+		return 1
 	fi
 
 	TOOL_QUERY="${USER_QUERY}" ${handler}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,10 @@
+# Test Fixtures
+
+- `sample.env`: example environment configuration for running `./src/main.sh`.
+  When exported, it defaults to a debug-friendly unsupervised mode with a mock llama
+  binary and emits a tool prompt highlighting the notes tool for reminder-style
+  queries.
+- `mock_llama.sh`: deterministic scorer used by the Bats suite. It ranks the
+  `notes` tool highest by emitting a score of 5 when the prompt includes
+  `Tool: notes`, and 1 otherwise. The planner summary will therefore start with
+  `[notes executed]` when called with a reminder query.

--- a/tests/fixtures/mock_llama.sh
+++ b/tests/fixtures/mock_llama.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Mock llama.cpp binary for deterministic test scoring.
+# Arguments:
+#   -m <path> (string): model path (ignored)
+#   -p <prompt> (string): prompt containing tool name and description
+set -euo pipefail
+PROMPT=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-p)
+		PROMPT="$2"
+		shift 2
+		;;
+	*)
+		shift 1
+		;;
+	esac
+done
+if printf '%s' "${PROMPT}" | grep -q "Tool: notes"; then
+	printf '5\n'
+else
+	printf '1\n'
+fi

--- a/tests/fixtures/sample.env
+++ b/tests/fixtures/sample.env
@@ -1,0 +1,9 @@
+# Sample environment configuration for do assistant
+# DO_MODEL_PATH (string): path to llama.cpp model to load.
+DO_MODEL_PATH=./models/demo.gguf
+# DO_SUPERVISED (bool): true to require confirmation before running tools.
+DO_SUPERVISED=false
+# DO_VERBOSITY (int): 0=quiet, 1=info, 2=debug.
+DO_VERBOSITY=2
+# LLAMA_BIN (string): llama.cpp binary to use for scoring; can be a stub during testing.
+LLAMA_BIN=./bin/llama-mock

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+#
+# Usage: bats tests/test_all.sh
+#
+# Environment variables:
+#   DO_VERBOSITY (int): 0=quiet, 1=info, 2=debug log output.
+#   DO_SUPERVISED (bool): true to require confirmations before running tools.
+#   LLAMA_BIN (string): path to llama.cpp binary or stub.
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes explicitly.
+
+setup() {
+	export DO_VERBOSITY=0
+	export DO_SUPERVISED=false
+}
+
+@test "shows CLI help" {
+	run ./src/main.sh --help -- "example query"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Usage: ./src/main.sh"* ]]
+}
+
+@test "prints version" {
+	run ./src/main.sh --version -- "query"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"do assistant"* ]]
+}
+
+@test "prompts in supervised mode and respects decline" {
+	run env DO_SUPERVISED=true DO_VERBOSITY=1 bash -c 'printf "n\n" | ./src/main.sh --supervised -- "list files"'
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'Execute tool "os_nav"? [y/N]:'* ]]
+	[[ "$output" == *"[os_nav skipped]"* ]]
+}
+
+@test "uses mock llama.cpp scoring to rank notes highest" {
+	run env DO_SUPERVISED=false \
+		DO_VERBOSITY=0 \
+		LLAMA_BIN="$(pwd)/tests/fixtures/mock_llama.sh" \
+		DO_MODEL_PATH="$(pwd)/tests/fixtures/mock-model.gguf" \
+		./src/main.sh -- "save reminder"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"notes(score=5"* ]]
+	[[ "$output" == *"[notes executed]"* ]]
+}
+
+@test "warns when llama.cpp dependency is missing but continues" {
+	run env LLAMA_BIN=/definitely/missing DO_VERBOSITY=1 ./src/main.sh --unsupervised -- "search files"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"binary not found"* ]]
+	[[ "$output" == *"Execution summary"* ]]
+}


### PR DESCRIPTION
## Summary
- document installer-driven setup, configuration env vars, operating modes, and sample config usage in the README
- add deterministic test fixtures (mock llama stub and sample env) with notes on expected planner outputs
- expand bats coverage for CLI help/version, supervised prompts, llama stub scoring, and missing dependency warnings, and align execution summary with declined tools

## Testing
- shfmt -w src/main.sh tests/test_all.sh tests/test_main.bats tests/fixtures/mock_llama.sh
- shellcheck src/main.sh tests/test_all.sh tests/test_main.bats tests/fixtures/mock_llama.sh
- bats tests/test_all.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69347e7258888325b581c9b40af5ea2d)