### PR TITLE
Centralize grammar definitions for llama structured calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ More scenarios and approval modes live in the [usage guide](docs/usage.md). Conf
 ## Prompt catalogue
 
 All prompts used by the assistant are centralized in [`src/prompts.sh`](src/prompts.sh) for easier maintenance. The file exposes prompt builders for direct responses, plan generation, and ReAct steps so updates to tone, structure, or schema can be made in one place.
+
+Structured outputs are enforced with shared [GBNF grammars](src/grammars/) referenced by the prompt builders and passed directly to `llama.cpp` during inference. Each grammar file name documents its purpose (e.g., `planner_plan.gbnf`, `react_action.gbnf`, `concise_response.gbnf`) so contributors can update schemas without hunting through inline prompt text.

--- a/src/grammar.sh
+++ b/src/grammar.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Grammar utilities for locating shared llama.cpp grammars.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/grammar.sh}/grammar.sh"
+#
+# Environment variables:
+#   None.
+#
+# Dependencies:
+#   - bash 5+
+#
+# Exit codes:
+#   Functions return non-zero when an unknown grammar name is requested.
+
+# Returns the absolute path to the grammar directory.
+grammar_root_dir() {
+        local script_dir
+        script_dir="${BASH_SOURCE[0]%/grammar.sh}"
+        cd "${script_dir}/grammars" && pwd
+}
+
+# Resolves a grammar name to its file path.
+# Arguments:
+#   $1 - grammar key (string)
+grammar_path() {
+        local grammar_name grammar_file
+        grammar_name="$1"
+
+        case "${grammar_name}" in
+        react_action)
+                grammar_file="react_action.gbnf"
+                ;;
+        planner_plan)
+                grammar_file="planner_plan.gbnf"
+                ;;
+        concise_response)
+                grammar_file="concise_response.gbnf"
+                ;;
+        *)
+                printf 'Unknown grammar requested: %s\n' "${grammar_name}" >&2
+                return 1
+                ;;
+        esac
+
+        printf '%s/%s' "$(grammar_root_dir)" "${grammar_file}"
+}
+
+# Reads a grammar file and writes it to stdout.
+# Arguments:
+#   $1 - grammar key (string)
+load_grammar_text() {
+        local grammar_name grammar_file_path
+        grammar_name="$1"
+        grammar_file_path="$(grammar_path "${grammar_name}")" || return 1
+
+        cat "${grammar_file_path}"
+}

--- a/src/grammars/concise_response.gbnf
+++ b/src/grammars/concise_response.gbnf
@@ -1,0 +1,3 @@
+root ::= text
+text ::= character*
+character ::= [^\n]

--- a/src/grammars/planner_plan.gbnf
+++ b/src/grammars/planner_plan.gbnf
@@ -1,0 +1,8 @@
+root ::= step (newline step)*
+step ::= number '.' space step_text
+number ::= [1-9] digit*
+digit ::= [0-9]
+step_text ::= step_char+
+step_char ::= [^\n]
+space ::= ' '
+newline ::= '\n'

--- a/src/prompts.sh
+++ b/src/prompts.sh
@@ -15,28 +15,38 @@
 # Exit codes:
 #   Functions print prompts and return 0 on success.
 
