### PR TITLE
Add config-driven approval and planning controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # do Assistant Entrypoint
 
 A lightweight MCP-inspired planner that wraps a local `llama.cpp` binary, ranks
-registered tools via ToolRAG, and executes them in either supervised (human
-confirmation) or unsupervised mode.
+registered tools via ToolRAG, and executes them with explicit approval controls
+and preview modes.
 
 ## Installation
 
@@ -28,50 +28,44 @@ What the installer does:
 5. Offers `--upgrade` (refresh files/model) and `--uninstall` flows, refusing
    to run on non-macOS hosts.
 
-Key environment variables:
-
-- `DO_MODEL`: HF repo[:file] identifier for the model download (default:
-  `Qwen/Qwen3-1.5B-Instruct-GGUF:qwen3-1.5b-instruct-q4_k_m.gguf`).
-- `DO_MODEL_BRANCH`: Branch or tag to download from (default: `main`).
-- `DO_MODEL_CACHE`: Directory where downloaded GGUF files are stored (default:
-  `~/.do/models`).
-- `DO_LINK_DIR`: Directory for the CLI symlink (default: `/usr/local/bin`).
-- `DO_INSTALLER_ASSUME_OFFLINE=true`: Skip network calls; installation fails if
-  downloads are required while offline.
-- `HF_TOKEN`: Optional Hugging Face token for gated model downloads.
-
 For manual setups, ensure `bash` 5+, `llama.cpp` (optional for heuristic mode),
 `fd`, and `rg` are on your `PATH`, then run the script directly with `./src/main.sh`.
 
 ## Configuration
 
-Environment variables control runtime behavior and can be stored in an env file
-(such as `tests/fixtures/sample.env`):
+The CLI defaults are stored in `${XDG_CONFIG_HOME:-~/.config}/do/config.env`.
+Initialize or update that file without running a query via:
 
