### PR TITLE
Add Apple Calendar tool handlers and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ The planner registers the following tools (each defined in `src/tools/<name>.sh`
 - `reminders_create`: create a new Apple Reminder (first line = title).
 - `reminders_list`: list incomplete Apple Reminders in the configured list.
 - `reminders_complete`: mark an Apple Reminder complete by title.
+- `calendar_create`: create a new Apple Calendar event (line 1: title; line 2: start time; optional line 3: location).
+- `calendar_list`: list upcoming Apple Calendar events for the configured calendar.
+- `calendar_search`: search Apple Calendar events by title or location.
 - `mail_draft`: create a new Apple Mail draft (line 1: recipients, line 2: subject).
 - `mail_send`: compose and send an Apple Mail message immediately.
 - `mail_search`: search Apple Mail inbox messages by subject, sender, or body.
@@ -99,6 +102,13 @@ Apple Notes tools expect the first line of `TOOL_QUERY` to be the note title and
 the remaining lines to form the body (where applicable). Set `NOTES_FOLDER` to
 point at a specific folder (default: `Notes`). On non-macOS hosts or when
 `osascript` is unavailable, the tools emit a warning and exit without changes.
+
+Apple Calendar tools use `TOOL_QUERY` lines for event details: the first line is
+the title, the second is a human-friendly start time (parsed by AppleScript's
+`date`), and the third is an optional location. Set `CALENDAR_NAME` to direct
+operations to a specific calendar (default: `Calendar`). These tools only run on
+macOS with `osascript` available; otherwise, they log a warning and return
+without executing.
 
 Apple Mail tools expect `TOOL_QUERY` lines to be structured as comma-separated
 recipients on the first line, a subject on the second, and the optional body on

--- a/src/tools.sh
+++ b/src/tools.sh
@@ -33,16 +33,19 @@ source "${TOOLS_DIR}/file_search.sh"
 source "${TOOLS_DIR}/notes/index.sh"
 # shellcheck source=./tools/reminders/index.sh disable=SC1091
 source "${TOOLS_DIR}/reminders/index.sh"
+# shellcheck source=./tools/calendar/index.sh disable=SC1091
+source "${TOOLS_DIR}/calendar/index.sh"
 # shellcheck source=./tools/mail/index.sh disable=SC1091
 source "${TOOLS_DIR}/mail/index.sh"
 # shellcheck source=./tools/applescript.sh disable=SC1091
 source "${TOOLS_DIR}/applescript.sh"
 
 initialize_tools() {
-	register_terminal
-	register_file_search
-	register_notes_suite
-	register_reminders_suite
-	register_mail_suite
-	register_applescript
+        register_terminal
+        register_file_search
+        register_notes_suite
+        register_reminders_suite
+        register_calendar_suite
+        register_mail_suite
+        register_applescript
 }

--- a/src/tools/calendar/common.sh
+++ b/src/tools/calendar/common.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Shared helpers for Apple Calendar tool integrations.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/calendar/common.sh}/calendar/common.sh"
+#
+# Environment variables:
+#   CALENDAR_NAME (string): target calendar name; defaults to "Calendar".
+#   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
+#   CALENDAR_OSASCRIPT_BIN (string): override path for osascript; defaults to "osascript".
+#   DRY_RUN (bool): when true, handlers should log intent without executing AppleScript.
+#   VERBOSITY (int): logging verbosity; see logging.sh.
+#
+# Dependencies:
+#   - bash 5+
+#   - osascript (optional; required on macOS)
+#   - logging helpers from logging.sh
+#
+# Exit codes:
+#   Functions emit errors via log and return non-zero on misuse.
+
+# shellcheck source=../../logging.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/calendar/common.sh}/logging.sh"
+
+calendar_name() {
+        # Prints the resolved Apple Calendar name.
+        local name
+        name=${CALENDAR_NAME:-"Calendar"}
+        printf '%s' "${name}"
+}
+
+calendar_require_platform() {
+        # Ensures Apple Calendar tools only run on macOS with osascript available.
+        if [[ "${IS_MACOS}" != true ]]; then
+                log "WARN" "Apple Calendar is only available on macOS" "${TOOL_QUERY:-}" || true
+                return 1
+        fi
+
+        if ! command -v "${CALENDAR_OSASCRIPT_BIN:-osascript}" >/dev/null 2>&1; then
+                log "WARN" "osascript missing; cannot reach Apple Calendar" "${TOOL_QUERY:-}" || true
+                return 1
+        fi
+
+        return 0
+}
+
+calendar_extract_event_fields() {
+        # Splits TOOL_QUERY into title, start time, and optional location.
+        # Emits three NUL-delimited fields: title, start time, location.
+        local query title start_time location rest
+        query=${TOOL_QUERY:-""}
+
+        if [[ -z "${query//[[:space:]]/}" ]]; then
+                log "ERROR" "Event title and time are required" "" || true
+                return 1
+        fi
+
+        title=${query%%$'\n'*}
+        rest=${query#"${title}"}
+        rest=${rest#$'\n'}
+        start_time=${rest%%$'\n'*}
+        location=${rest#"${start_time}"}
+        location=${location#$'\n'}
+
+        if [[ -z "${title//[[:space:]]/}" || -z "${start_time//[[:space:]]/}" ]]; then
+                log "ERROR" "Event title and time are required" "${query}" || true
+                return 1
+        fi
+
+        printf '%s\0%s\0%s\0' "${title}" "${start_time}" "${location}"
+}
+
+calendar_run_script() {
+        # Runs an AppleScript provided on stdin, passing through all arguments.
+        # Arguments:
+        #   $@ - parameters forwarded to osascript
+        local bin
+        bin=${CALENDAR_OSASCRIPT_BIN:-osascript}
+        "${bin}" - "$@"
+}
+
+calendar_resolve_calendar_script() {
+        # Emits AppleScript lines that resolve the target calendar.
+        local cal
+        cal=$(calendar_name)
+        cal=${cal//"/\\"/}
+        printf '        if not (exists calendar "%s") then\n' "${cal}"
+        printf '                error "Calendar not found: %s"\n' "${cal}"
+        printf '        end if\n'
+        printf '        set targetCalendar to calendar "%s"\n' "${cal}"
+}

--- a/src/tools/calendar/create.sh
+++ b/src/tools/calendar/create.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Create a new Apple Calendar event using TOOL_QUERY lines for details.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/calendar/create.sh}/calendar/create.sh"
+#
+# Environment variables:
+#   TOOL_QUERY (string): event details; first line = title, second = start time, optional third = location.
+#   CALENDAR_NAME (string): target calendar name.
+#   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
+#   DRY_RUN (bool): when true, logs intent without executing AppleScript.
+#
+# Dependencies:
+#   - bash 5+
+#   - osascript (optional on macOS)
+#   - logging helpers from logging.sh
+#   - calendar helpers from calendar/common.sh
+#   - register_tool from tools/registry.sh
+#
+# Exit codes:
+#   Returns non-zero only when registration is misused.
+
+# shellcheck source=../registry.sh disable=SC1091
+source "${BASH_SOURCE[0]%/calendar/create.sh}/registry.sh"
+# shellcheck source=../../logging.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/calendar/create.sh}/logging.sh"
+# shellcheck source=./common.sh disable=SC1091
+source "${BASH_SOURCE[0]%/create.sh}/common.sh"
+
+calendar_dry_run_guard() {
+        if [[ "${DRY_RUN}" == true ]]; then
+                log "INFO" "Dry run: skipping Apple Calendar event creation" "${TOOL_QUERY:-}" || true
+                return 0
+        fi
+
+        return 1
+}
+
+tool_calendar_create() {
+        local title start_time location calendar_script
+
+        if calendar_dry_run_guard; then
+                return 0
+        fi
+
+        if ! calendar_require_platform; then
+                return 0
+        fi
+
+        if ! { IFS= read -r -d '' title && IFS= read -r -d '' start_time && IFS= read -r -d '' location; } < <(calendar_extract_event_fields); then
+                return 0
+        fi
+
+        calendar_script="$(calendar_resolve_calendar_script)"
+
+        log "INFO" "Creating Apple Calendar event" "${title}"
+        calendar_run_script "${title}" "${start_time}" "${location}" <<APPLESCRIPT
+on run argv
+        set eventTitle to item 1 of argv
+        set eventStart to item 2 of argv
+        set eventLocation to item 3 of argv
+        tell application "Calendar"
+${calendar_script}
+                set startDate to date eventStart
+                set newEvent to make new event at end of events of targetCalendar with properties {summary:eventTitle, start date:startDate}
+                if eventLocation is not "" then
+                        set location of newEvent to eventLocation
+                end if
+                return summary of newEvent
+        end tell
+end run
+APPLESCRIPT
+}
+
+register_calendar_create() {
+        register_tool \
+                "calendar_create" \
+                "Create a new Apple Calendar event (line 1: title; line 2: start time)." \
+                "osascript -e 'make new event with {summary:<title>, start date:date \"<time>\"}'" \
+                "Requires macOS Calendar access; event details are sent to Calendar." \
+                tool_calendar_create
+}

--- a/src/tools/calendar/index.sh
+++ b/src/tools/calendar/index.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Aggregator for Apple Calendar tools.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/calendar/index.sh}/calendar/index.sh"
+#
+# Environment variables:
+#   CALENDAR_NAME (string): target calendar within Apple Calendar.
+#   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
+#
+# Dependencies:
+#   - bash 5+
+#   - logging helpers from logging.sh
+#   - register_tool utilities from tools/registry.sh
+#
+# Exit codes:
+#   Functions emit errors via log and return non-zero when misused.
+
+# shellcheck source=./common.sh disable=SC1091
+source "${BASH_SOURCE[0]%/index.sh}/common.sh"
+# shellcheck source=./create.sh disable=SC1091
+source "${BASH_SOURCE[0]%/index.sh}/create.sh"
+# shellcheck source=./list.sh disable=SC1091
+source "${BASH_SOURCE[0]%/index.sh}/list.sh"
+# shellcheck source=./search.sh disable=SC1091
+source "${BASH_SOURCE[0]%/index.sh}/search.sh"
+
+register_calendar_suite() {
+        register_calendar_create
+        register_calendar_list
+        register_calendar_search
+}

--- a/src/tools/calendar/list.sh
+++ b/src/tools/calendar/list.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# List upcoming Apple Calendar events for the configured calendar.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/calendar/list.sh}/calendar/list.sh"
+#
+# Environment variables:
+#   CALENDAR_NAME (string): target calendar name.
+#   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
+#   DRY_RUN (bool): when true, logs intent without executing AppleScript.
+#
+# Dependencies:
+#   - bash 5+
+#   - osascript (optional on macOS)
+#   - logging helpers from logging.sh
+#   - calendar helpers from calendar/common.sh
+#   - register_tool from tools/registry.sh
+#
+# Exit codes:
+#   Returns non-zero only when registration is misused.
+
+# shellcheck source=../registry.sh disable=SC1091
+source "${BASH_SOURCE[0]%/calendar/list.sh}/registry.sh"
+# shellcheck source=../../logging.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/calendar/list.sh}/logging.sh"
+# shellcheck source=./common.sh disable=SC1091
+source "${BASH_SOURCE[0]%/list.sh}/common.sh"
+
+calendar_list_dry_run_guard() {
+        if [[ "${DRY_RUN}" == true ]]; then
+                log "INFO" "Dry run: skipping Apple Calendar listing" "${TOOL_QUERY:-}" || true
+                return 0
+        fi
+
+        return 1
+}
+
+tool_calendar_list() {
+        local calendar_script
+
+        if calendar_list_dry_run_guard; then
+                return 0
+        fi
+
+        if ! calendar_require_platform; then
+                return 0
+        fi
+
+        calendar_script="$(calendar_resolve_calendar_script)"
+
+        log "INFO" "Listing upcoming Apple Calendar events" "$(calendar_name)"
+        calendar_run_script <<APPLESCRIPT
+on run
+        tell application "Calendar"
+${calendar_script}
+                set nowDate to current date
+                set upcoming to every event of targetCalendar whose start date >= nowDate
+                set formattedEvents to {}
+                repeat with ev in upcoming
+                        set startDate to start date of ev
+                        set endDate to end date of ev
+                        set summaryText to summary of ev
+                        set locationText to location of ev
+                        set end of formattedEvents to (summaryText & " | " & (startDate as string) & " -> " & (endDate as string) & " @ " & locationText)
+                end repeat
+                set AppleScript's text item delimiters to "\n"
+                return formattedEvents as string
+        end tell
+end run
+APPLESCRIPT
+}
+
+register_calendar_list() {
+        register_tool \
+                "calendar_list" \
+                "List upcoming Apple Calendar events from the configured calendar." \
+                "osascript -e 'events of calendar <name> starting today'" \
+                "Requires macOS Calendar access; read-only." \
+                tool_calendar_list
+}

--- a/src/tools/calendar/search.sh
+++ b/src/tools/calendar/search.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Search Apple Calendar events by title or location.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/calendar/search.sh}/calendar/search.sh"
+#
+# Environment variables:
+#   TOOL_QUERY (string): search phrase to match.
+#   CALENDAR_NAME (string): target calendar name.
+#   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
+#   DRY_RUN (bool): when true, logs intent without executing AppleScript.
+#
+# Dependencies:
+#   - bash 5+
+#   - osascript (optional on macOS)
+#   - logging helpers from logging.sh
+#   - calendar helpers from calendar/common.sh
+#   - register_tool from tools/registry.sh
+#
+# Exit codes:
+#   Returns non-zero only when registration is misused.
+
+# shellcheck source=../registry.sh disable=SC1091
+source "${BASH_SOURCE[0]%/calendar/search.sh}/registry.sh"
+# shellcheck source=../../logging.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/calendar/search.sh}/logging.sh"
+# shellcheck source=./common.sh disable=SC1091
+source "${BASH_SOURCE[0]%/search.sh}/common.sh"
+
+calendar_search_dry_run_guard() {
+        if [[ "${DRY_RUN}" == true ]]; then
+                log "INFO" "Dry run: skipping Apple Calendar search" "${TOOL_QUERY:-}" || true
+                return 0
+        fi
+
+        return 1
+}
+
+tool_calendar_search() {
+        local query calendar_script
+        query=${TOOL_QUERY:-""}
+
+        if calendar_search_dry_run_guard; then
+                return 0
+        fi
+
+        if ! calendar_require_platform; then
+                return 0
+        fi
+
+        if [[ -z "${query//[[:space:]]/}" ]]; then
+                log "ERROR" "Search term is required" "" || true
+                return 0
+        fi
+
+        calendar_script="$(calendar_resolve_calendar_script)"
+
+        log "INFO" "Searching Apple Calendar" "${query}"
+        calendar_run_script "${query}" <<APPLESCRIPT
+on run argv
+        set searchTerm to item 1 of argv
+        tell application "Calendar"
+${calendar_script}
+                set matches to {}
+                repeat with candidate in every event of targetCalendar
+                        if (summary of candidate contains searchTerm) or (location of candidate contains searchTerm) then
+                                set end of matches to (summary of candidate)
+                        end if
+                end repeat
+                set AppleScript's text item delimiters to "\n"
+                return matches as string
+        end tell
+end run
+APPLESCRIPT
+}
+
+register_calendar_search() {
+        register_tool \
+                "calendar_search" \
+                "Search Apple Calendar events by title or location." \
+                "osascript -e 'events whose summary contains \"<term>\"'" \
+                "Requires macOS Calendar access; read-only." \
+                tool_calendar_search
+}

--- a/tests/fixtures/osascript_stub.sh
+++ b/tests/fixtures/osascript_stub.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-log_file="${NOTES_STUB_LOG:-${REMINDERS_STUB_LOG:-${MAIL_STUB_LOG:-}}}"
+log_file="${NOTES_STUB_LOG:-${REMINDERS_STUB_LOG:-${MAIL_STUB_LOG:-${CALENDAR_STUB_LOG:-}}}}"
 if [[ -n "${log_file}" ]]; then
 	{
 		printf 'ARGS:'

--- a/tests/test_calendar.bats
+++ b/tests/test_calendar.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Focused tests for Apple Calendar tool helpers.
+#
+# Usage: bats tests/test_calendar.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "calendar tools warn when run off macOS" {
+        run bash -lc 'source ./src/tools/calendar/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_QUERY=$'"'"'Title\nTomorrow'"'"'; tool_calendar_create'
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Apple Calendar is only available on macOS"* ]]
+}
+
+@test "calendar_create passes fields to osascript" {
+        run bash -lc '
+                export CALENDAR_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+                export CALENDAR_STUB_LOG="$(mktemp)"
+                export IS_MACOS=true
+                export VERBOSITY=0
+                TOOL_QUERY=$'"'"'Team Sync\n2024-06-02 10:00\nHQ'"'"'
+                source ./src/tools/calendar/index.sh
+                tool_calendar_create
+                cat "${CALENDAR_STUB_LOG}"
+        '
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"ARGS: - Team\ Sync 2024-06-02\ 10:00 HQ"* ]]
+        [[ "$output" == *"make new event"* ]]
+}
+
+@test "calendar_list warns when osascript is unavailable" {
+        run bash -lc '
+                export CALENDAR_OSASCRIPT_BIN="missing-binary"
+                export IS_MACOS=true
+                export VERBOSITY=1
+                source ./src/tools/calendar/index.sh
+                tool_calendar_list
+        '
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"osascript missing; cannot reach Apple Calendar"* ]]
+}
+
+@test "calendar_search skips execution during dry run" {
+        run bash -lc '
+                export CALENDAR_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+                export CALENDAR_STUB_LOG="$(mktemp)"
+                export IS_MACOS=true
+                export DRY_RUN=true
+                export VERBOSITY=1
+                TOOL_QUERY="Planning"
+                source ./src/tools/calendar/index.sh
+                tool_calendar_search
+                if [[ -f "${CALENDAR_STUB_LOG}" ]]; then
+                        cat "${CALENDAR_STUB_LOG}"
+                fi
+        '
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Dry run: skipping Apple Calendar search"* ]]
+}

