### PR TITLE
Refactor tool query derivation dispatch

### DIFF
--- a/src/tools/notes/append.sh
+++ b/src/tools/notes/append.sh
@@ -28,8 +28,14 @@ source "${BASH_SOURCE[0]%/tools/notes/append.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/append.sh}/common.sh"
 
+derive_notes_append_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        printf '%s\n' "$1"
+}
+
 tool_notes_append() {
-	local title body folder_script
+        local title body folder_script
 
 	if ! notes_require_platform; then
 		return 0

--- a/src/tools/notes/create.sh
+++ b/src/tools/notes/create.sh
@@ -28,8 +28,35 @@ source "${BASH_SOURCE[0]%/tools/notes/create.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/create.sh}/common.sh"
 
+derive_notes_create_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        local user_query nocasematch_enabled
+        user_query="$1"
+        nocasematch_enabled=false
+
+        if shopt -q nocasematch; then
+                nocasematch_enabled=true
+        fi
+        shopt -s nocasematch
+
+        if [[ "${user_query}" =~ note[[:space:]]+(.+) ]]; then
+                printf '%s\n' "${BASH_REMATCH[1]}"
+                if [[ "${nocasematch_enabled}" == false ]]; then
+                        shopt -u nocasematch
+                fi
+                return
+        fi
+
+        if [[ "${nocasematch_enabled}" == false ]]; then
+                shopt -u nocasematch
+        fi
+
+        printf '%s\n' "${user_query}"
+}
+
 tool_notes_create() {
-	local title body folder_script
+        local title body folder_script
 
 	if ! notes_require_platform; then
 		return 0

--- a/src/tools/notes/list.sh
+++ b/src/tools/notes/list.sh
@@ -27,8 +27,14 @@ source "${BASH_SOURCE[0]%/tools/notes/list.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/list.sh}/common.sh"
 
+derive_notes_list_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        printf '%s\n' "$1"
+}
+
 tool_notes_list() {
-	local folder_script
+        local folder_script
 	if ! notes_require_platform; then
 		return 0
 	fi

--- a/src/tools/notes/read.sh
+++ b/src/tools/notes/read.sh
@@ -28,8 +28,14 @@ source "${BASH_SOURCE[0]%/tools/notes/read.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/read.sh}/common.sh"
 
+derive_notes_read_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        printf '%s\n' "$1"
+}
+
 tool_notes_read() {
-	local title folder_script
+        local title folder_script
 	title=${TOOL_QUERY:-""}
 
 	if ! notes_require_platform; then

--- a/src/tools/notes/search.sh
+++ b/src/tools/notes/search.sh
@@ -28,8 +28,14 @@ source "${BASH_SOURCE[0]%/tools/notes/search.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/search.sh}/common.sh"
 
+derive_notes_search_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        printf '%s\n' "$1"
+}
+
 tool_notes_search() {
-	local query folder_script
+        local query folder_script
 	query=${TOOL_QUERY:-""}
 
 	if ! notes_require_platform; then

--- a/src/tools/reminders/create.sh
+++ b/src/tools/reminders/create.sh
@@ -28,8 +28,43 @@ source "${BASH_SOURCE[0]%/tools/reminders/create.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/create.sh}/common.sh"
 
+derive_reminders_create_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        local user_query nocasematch_enabled
+        user_query="$1"
+        nocasematch_enabled=false
+
+        if shopt -q nocasematch; then
+                nocasematch_enabled=true
+        fi
+        shopt -s nocasematch
+
+        if [[ "${user_query}" =~ remind[[:space:]]+me[[:space:]]+to[[:space:]]+(.+) ]]; then
+                printf '%s\n' "${BASH_REMATCH[1]}"
+                if [[ "${nocasematch_enabled}" == false ]]; then
+                        shopt -u nocasematch
+                fi
+                return
+        fi
+
+        if [[ "${user_query}" =~ remind[[:space:]]+me[[:space:]]+(.+) ]]; then
+                printf '%s\n' "${BASH_REMATCH[1]}"
+                if [[ "${nocasematch_enabled}" == false ]]; then
+                        shopt -u nocasematch
+                fi
+                return
+        fi
+
+        if [[ "${nocasematch_enabled}" == false ]]; then
+                shopt -u nocasematch
+        fi
+
+        printf '%s\n' "${user_query}"
+}
+
 tool_reminders_create() {
-	local title body list_script
+        local title body list_script
 
 	if ! reminders_require_platform; then
 		return 0

--- a/src/tools/reminders/list.sh
+++ b/src/tools/reminders/list.sh
@@ -27,8 +27,14 @@ source "${BASH_SOURCE[0]%/tools/reminders/list.sh}/logging.sh"
 # shellcheck source=./common.sh disable=SC1091
 source "${BASH_SOURCE[0]%/list.sh}/common.sh"
 
+derive_reminders_list_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        printf 'list\n'
+}
+
 tool_reminders_list() {
-	local list_script
+        local list_script
 
 	if ! reminders_require_platform; then
 		return 0

--- a/src/tools/terminal.sh
+++ b/src/tools/terminal.sh
@@ -28,8 +28,8 @@ source "${BASH_SOURCE[0]%/tools/terminal.sh}/logging.sh"
 source "${BASH_SOURCE[0]%/terminal.sh}/registry.sh"
 
 TERMINAL_ALLOWED_COMMANDS=(
-	"status"
-	"pwd"
+        "status"
+        "pwd"
 	"ls"
 	"cd"
 	"cat"
@@ -46,12 +46,42 @@ TERMINAL_ALLOWED_COMMANDS=(
 	"rm"
 	"stat"
 	"wc"
-	"du"
-	"base64"
+        "du"
+        "base64"
 )
 
 TERMINAL_SESSION_ID="${TERMINAL_SESSION_ID:-}" # string session identifier
 TERMINAL_WORKDIR="${TERMINAL_WORKDIR:-}"       # string working directory for the persistent session
+
+derive_terminal_query() {
+        # Arguments:
+        #   $1 - user query (string)
+        local user_query lower_query
+        user_query="$1"
+        lower_query=${user_query,,}
+
+        if [[ "${user_query}" =~ \`([^\`]+)\` ]]; then
+                printf '%s\n' "${BASH_REMATCH[1]}"
+                return
+        fi
+
+        if [[ "${lower_query}" == *"todo"* ]]; then
+                printf 'rg -n "TODO" .\n'
+                return
+        fi
+
+        if [[ "${lower_query}" == *"list files"* || "${lower_query}" == *"show directory"* || "${lower_query}" == *"show folder"* ]]; then
+                printf 'ls -la\n'
+                return
+        fi
+
+        if [[ "${user_query}" =~ (^|[[:space:]])(ls|cd|cat|grep|find|pwd|rg)([[:space:]]|$) ]]; then
+                printf '%s\n' "${BASH_REMATCH[2]}"
+                return
+        fi
+
+        printf 'status\n'
+}
 
 terminal_init_session() {
 	if [[ -z "${TERMINAL_SESSION_ID}" ]]; then

--- a/tests/test_tool_query_derivation.bats
+++ b/tests/test_tool_query_derivation.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Tests for tool-specific query derivation dispatch.
+#
+# Usage:
+#   bats tests/test_tool_query_derivation.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "terminal derivation maps to helper function" {
+        run bash -lc 'source ./src/planner.sh; VERBOSITY=0; derive_tool_query "terminal" "please list files"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == "ls -la" ]]
+}
+
+@test "reminders derivation trims leading phrase" {
+        run bash -lc 'source ./src/planner.sh; VERBOSITY=0; derive_tool_query "reminders_create" "Remind me to call mom"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == "call mom" ]]
+}
+
+@test "default derivation echoes unknown tool queries" {
+        run bash -lc 'source ./src/planner.sh; VERBOSITY=0; derive_tool_query "unregistered_tool" "raw query"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == "raw query" ]]
+}
+
+@test "notes derivation strips leading keyword" {
+        run bash -lc 'source ./src/planner.sh; VERBOSITY=0; derive_tool_query "notes_create" "note meeting notes"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == "meeting notes" ]]
+}


### PR DESCRIPTION
## Summary
- add tool-specific query derivation helpers alongside terminal, reminders, and notes tools and dispatch via registry mapping
- route derive_tool_query through a lookup table with a default handler to keep planner logic focused
- cover query derivation dispatch with new bats tests

## Testing
- bats tests/test_tool_query_derivation.bats
- bats tests/test_main.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693604667b588325b7ab8567ad97a0d9)