-- `DO_MODEL`: HF repo[:file] identifier for the llama.cpp model (default:
+```bash
+./src/main.sh init --model your-org/your-model:custom.gguf --model-branch main --model-cache ~/.do/models
+```
+
+The config file is a simple `key="value"` env-style document. Supported keys:
+
+- `MODEL_SPEC`: HF repo[:file] identifier for the llama.cpp model (default:
   `Qwen/Qwen3-1.5B-Instruct-GGUF:qwen3-1.5b-instruct-q4_k_m.gguf`).
-- `DO_MODEL_BRANCH`: Optional branch or tag for the model download (default:
+- `MODEL_BRANCH`: Optional branch or tag for the model download (default:
   `main`).
-- `DO_MODEL_CACHE`: Cache directory holding downloaded GGUF files (default:
+- `MODEL_CACHE`: Cache directory holding downloaded GGUF files (default:
   `~/.do/models`).
-- `DO_SUPERVISED`: `true`/`false` to toggle confirmation prompts (default:
-  `true`).
-- `DO_VERBOSITY`: `0` (quiet), `1` (info), `2` (debug). Overrides `-v`/`-q`.
-- `LLAMA_BIN`: llama.cpp binary to use (default: `llama`; can point to the mock
-  `tests/fixtures/mock_llama.sh` during testing).
+- `APPROVE_ALL`: `true` to skip prompts by default; `false` prompts before each
+  tool.
+- `FORCE_CONFIRM`: `true` to always prompt, even when `--yes` is set in the
+  config.
+- `VERBOSITY`: `0` (quiet), `1` (info), `2` (debug).
 
-The included `tests/fixtures/sample.env` demonstrates a debug-friendly,
-unsupervised configuration that prefers the notes tool for reminder queries.
-Running with that config and a reminder request will emit a tool prompt where
-`notes` is scored highest, followed by a summary beginning with
-`[notes executed]`.
+Legacy environment variables such as `DO_MODEL`, `DO_MODEL_BRANCH`, and
+`DO_MODEL_CACHE` are still honored when set for backward compatibility, but the
+CLI and config file are the primary configuration surfaces.
 
-## Modes
+## Approval and preview modes
 
-- **Supervised** (default): prompts before executing each tool. Declining a tool
-  logs a skip and continues through the ranked list.
-- **Unsupervised**: executes ranked tools without prompts; enable with
-  `--unsupervised` or `DO_SUPERVISED=false`.
+- **Default**: prompts before executing each tool. Declining a tool logs a skip
+  and continues through the ranked list.
+- `--yes` / `--no-confirm`: executes ranked tools without prompts.
+- `--confirm`: forces prompts even if the config opts into auto-approval.
+- `--dry-run`: prints the planned calls without running any tool handlers.
+- `--plan-only`: emits the machine-readable plan JSON and exits.
 
 ## Tooling registry
 
@@ -92,25 +86,16 @@ execution ordering.
 
 ## Usage examples
 
-Supervised run (default):
+Prompted run (default):
 
 ```bash
 ./src/main.sh -- "inspect project layout and search notes"
 ```
 
-Unsupervised run with a specific model selection:
+Auto-approval with a specific model selection:
 
 ```bash
-DO_SUPERVISED=false ./src/main.sh --model your-org/your-model:custom.gguf --model-cache ~/.do/models -- "save reminder"
-```
-
-Using the sample configuration:
-
-```bash
-set -a
-. tests/fixtures/sample.env
-set +a
-./src/main.sh -- "capture reminder for tomorrow"
+./src/main.sh --yes --model your-org/your-model:custom.gguf --model-cache ~/.do/models -- "save reminder"
 ```
 
 Use `--help` to view all options. Pass `--verbose` for debug-level logs or
@@ -128,6 +113,6 @@ shellcheck scripts/install tests/test_install.bats
 bats tests/test_all.sh tests/test_install.bats
 ```
 
-The Bats suite covers CLI help/version output, supervised prompts, deterministic
+The Bats suite covers CLI help/version output, confirmation prompts, deterministic
 mock scoring via `tests/fixtures/mock_llama.sh`, and graceful handling when
 `LLAMA_BIN` is missing.

--- a/tests/test_main.bats
+++ b/tests/test_main.bats
@@ -1,18 +1,29 @@
 #!/usr/bin/env bats
 
 setup() {
-	export DO_VERBOSITY=0
-	export DO_SUPERVISED=false
-	export DO_MODEL="example/repo:demo.gguf"
-	export DO_MODEL_CACHE="${BATS_TMPDIR}/do-models"
-	mkdir -p "${DO_MODEL_CACHE}"
-	printf "stub-model-body" >"${DO_MODEL_CACHE}/demo.gguf"
+	TEST_ROOT="${BATS_TMPDIR}/do-main"
+	export HOME="${TEST_ROOT}/home"
+	export CONFIG_FILE="${TEST_ROOT}/config.env"
+	MODEL_CACHE="${TEST_ROOT}/models"
+
+	mkdir -p "${MODEL_CACHE}" "${HOME}"
+	printf "stub-model-body" >"${MODEL_CACHE}/demo.gguf"
+
+	cat >"${CONFIG_FILE}" <<EOF
+MODEL_SPEC="example/repo:demo.gguf"
+MODEL_BRANCH="main"
+MODEL_CACHE="${MODEL_CACHE}"
+VERBOSITY=0
+APPROVE_ALL=false
+FORCE_CONFIRM=false
+EOF
 }
 
 @test "shows help text" {
 	run ./src/main.sh --help -- "example query"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Usage: ./src/main.sh"* ]]
+	[[ "$output" != *"DO_MODEL"* ]]
 }
 
 @test "prints version" {
@@ -21,9 +32,39 @@ setup() {
 	[[ "$output" == *"do assistant"* ]]
 }
 
-@test "runs planner in unsupervised mode" {
-	run ./src/main.sh --unsupervised -- "note something"
+@test "prompts before executing when approval is required" {
+	run bash -lc "printf 'n\\n' | ./src/main.sh --config '${CONFIG_FILE}' -- 'list files'"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'Execute tool "os_nav"? [y/N]:'* ]]
+	[[ "$output" == *"[os_nav skipped]"* ]]
+}
+
+@test "--yes bypasses prompts" {
+	run ./src/main.sh --config "${CONFIG_FILE}" --yes -- "note something"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Suggested tools"* ]]
 	[[ "$output" == *"notes executed"* ]]
+}
+
+@test "--dry-run prints plan without execution" {
+	run ./src/main.sh --config "${CONFIG_FILE}" --dry-run --yes -- "note something"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Dry run: planned tool calls"* ]]
+	[[ "$output" != *"notes executed"* ]]
+}
+
+@test "--plan-only emits JSON plan" {
+	run ./src/main.sh --config "${CONFIG_FILE}" --plan-only -- "note something"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"[{\"tool\""* ]]
+	[[ "$output" == *"notes"* ]]
+}
+
+@test "init writes configuration" {
+	local new_config
+	new_config="${BATS_TMPDIR}/fresh-config.env"
+	run ./src/main.sh init --config "${new_config}" --model "example/repo:demo.gguf" --model-branch dev --model-cache "${MODEL_CACHE}"
+	[ "$status" -eq 0 ]
+	[ -f "${new_config}" ]
+	grep -q "MODEL_BRANCH=\"dev\"" "${new_config}"
 }


### PR DESCRIPTION
## Summary
- add config file loading plus an `init` command to capture model and approval defaults without relying on env vars
- replace supervised/unsupervised flags with confirmation, `--yes`, `--dry-run`, and `--plan-only` controls and refresh CLI help/docs
- update tests and docs to cover config-driven runs, plan previews, and approval behaviors

## Testing
- shfmt -w src/main.sh tests/test_main.bats tests/test_all.sh
- shellcheck src/main.sh tests/test_main.bats tests/test_all.sh
- bats tests/test_main.bats tests/test_all.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934860a52b88325a35fd008ec8f353e)