### PR TITLE
Add CI workflows for linting and tests

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -1,0 +1,26 @@
+name: Installation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  installer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck shfmt bats
+
+      - name: Lint installer
+        run: |
+          shfmt -d scripts/install tests/test_install.bats
+          shellcheck scripts/install tests/test_install.bats
+
+      - name: Run installer tests
+        run: bats tests/test_install.bats

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,40 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck shfmt bats
+
+      - name: Check formatting
+        run: |
+          shfmt -d \
+            src/main.sh \
+            scripts/install \
+            tests/test_all.sh \
+            tests/test_main.bats \
+            tests/test_install.bats
+
+      - name: Run shellcheck
+        run: |
+          shellcheck \
+            src/main.sh \
+            scripts/install \
+            tests/test_all.sh \
+            tests/test_main.bats \
+            tests/test_install.bats
+
+      - name: Run Bats suite
+        run: |
+          bats tests/test_main.bats tests/test_all.sh tests/test_install.bats


### PR DESCRIPTION
## Summary
- add a Run Tests workflow that installs tooling, checks formatting, lints, and runs the full Bats suite
- add an Installation workflow to lint and exercise the installer-focused tests

## Testing
- shfmt -d src/main.sh scripts/install tests/test_all.sh tests/test_main.bats tests/test_install.bats
- shellcheck src/main.sh scripts/install tests/test_all.sh tests/test_main.bats tests/test_install.bats
- bats tests/test_main.bats tests/test_all.sh tests/test_install.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934813d2dfc8325b336ed069e95ff7d)