### PR TITLE
Enhance os_nav persistent terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ CLI and config file are the primary configuration surfaces.
 
 The planner registers the following tools (each defined in `src/tools/<name>.sh`):
 
-- `os_nav`: inspect the working directory (read-only).
+- `os_nav`: persistent terminal session with a limited command set (pwd, ls,
+  cd, cat, head, tail, find, grep, open on macOS).
 - `file_search`: search for files and contents using `fd`/`rg` fallbacks.
 - `notes_create`: create a new Apple Note (first line = title).
 - `notes_append`: append text to an existing Apple Note by title.
@@ -87,6 +88,12 @@ The planner registers the following tools (each defined in `src/tools/<name>.sh`
 - `mail_list_inbox`: list recent Apple Mail inbox messages.
 - `mail_list_unread`: list unread Apple Mail inbox messages.
 - `applescript`: execute AppleScript snippets on macOS (no-op elsewhere).
+
+The `os_nav` tool keeps a per-query working directory and reuses it across
+invocations so agents can `cd` once and continue running commands from the same
+location. Supported commands include `status` (default, shows the current
+directory and a listing), `pwd`, `ls`, `cd`, `cat`, `head`, `tail`, `find`, and
+`grep`, plus `open` on macOS hosts.
 
 Apple Notes tools expect the first line of `TOOL_QUERY` to be the note title and
 the remaining lines to form the body (where applicable). Set `NOTES_FOLDER` to

--- a/src/tools/os_nav.sh
+++ b/src/tools/os_nav.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# Operating-system navigation tool for listing the current directory.
+# Operating-system navigation tool that exposes a persistent, command-limited
+# shell session for the agent.
 #
 # Usage:
 #   source "${BASH_SOURCE[0]%/tools/os_nav.sh}/tools/os_nav.sh"
 #
 # Environment variables:
-#   None
+#   TOOL_QUERY (string): command to run within the session (defaults to "status").
+#   IS_MACOS (bool): enables the macOS-specific `open` command when true.
+#   OS_NAV_SESSION_ID (string, optional): reused session identifier for logging.
+#   OS_NAV_WORKDIR (string, optional): starting working directory for the session.
 #
 # Dependencies:
 #   - bash 5+
-#   - coreutils (ls, pwd)
+#   - coreutils (ls, pwd, cat, head, tail)
 #   - logging helpers from logging.sh
 #   - register_tool from tools/registry.sh
 #
@@ -23,17 +27,158 @@ source "${BASH_SOURCE[0]%/tools/os_nav.sh}/logging.sh"
 # shellcheck source=./registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/os_nav.sh}/registry.sh"
 
+OS_NAV_ALLOWED_COMMANDS=(
+	"status"
+	"pwd"
+	"ls"
+	"cd"
+	"cat"
+	"head"
+	"tail"
+	"find"
+	"grep"
+	"open"
+)
+
+OS_NAV_SESSION_ID="${OS_NAV_SESSION_ID:-}" # string session identifier
+OS_NAV_WORKDIR="${OS_NAV_WORKDIR:-}"       # string working directory for the persistent session
+
+os_nav_init_session() {
+	if [[ -z "${OS_NAV_SESSION_ID}" ]]; then
+		OS_NAV_SESSION_ID="os-nav-${EPOCHSECONDS}"
+	fi
+
+	if [[ -z "${OS_NAV_WORKDIR}" ]]; then
+		OS_NAV_WORKDIR="$(pwd)"
+	fi
+}
+
+os_nav_run_in_workdir() {
+	# Arguments:
+	#   $1 - command (string)
+	#   $@ - remaining args passed to the command (array)
+	local command
+	command="$1"
+	shift
+	(
+		cd "${OS_NAV_WORKDIR}" &&
+			"${command}" "$@"
+	)
+}
+
+os_nav_allowed() {
+	# Arguments:
+	#   $1 - candidate command (string)
+	local candidate allowed
+	candidate="$1"
+	for allowed in "${OS_NAV_ALLOWED_COMMANDS[@]}"; do
+		if [[ "${candidate}" == "${allowed}" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+os_nav_change_dir() {
+	# Arguments:
+	#   $@ - path components to join (array)
+	local target resolved
+	if [[ $# -eq 0 ]]; then
+		log "ERROR" "cd requires a target" ""
+		return 1
+	fi
+
+	target="$*"
+
+	if ! resolved=$(cd "${OS_NAV_WORKDIR}" && cd "${target}" && pwd); then
+		log "ERROR" "Unable to change directory" "${target}"
+		return 1
+	fi
+
+	OS_NAV_WORKDIR="${resolved}"
+	printf '%s\n' "${OS_NAV_WORKDIR}"
+}
+
+os_nav_print_status() {
+	printf 'Session: %s\n' "${OS_NAV_SESSION_ID}"
+	printf 'Working directory: %s\n' "${OS_NAV_WORKDIR}"
+	printf 'Allowed commands: %s\n' "${OS_NAV_ALLOWED_COMMANDS[*]}"
+	os_nav_run_in_workdir pwd
+	os_nav_run_in_workdir ls -la
+}
+
 tool_os_nav() {
-	log "INFO" "Running OS navigation" "Listing working directory"
-	pwd
-	ls -la
+	local query raw_args command args
+	os_nav_init_session
+
+	query=${TOOL_QUERY:-""}
+	read -r -a raw_args <<<"${query}"
+	command=${raw_args[0]:-status}
+	args=()
+	if [[ ${#raw_args[@]} -gt 1 ]]; then
+		args=("${raw_args[@]:1}")
+	fi
+
+	if ! os_nav_allowed "${command}"; then
+		log "WARN" "Unknown os_nav command; showing status" "${command}"
+		command="status"
+	fi
+
+	case "${command}" in
+	status)
+		os_nav_print_status
+		;;
+	pwd)
+		os_nav_run_in_workdir pwd
+		;;
+	ls)
+		if [[ ${#args[@]} -eq 0 ]]; then
+			os_nav_run_in_workdir ls -la
+		else
+			os_nav_run_in_workdir ls "${args[@]}"
+		fi
+		;;
+	cd)
+		os_nav_change_dir "${args[@]}"
+		;;
+	cat)
+		os_nav_run_in_workdir cat "${args[@]}"
+		;;
+	head)
+		os_nav_run_in_workdir head "${args[@]}"
+		;;
+	tail)
+		os_nav_run_in_workdir tail "${args[@]}"
+		;;
+	find)
+		if [[ ${#args[@]} -eq 0 ]]; then
+			os_nav_run_in_workdir find .
+		else
+			os_nav_run_in_workdir find "${args[@]}"
+		fi
+		;;
+	grep)
+		os_nav_run_in_workdir grep "${args[@]}"
+		;;
+	open)
+		if [[ "${IS_MACOS}" != true ]]; then
+			log "WARN" "'open' is macOS-only; skipping" "${args[*]:-""}"
+			return 0
+		fi
+		os_nav_run_in_workdir open "${args[@]}"
+		;;
+	*)
+		log "ERROR" "Unsupported os_nav command after validation" "${command}"
+		return 1
+		;;
+	esac
 }
 
 register_os_nav() {
 	register_tool \
 		"os_nav" \
-		"Inspect the current working directory contents." \
-		"pwd && ls -la" \
-		"Read-only visibility of local filesystem." \
+		"Persistent terminal session for navigation and basic commands (pwd, ls, cd, cat, head, tail, find, grep, open)." \
+		"os_nav <status|pwd|ls|cd|cat|head|tail|find|grep|open>" \
+		"Restricted command set with a per-query working directory." \
 		tool_os_nav
 }

--- a/tests/test_os_nav.bats
+++ b/tests/test_os_nav.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Focused tests for the os_nav tool's persistent terminal session.
+#
+# Usage: bats tests/test_os_nav.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "status default exposes allowed commands" {
+	run bash -lc 'source ./src/tools/os_nav.sh; VERBOSITY=0; TOOL_QUERY=""; tool_os_nav'
+	[ "$status" -eq 0 ]
+	[[ "${lines[0]}" == Session:* ]]
+	[[ "${output}" == *"Allowed commands:"* ]]
+}
+
+@test "cd updates persistent working directory" {
+	run bash -lc 'source ./src/tools/os_nav.sh; VERBOSITY=0; OS_NAV_WORKDIR="$(pwd)"; TOOL_QUERY="cd tests"; tool_os_nav; TOOL_QUERY="pwd"; tool_os_nav'
+	[ "$status" -eq 0 ]
+	last_index=$((${#lines[@]} - 1))
+	[[ "${lines[$last_index]}" == *"/tests" ]]
+}
+
+@test "unknown command falls back to status" {
+	run bash -lc 'source ./src/tools/os_nav.sh; VERBOSITY=0; TOOL_QUERY="launch rockets"; tool_os_nav'
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"Allowed commands:"* ]]
+}


### PR DESCRIPTION
## Summary
- expand os_nav into a persistent terminal session with a limited command whitelist
- document the session behavior and allowed commands in the README
- add Bats coverage for os_nav commands and session persistence

## Testing
- bats tests/test_os_nav.bats tests/test_modules.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934a9a8100c83259252d9374eec81f3)