### PR TITLE
Refine planner-driven tool flow

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -13,3 +13,12 @@ bats tests/test_all.sh tests/test_install.bats tests/test_main.bats tests/test_m
 The Bats suite covers CLI help/version output, confirmation prompts, deterministic mock scoring via `tests/fixtures/mock_llama.sh`, and graceful handling when `LLAMA_BIN` is missing.
 
 Set `TESTING_PASSTHROUGH=true` when running the suite to disable llama.cpp invocation and surface test-only code paths without muting runtime errors that depend on llama availability.
+
+## Planning workflow
+
+The planner now drives execution through an explicit, tool-aware outline:
+
+1. `generate_plan_outline` prompts the model with the full tool catalog to produce a numbered, high-level plan that explicitly names tools and always ends with `final_answer`.
+2. `extract_tools_from_plan` reads that outline to build the allowed tool list (ensuring `final_answer` is available for the final handoff).
+3. `build_plan_entries_from_tools` derives concrete tool queries for the React loop while preserving the outline for agent guidance.
+4. The React loop executes tools in sequence, adapting after each observation until the `final_answer` tool is invoked.

--- a/src/main.sh
+++ b/src/main.sh
@@ -65,7 +65,7 @@ source "${SCRIPT_DIR}/runtime.sh"
 
 main() {
 	local -A settings
-	local ranked_tools plan_entries plan_action
+	local plan_outline required_tools plan_entries plan_action
 
 	load_runtime_settings settings "$@"
 
@@ -76,17 +76,18 @@ main() {
 	fi
 
 	prepare_environment_with_settings settings
-	log "INFO" "Starting tool selection" "${settings[user_query]}"
-	ranked_tools="$(rank_tools "${settings[user_query]}")"
-	log "INFO" "Selected tools" "${ranked_tools}"
-	plan_entries="$(build_plan_entries "${ranked_tools}" "${settings[user_query]}")"
+	log "INFO" "Starting plan generation" "${settings[user_query]}"
+	plan_outline="$(generate_plan_outline "${settings[user_query]}")"
+	required_tools="$(extract_tools_from_plan "${plan_outline}")"
+	log "INFO" "Planner identified tools" "${required_tools}"
+	plan_entries="$(build_plan_entries_from_tools "${required_tools}" "${settings[user_query]}")"
 
-	render_plan_outputs plan_action settings "${ranked_tools}" "${plan_entries}"
+	render_plan_outputs plan_action settings "${required_tools}" "${plan_entries}" "${plan_outline}"
 	if [[ "${plan_action}" == "exit" ]]; then
 		return 0
 	fi
 
-	select_response_strategy settings "${ranked_tools}" "${plan_entries}"
+	select_response_strategy settings "${required_tools}" "${plan_entries}" "${plan_outline}"
 }
 
 main "$@"

--- a/tests/fixtures/mock_llama_relevance.sh
+++ b/tests/fixtures/mock_llama_relevance.sh
@@ -38,29 +38,29 @@ if [[ "${prompt_lower}" == *"concise response"* ]]; then
 	exit 0
 fi
 
-if [[ "${user_request_lower}" == *"joke"* || "${user_request_lower}" == *"chat"* ]]; then
-	printf '{}\n'
+if [[ "${prompt_lower}" == *"numbered list of high-level actions"* || "${prompt_lower}" == *"available tools"* ]]; then
+	if [[ "${user_request_lower}" == *"remind"* ]]; then
+		printf '1. Use reminders_create to schedule the reminder.\n2. Use final_answer to confirm for the user.\n'
+		exit 0
+	fi
+
+	if [[ "${user_request_lower}" == *"note"* ]]; then
+		printf '1. Use notes_create to capture the note.\n2. Use final_answer to summarize what was saved.\n'
+		exit 0
+	fi
+
+	if [[ "${user_request_lower}" == *"todo"* ]]; then
+		printf '1. Use terminal to search for TODO markers.\n2. Use final_answer to summarize findings.\n'
+		exit 0
+	fi
+
+	if [[ "${user_request_lower}" == *"file"* || "${user_request_lower}" == *"folder"* ]]; then
+		printf '1. Use terminal to inspect the files.\n2. Use final_answer to relay the results.\n'
+		exit 0
+	fi
+
+	printf '1. Use final_answer to respond directly.\n'
 	exit 0
 fi
 
-if [[ "${user_request_lower}" == *"remind"* ]]; then
-	printf '{"reminders_create":true}\n'
-	exit 0
-fi
-
-if [[ "${user_request_lower}" == *"note"* ]]; then
-	printf '{"notes_create":true}\n'
-	exit 0
-fi
-
-if [[ "${user_request_lower}" == *"todo"* ]]; then
-	printf '{"terminal":true}\n'
-	exit 0
-fi
-
-if [[ "${user_request_lower}" == *"file"* || "${user_request_lower}" == *"folder"* ]]; then
-	printf '{"terminal":true}\n'
-	exit 0
-fi
-
-printf '{}\n'
+printf '1. Use final_answer to respond directly.\n'

--- a/tests/test_main.bats
+++ b/tests/test_main.bats
@@ -57,11 +57,11 @@ EOF
 	[[ "$output" == *"\"query\""* ]]
 }
 
-@test "casual prompts skip tools" {
+@test "casual prompts still finish with final_answer" {
 	run ./src/main.sh --config "${CONFIG_FILE}" --yes -- "tell me a joke"
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"Suggested tools: none."* ]]
-	[[ "$output" != *"executed"* ]]
+	[[ "$output" == *"Suggested tools:"* ]]
+	[[ "$output" == *"final_answer"* ]]
 }
 
 @test "conversational phrasing suggests terminal tool" {
@@ -69,13 +69,6 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Suggested tools"* ]]
 	[[ "$output" == *"terminal"* ]]
-}
-
-@test "direct responses log fallback when no tools apply" {
-	run ./src/main.sh --config "${CONFIG_FILE}" --yes -- "just chat with me"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"No tools selected; responding directly"* ]]
-	[[ "$output" == *"Responding directly to: just chat with me"* ]]
 }
 
 @test "reminder intent builds reminder plan" {


### PR DESCRIPTION
## Summary
- replace structured tool relevance with a planner prompt that emits numbered outlines and captures required tools
- feed plan-derived tool lists and outlines into the react loop and updated mocks/tests for the new execution path
- document the revised planning workflow for contributors

## Testing
- bats tests/test_main.bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69361f192a108325be8312b108112c6e)