### PR TITLE
Handle llama unavailability fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Write a config file up front with a custom model branch (defaults to `bartowski/
 
 More scenarios and approval modes live in the [usage guide](docs/usage.md). Configuration keys are covered in [configuration](docs/configuration.md), and available tools are listed in [tools](docs/tools.md). Development and testing steps are in [development](docs/development.md).
 
+### Offline and testing behavior
+
+Set `TESTING_PASSTHROUGH=true` to disable llama.cpp calls during tests or offline usage. The planner exposes deterministic fallbacks when `LLAMA_AVAILABLE=false`, returning a simple final-answer-only plan and concise responses that acknowledge the original request instead of invoking `llama.cpp`.
+
 ## Prompt catalogue
 
 All prompts used by the assistant are centralized in [`src/prompts.sh`](src/prompts.sh) for easier maintenance. The file exposes prompt builders for direct responses, plan generation, and ReAct steps so updates to tone, structure, or schema can be made in one place.

--- a/src/respond.sh
+++ b/src/respond.sh
@@ -24,18 +24,24 @@ source "${BASH_SOURCE[0]%/respond.sh}/prompts.sh"
 source "${BASH_SOURCE[0]%/respond.sh}/grammar.sh"
 
 respond_text() {
-	# Arguments:
-	#   $1 - user query (string)
-	#   $2 - number of tokens to generate (int)
-	local user_query prompt number_of_tokens concise_grammar_path
-	user_query="$1"
-	number_of_tokens="$2"
-	concise_grammar_path="$(grammar_path concise_response)"
+        # Arguments:
+        #   $1 - user query (string)
+        #   $2 - number of tokens to generate (int)
+        local user_query prompt number_of_tokens concise_grammar_path
+        user_query="$1"
+        number_of_tokens="$2"
+        concise_grammar_path="$(grammar_path concise_response)"
 
-	if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
-		printf 'Responding directly to: %s\n' "${user_query}"
-		return 0
-	fi
+        if [[ "${LLAMA_AVAILABLE}" != true ]]; then
+                log "WARN" "llama unavailable; returning deterministic response" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
+                printf 'LLM unavailable. Request received: %s\n' "${user_query}"
+                return 0
+        fi
+
+        if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
+                printf 'Responding directly to: %s\n' "${user_query}"
+                return 0
+        fi
 
 	prompt="$(build_concise_response_prompt "${user_query}")"
 	llama_infer "${prompt}" "\n" "${number_of_tokens}" "${concise_grammar_path}"


### PR DESCRIPTION
## Summary
- guard llama inference against unavailable binaries with static plan fallback
- return deterministic responses when llama is disabled and document offline behavior
- add bats coverage to verify TESTING_PASSTHROUGH prevents llama invocation

## Testing
- bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693633a45db48325b9e45a306912736c)