### PR TITLE
Simplify tool relevance grammar handling

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -8,3 +8,5 @@
   `notes_create` tool highest by emitting a score of 5 when the prompt includes
   `Tool: notes_create`, and 1 otherwise. The planner summary will therefore start
   with `[notes_create executed]` when called with a reminder query.
+- `mock_llama_relevance.sh`: emits a JSON map of tool names to booleans for
+  grammar-constrained relevance tests.

--- a/tests/fixtures/mock_llama_relevance.sh
+++ b/tests/fixtures/mock_llama_relevance.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Mock llama.cpp binary for grammar-constrained tool relevance detection.
+# Arguments:
+#   --hf-repo <repo> (string): repository name (ignored)
+#   --hf-file <file> (string): model file (ignored)
+#   --grammar <grammar> (string): grammar rules (ignored)
+#   -p <prompt> (string): user prompt (ignored)
+set -euo pipefail
+
+while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --hf-repo|--hf-file|--grammar|-p)
+                # Skip option and its argument
+                shift 2
+                ;;
+        *)
+                shift 1
+                ;;
+        esac
+done
+
+printf '{"terminal":true,"notes_create":false,"reminders_create":false}\n'

--- a/tests/test_modules.bats
+++ b/tests/test_modules.bats
@@ -65,6 +65,20 @@ run bash -lc 'source ./src/planner.sh; initialize_tools; raw='"'"'[{"tool":"term
 [ "${lines[1]}" = "4:terminal" ]
 }
 
+@test "structured_tool_relevance parses boolean map grammar" {
+        run bash -lc '
+                source ./src/planner.sh
+                initialize_tools
+                LLAMA_AVAILABLE=true
+                LLAMA_BIN="./tests/fixtures/mock_llama_relevance.sh"
+                MODEL_REPO="demo/repo"
+                MODEL_FILE="demo.gguf"
+                structured_tool_relevance "list files"
+        '
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "5:terminal" ]
+}
+
 @test "emit_plan_json builds valid array" {
 run bash -lc $'source ./src/planner.sh; plan=$'"'"'terminal|echo "hi"|4\nnotes_create|add note|3'"'"'; emit_plan_json "${plan}"'
 [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- update the llama tool relevance grammar to return a JSON object of booleans and adjust parsing
- add a mock relevance fixture and document it for tests
- extend module tests to cover the new grammar-driven relevance flow

## Testing
- shellcheck src/planner.sh tests/fixtures/mock_llama_relevance.sh
- bats tests/test_modules.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c75eccf88325b98152c1666a94bd)