--- a/tests/test_modules.bats
+++ b/tests/test_modules.bats
@@ -25,25 +25,28 @@
 }
 
 @test "initialize_tools registers each module" {
-	run bash -lc 'source ./src/tools.sh; init_tool_registry; initialize_tools; printf "%s\n" "${TOOLS[@]}"'
-	[ "$status" -eq 0 ]
-	[ "${#lines[@]}" -eq 16 ]
-	[ "${lines[0]}" = "terminal" ]
-	[ "${lines[1]}" = "file_search" ]
-	[ "${lines[2]}" = "notes_create" ]
-	[ "${lines[3]}" = "notes_append" ]
-	[ "${lines[4]}" = "notes_list" ]
-	[ "${lines[5]}" = "notes_search" ]
-	[ "${lines[6]}" = "notes_read" ]
-	[ "${lines[7]}" = "reminders_create" ]
-	[ "${lines[8]}" = "reminders_list" ]
-	[ "${lines[9]}" = "reminders_complete" ]
-	[ "${lines[10]}" = "mail_draft" ]
-	[ "${lines[11]}" = "mail_send" ]
-	[ "${lines[12]}" = "mail_search" ]
-	[ "${lines[13]}" = "mail_list_inbox" ]
-	[ "${lines[14]}" = "mail_list_unread" ]
-	[ "${lines[15]}" = "applescript" ]
+        run bash -lc 'source ./src/tools.sh; init_tool_registry; initialize_tools; printf "%s\n" "${TOOLS[@]}"'
+        [ "$status" -eq 0 ]
+        [ "${#lines[@]}" -eq 19 ]
+        [ "${lines[0]}" = "terminal" ]
+        [ "${lines[1]}" = "file_search" ]
+        [ "${lines[2]}" = "notes_create" ]
+        [ "${lines[3]}" = "notes_append" ]
+        [ "${lines[4]}" = "notes_list" ]
+        [ "${lines[5]}" = "notes_search" ]
+        [ "${lines[6]}" = "notes_read" ]
+        [ "${lines[7]}" = "reminders_create" ]
+        [ "${lines[8]}" = "reminders_list" ]
+        [ "${lines[9]}" = "reminders_complete" ]
+        [ "${lines[10]}" = "calendar_create" ]
+        [ "${lines[11]}" = "calendar_list" ]
+        [ "${lines[12]}" = "calendar_search" ]
+        [ "${lines[13]}" = "mail_draft" ]
+        [ "${lines[14]}" = "mail_send" ]
+        [ "${lines[15]}" = "mail_search" ]
+        [ "${lines[16]}" = "mail_list_inbox" ]
+        [ "${lines[17]}" = "mail_list_unread" ]
+        [ "${lines[18]}" = "applescript" ]
 }
 
 @test "json_escape preserves newlines and quotes" {


### PR DESCRIPTION
## Summary
- add Apple Calendar tool suite with create, list, and search handlers using osascript
- register calendar tools in the shared registry and document usage and macOS limitations
- expand test fixtures and add bats coverage for calendar behavior and tool registration

## Testing
- bats tests/test_modules.bats
- bats tests/test_calendar.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e98bedcc83258998863f3468e127)