### PR TITLE
Handle offline planner outline

### DIFF
--- a/src/planner.sh
+++ b/src/planner.sh
@@ -36,25 +36,25 @@ source "${BASH_SOURCE[0]%/planner.sh}/prompts.sh"
 source "${BASH_SOURCE[0]%/planner.sh}/grammar.sh"
 
 llama_infer() {
-        # Runs llama.cpp with HF caching enabled for the configured model.
-        # Arguments:
-        #   $1 - prompt string
-        #   $2 - stop string (optional)
-        #   $3 - max tokens (optional)
-        #   $4 - grammar file path (optional)
-        local prompt stop_string number_of_tokens grammar_file_path
-        prompt="$1"
-        stop_string="${2:-}"
-        number_of_tokens="${3:-256}"
-        grammar_file_path="${4:-}"
+	# Runs llama.cpp with HF caching enabled for the configured model.
+	# Arguments:
+	#   $1 - prompt string
+	#   $2 - stop string (optional)
+	#   $3 - max tokens (optional)
+	#   $4 - grammar file path (optional)
+	local prompt stop_string number_of_tokens grammar_file_path
+	prompt="$1"
+	stop_string="${2:-}"
+	number_of_tokens="${3:-256}"
+	grammar_file_path="${4:-}"
 
-        if [[ "${LLAMA_AVAILABLE}" != true ]]; then
-                log "WARN" "llama unavailable; skipping inference" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
-                return 1
-        fi
+	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
+		log "WARN" "llama unavailable; skipping inference" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
+		return 1
+	fi
 
-        local additional_args
-        additional_args=()
+	local additional_args
+	additional_args=()
 
 	if [[ -n "${grammar_file_path}" ]]; then
 		additional_args+=(--grammar "${grammar_file_path}")
@@ -148,17 +148,19 @@ append_final_answer_step() {
 generate_plan_outline() {
 	# Arguments:
 	#   $1 - user query (string)
-	local user_query prompt raw_plan planner_grammar_path
+	local user_query
 	user_query="$1"
-	local tool_lines
-	tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${TOOLS[@]}")" format_tool_summary_line)"
-	planner_grammar_path="$(grammar_path planner_plan)"
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "INFO" "Using static plan outline because llama is unavailable" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
 		printf '1. Use final_answer to respond directly to the user request.'
 		return 0
 	fi
+
+	local prompt raw_plan planner_grammar_path
+	local tool_lines
+	tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${TOOLS[@]}")" format_tool_summary_line)"
+	planner_grammar_path="$(grammar_path planner_plan)"
 
 	prompt="$(build_planner_prompt "${user_query}" "${tool_lines}")"
 	raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_grammar_path}")"
@@ -341,6 +343,7 @@ execute_tool_with_query() {
 	return 0
 }
 