-build_concise_response_prompt() {
-        # Arguments:
-        #   $1 - user query (string)
-        local user_query
-        user_query="$1"
+# shellcheck source=./grammar.sh disable=SC1091
+source "${BASH_SOURCE[0]%/prompts.sh}/grammar.sh"
 
-cat <<PROMPT
+build_concise_response_prompt() {
+	# Arguments:
+	#   $1 - user query (string)
+	local user_query concise_grammar
+	user_query="$1"
+	concise_grammar="$(load_grammar_text concise_response)"
+
+	cat <<PROMPT
 Provide a short, concise answer (two to three sentences) to the user. Your response will be stopped after the first newline character. USER REQUEST: ${user_query}.
-CONCISE RESPONSE:  
+Follow this grammar to avoid multi-line answers:
+${concise_grammar}
+CONCISE RESPONSE:
 PROMPT
 }
 
 build_planner_prompt() {
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted tool descriptions (string)
-        local user_query tool_lines
-        user_query="$1"
-        tool_lines="$2"
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted tool descriptions (string)
+	local user_query tool_lines planner_grammar
+	user_query="$1"
+	tool_lines="$2"
+	planner_grammar="$(load_grammar_text planner_plan)"
 
-cat <<PROMPT
+	cat <<PROMPT
 You are a planner for an autonomous agent. Given a user request and a list of available tools, draft a numbered list of high-level actions the agent should take. Each step must mention the tool name that will be used. Do NOT include fully executable shell commands; keep the guidance conceptual. Always end with a final step that uses the final_answer tool to deliver the response back to the user.
+
+Constrain your response using this grammar:
+${planner_grammar}
 
 Available tools:
 ${tool_lines}
@@ -45,23 +55,24 @@ PROMPT
 }
 
 build_react_prompt() {
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted allowed tool descriptions (string)
-        #   $3 - high-level plan outline (string)
-        #   $4 - prior interaction history (string)
-        local user_query allowed_tools plan_outline history
-        user_query="$1"
-        allowed_tools="$2"
-        plan_outline="$3"
-        history="$4"
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted allowed tool descriptions (string)
+	#   $3 - high-level plan outline (string)
+	#   $4 - prior interaction history (string)
+	local user_query allowed_tools plan_outline history react_grammar
+	user_query="$1"
+	allowed_tools="$2"
+	plan_outline="$3"
+	history="$4"
+	react_grammar="$(load_grammar_text react_action)"
 
-cat <<PROMPT
+	cat <<PROMPT
 You are an assistant planning a sequence of actions. Use the high-level plan as guidance but adapt after each observation.
 Respond ONLY with a single JSON object per turn.
-Action schema:
-- To use a tool: {"type":"tool","tool":"<tool_name>","query":"<specific command>"}
-- To finish: {"type":"tool","tool":"final_answer","query":"<final user-facing reply>"}
+
+Action schema (grammar enforced):
+${react_grammar}
 High-level plan:
 ${plan_outline}
 User request: ${user_query}

--- a/src/respond.sh
+++ b/src/respond.sh
@@ -20,21 +20,24 @@
 source "${BASH_SOURCE[0]%/respond.sh}/logging.sh"
 # shellcheck source=./prompts.sh disable=SC1091
 source "${BASH_SOURCE[0]%/respond.sh}/prompts.sh"
+# shellcheck source=./grammar.sh disable=SC1091
+source "${BASH_SOURCE[0]%/respond.sh}/grammar.sh"
 
 respond_text() {
 	# Arguments:
 	#   $1 - user query (string)
 	#   $2 - number of tokens to generate (int)
-	local user_query prompt number_of_tokens
+	local user_query prompt number_of_tokens concise_grammar_path
 	user_query="$1"
 	number_of_tokens="$2"
+	concise_grammar_path="$(grammar_path concise_response)"
 
 	if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
 		printf 'Responding directly to: %s\n' "${user_query}"
 		return 0
 	fi
 
-        prompt="$(build_concise_response_prompt "${user_query}")"
-        llama_infer "${prompt}" "\n" "${number_of_tokens}"
-        return 0
+	prompt="$(build_concise_response_prompt "${user_query}")"
+	llama_infer "${prompt}" "\n" "${number_of_tokens}" "${concise_grammar_path}"
+	return 0
 }


### PR DESCRIPTION
## Summary
- add shared grammar directory with helpers for planner, ReAct, and concise responses
- update prompt builders and llama calls to load centralized grammars
- document grammar location and extend tests to assert correct grammar usage

## Testing
- bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69362f6916048325bec58e8930e6a64d)