+# shellcheck disable=SC2154,SC2178
 initialize_react_state() {
 	# Arguments:
 	#   $1 - name of associative array to populate
@@ -348,6 +351,7 @@ initialize_react_state() {
 	#   $3 - allowed tools (newline delimited)
 	#   $4 - ranked plan entries
 	#   $5 - plan outline text
+	# shellcheck disable=SC2178
 	local -n state_ref=$1
 	state_ref[user_query]="$2"
 	state_ref[allowed_tools]="$3"
@@ -364,12 +368,14 @@ record_history() {
 	# Arguments:
 	#   $1 - name of associative array holding state
 	#   $2 - formatted history entry
+	# shellcheck disable=SC2178
 	local -n state_ref=$1
 	local entry
 	entry="$2"
 	state_ref[history]+=$(printf '%s\n' "${entry}")
 }
 
+# shellcheck disable=SC2178,SC2034
 select_next_action() {
 	# Arguments:
 	#   $1 - name of associative array holding state
@@ -377,6 +383,7 @@ select_next_action() {
 	local state_name output_name
 	state_name="$1"
 	output_name="${2:-}"
+	# shellcheck disable=SC2178
 	local -n state_ref=$state_name
 	local react_prompt plan_index planned_entry tool query next_action_payload allowed_tool_descriptions allowed_tool_lines
 	if [[ "${USE_REACT_LLAMA:-false}" == true && "${LLAMA_AVAILABLE}" == true ]]; then
@@ -434,6 +441,7 @@ validate_tool_permission() {
 	#   $1 - name of associative array holding state
 	#   $2 - tool name to validate
 	local state_name
+	# shellcheck disable=SC2178
 	local -n state_ref=$1
 	local tool
 	state_name="$1"
@@ -464,6 +472,7 @@ record_tool_execution() {
 	#   $4 - observation text
 	#   $5 - step index
 	local state_name
+	# shellcheck disable=SC2178
 	local -n state_ref=$1
 	local tool query observation step_index
 	state_name="$1"
@@ -477,6 +486,7 @@ record_tool_execution() {
 finalize_react_result() {
 	# Arguments:
 	#   $1 - name of associative array holding state
+	# shellcheck disable=SC2178
 	local -n state_ref=$1
 	if [[ -z "${state_ref[final_answer]}" ]]; then
 		state_ref[final_answer]="$(respond_text "${state_ref[user_query]} ${state_ref[history]}" 1000)"

--- a/tests/test_modules.bats
+++ b/tests/test_modules.bats
@@ -35,7 +35,7 @@
 }
 
 @test "init_environment keeps llama enabled when passthrough is unset" {
-        run bash -lc '
+	run bash -lc '
                 unset TESTING_PASSTHROUGH
                 MODEL_SPEC="demo/repo:demo.gguf"
                 DEFAULT_MODEL_FILE="demo.gguf"
@@ -47,12 +47,12 @@
                 init_environment
                 printf "%s" "${LLAMA_AVAILABLE}"
         '
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "true" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "true" ]
 }
 
 @test "llama_infer reports unavailability without invoking llama" {
-        run bash -lc '
+	run bash -lc '
                 tmpdir=$(mktemp -d)
                 export LLAMA_AVAILABLE=false
                 export LLAMA_BIN="${tmpdir}/llama"
@@ -70,19 +70,19 @@ EOF
                 printf "LOG:%s\n" "$(cat "${TMP_LOG}" 2>/dev/null || true)"
         '
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "STATUS:1" ]
-        [ "${lines[1]}" = "LOG:" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "STATUS:1" ]
+	[ "${lines[1]}" = "LOG:" ]
 }
 
 @test "init_tool_registry clears previous tools" {
 	run bash -lc 'source ./src/tools.sh; TOOLS=(stub); TOOL_DESCRIPTION=( [stub]="desc"); init_tool_registry; echo "${#TOOLS[@]}"'
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" -eq 0 ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" -eq 0 ]
 }
 
 @test "assert_osascript_available warns and exits when not on macOS" {
-        run bash -lc '
+	run bash -lc '
                 IS_MACOS=false
                 VERBOSITY=1
                 TOOL_QUERY="demo query"
@@ -94,13 +94,13 @@ EOF
                         "${TOOL_QUERY}"
         '
 
-        [ "$status" -eq 1 ]
-        [ "$(echo "${output}" | jq -r '.message')" = "AppleScript not available on this platform" ]
-        [ "$(echo "${output}" | jq -r '.detail')" = "demo query" ]
+	[ "$status" -eq 1 ]
+	[ "$(echo "${output}" | jq -r '.message')" = "AppleScript not available on this platform" ]
+	[ "$(echo "${output}" | jq -r '.detail')" = "demo query" ]
 }
 
 @test "assert_osascript_available flags missing binary on macOS" {
-        run bash -lc '
+	run bash -lc '
                 IS_MACOS=true
                 VERBOSITY=1
                 source ./src/tools/osascript_helpers.sh
@@ -111,14 +111,14 @@ EOF
                         ""
         '
 
-        [ "$status" -eq 1 ]
-        [ "$(echo "${output}" | jq -r '.message')" = "osascript missing; cannot execute AppleScript" ]
+	[ "$status" -eq 1 ]
+	[ "$(echo "${output}" | jq -r '.message')" = "osascript missing; cannot execute AppleScript" ]
 }
 
 @test "initialize_tools registers each module" {
-        run bash -lc 'source ./src/tools.sh; init_tool_registry; initialize_tools; printf "%s\n" "${TOOLS[@]}"'
-        [ "$status" -eq 0 ]
-        [ "${#lines[@]}" -eq 22 ]
+	run bash -lc 'source ./src/tools.sh; init_tool_registry; initialize_tools; printf "%s\n" "${TOOLS[@]}"'
+	[ "$status" -eq 0 ]
+	[ "${#lines[@]}" -eq 22 ]
 	[ "${lines[0]}" = "terminal" ]
 	[ "${lines[1]}" = "file_search" ]
 	[ "${lines[2]}" = "clipboard_copy" ]
@@ -299,7 +299,7 @@ printf "LOG:%s\n" "$(cat "${LOG_FILE}")"
 }
 
 @test "select_next_action follows plan entries before finalizing" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/planner.sh
                 respond_text() { printf "offline response"; }
                 declare -A state=(
@@ -317,13 +317,13 @@ printf "LOG:%s\n" "$(cat "${LOG_FILE}")"
                 select_next_action state | jq -r ".type,.tool,.query"
         '
 	[ "$status" -eq 0 ]
-        [ "${lines[0]}" = "tool" ]
-        [ "${lines[1]}" = "terminal" ]
-        [ "${lines[2]}" = "echo hi" ]
+	[ "${lines[0]}" = "tool" ]
+	[ "${lines[1]}" = "terminal" ]
+	[ "${lines[2]}" = "echo hi" ]
 }
 
 @test "select_next_action uses llama grammar and captures output" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/planner.sh
 
                 llama_arg_file="$(mktemp)"
@@ -358,14 +358,14 @@ printf "LOG:%s\n" "$(cat "${LOG_FILE}")"
                 printf "%s\n" "${action_json}" "COUNT:${llama_arg_count}" "GRAMMAR:${llama_grammar}" "EXPECTED:${expected_grammar}"
         '
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = '{"type":"tool","tool":"terminal","query":"ls"}' ]
-        [ "${lines[1]}" = "COUNT:4" ]
-        [ "${lines[2]}" = "GRAMMAR:${lines[3]#EXPECTED:}" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = '{"type":"tool","tool":"terminal","query":"ls"}' ]
+	[ "${lines[1]}" = "COUNT:4" ]
+	[ "${lines[2]}" = "GRAMMAR:${lines[3]#EXPECTED:}" ]
 }
 
 @test "generate_plan_outline uses shared planner grammar" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/planner.sh
                 initialize_tools
                 LLAMA_AVAILABLE=true
@@ -380,14 +380,33 @@ plan_text="$(generate_plan_outline "list files")"
 printf "PLAN:%s\nGRAMMAR:%s\n" "${plan_text}" "$(cat "${llama_grammar_file}")"
         '
 
-        [ "$status" -eq 0 ]
-        expected_grammar="$(cd src && pwd)/grammars/planner_plan.gbnf"
-        last_index=$(( ${#lines[@]} - 1 ))
-        [ "${lines[${last_index}]}" = "GRAMMAR:${expected_grammar}" ]
+	[ "$status" -eq 0 ]
+	expected_grammar="$(cd src && pwd)/grammars/planner_plan.gbnf"
+	last_index=$((${#lines[@]} - 1))
+	[ "${lines[${last_index}]}" = "GRAMMAR:${expected_grammar}" ]
+}
+
+@test "generate_plan_outline short-circuits when llama unavailable" {
+	run bash -lc '
+                tmpdir=$(mktemp -d)
+                source ./src/planner.sh
+                llama_infer() { printf "called" >"${tmpdir}/llama.called"; }
+                log() { :; }
+                initialize_tools
+                LLAMA_AVAILABLE=false
+
+                plan_text="$(generate_plan_outline "offline request")"
+                call_log="$(cat "${tmpdir}/llama.called" 2>/dev/null || true)"
+                printf "PLAN:%s\nCALLED:%s\n" "${plan_text}" "${call_log}"
+        '
+
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "PLAN:1. Use final_answer to respond directly to the user request." ]
+	[ "${lines[1]}" = "CALLED:" ]
 }
 
 @test "respond_text forwards concise response grammar" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/respond.sh
                 LLAMA_AVAILABLE=true
 
@@ -400,14 +419,14 @@ printf "PLAN:%s\nGRAMMAR:%s\n" "${plan_text}" "$(cat "${llama_grammar_file}")"
                 printf "RESPONSE:%s\nGRAMMAR:%s\n" "${response_output}" "$(cat "${llama_grammar_file}")"
         '
 
-        [ "$status" -eq 0 ]
-        expected_grammar="$(cd src && pwd)/grammars/concise_response.gbnf"
-        last_index=$(( ${#lines[@]} - 1 ))
-        [ "${lines[${last_index}]}" = "GRAMMAR:${expected_grammar}" ]
+	[ "$status" -eq 0 ]
+	expected_grammar="$(cd src && pwd)/grammars/concise_response.gbnf"
+	last_index=$((${#lines[@]} - 1))
+	[ "${lines[${last_index}]}" = "GRAMMAR:${expected_grammar}" ]
 }
 
 @test "respond_text falls back when llama is unavailable" {
-        run bash -lc '
+	run bash -lc '
                 tmpdir=$(mktemp -d)
                 export TESTING_PASSTHROUGH=true
                 export LLAMA_BIN="${tmpdir}/llama"
@@ -426,14 +445,14 @@ printf "PLAN:%s\nGRAMMAR:%s\n" "${plan_text}" "$(cat "${llama_grammar_file}")"
                 printf "OUTPUT:%s\nLOG:%s\nAVAILABLE:%s\n" "${response_output}" "$(cat "${tmpdir}/llama.log" 2>/dev/null || true)" "${LLAMA_AVAILABLE}"
         '
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "OUTPUT:LLM unavailable. Request received: offline question" ]
-        [ "${lines[1]}" = "LOG:" ]
-        [ "${lines[2]}" = "AVAILABLE:false" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "OUTPUT:LLM unavailable. Request received: offline question" ]
+	[ "${lines[1]}" = "LOG:" ]
+	[ "${lines[2]}" = "AVAILABLE:false" ]
 }
 
 @test "select_next_action logs and fails on invalid llama output" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/planner.sh
 
                 llama_infer() {
@@ -462,10 +481,10 @@ printf "PLAN:%s\nGRAMMAR:%s\n" "${plan_text}" "$(cat "${llama_grammar_file}")"
                 exit ${rc}
         '
 
-        [ "$status" -eq 1 ]
-        [[ "${output}" == *"Invalid action output from llama"* ]]
-        last_index=$((${#lines[@]} - 1))
-        [ "${lines[${last_index}]}" = "STATUS:1" ]
+	[ "$status" -eq 1 ]
+	[[ "${output}" == *"Invalid action output from llama"* ]]
+	last_index=$((${#lines[@]} - 1))
+	[ "${lines[${last_index}]}" = "STATUS:1" ]
 }
 
 @test "validate_tool_permission records history for disallowed tool" {


### PR DESCRIPTION
## Summary
- short-circuit plan outline generation when llama is unavailable, returning only a final_answer step
- adjust planner shellcheck annotations to keep linting clean
- add bats coverage to assert offline planning skips llama invocation

## Testing
- shfmt -w src/planner.sh tests/test_modules.bats
- shellcheck src/planner.sh tests/test_modules.bats
- bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363672edd08325abcb9f6b437b740a)