### PR TITLE
Add shared error envelope helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ Set `TESTING_PASSTHROUGH=true` to disable llama.cpp calls during tests or offlin
 All prompts used by the assistant are centralized in [`src/prompts.sh`](src/prompts.sh) for easier maintenance. The file exposes prompt builders for direct responses, plan generation, and ReAct steps so updates to tone, structure, or schema can be made in one place.
 
 Structured outputs are enforced with shared [GBNF grammars](src/grammars/) referenced by the prompt builders and passed directly to `llama.cpp` during inference. Each grammar file name documents its purpose (e.g., `planner_plan.gbnf`, `react_action.gbnf`, `concise_response.gbnf`) so contributors can update schemas without hunting through inline prompt text.
+
+## Structured error envelopes
+
+Shared helpers in [`src/errors.sh`](src/errors.sh) emit JSON envelopes for fatal and warning paths while ensuring non-zero exit
+codes from pipelines and subshells. The envelope format is consistent across runtime and tool scripts:
+
+```json
+{
+  "name": "cli",
+  "category": "usage",
+  "message": "--model requires an HF repo[:file] value"
+}
+```
+
+- `name` identifies the emitting runtime or tool.
+- `category` classifies the error (for example, `usage`, `pipeline`, or `fatal`).
+- `message` carries the human-readable detail for the failure.

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -115,30 +115,27 @@ parse_args() {
 			DRY_RUN=true
 			shift
 			;;
-		-m | --model)
-			if [[ $# -lt 2 ]]; then
-				log "ERROR" "--model requires an HF repo[:file] value"
-				exit 1
-			fi
-			MODEL_SPEC="$2"
-			shift 2
-			;;
-		--model-branch)
-			if [[ $# -lt 2 ]]; then
-				log "ERROR" "--model-branch requires a branch or tag"
-				exit 1
-			fi
-			MODEL_BRANCH="$2"
-			shift 2
-			;;
-		--config)
-			if [[ $# -lt 2 ]]; then
-				log "ERROR" "--config requires a path"
-				exit 1
-			fi
-			CONFIG_FILE="$2"
-			shift 2
-			;;
+                -m | --model)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--model requires an HF repo[:file] value"
+                        fi
+                        MODEL_SPEC="$2"
+                        shift 2
+                        ;;
+                --model-branch)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--model-branch requires a branch or tag"
+                        fi
+                        MODEL_BRANCH="$2"
+                        shift 2
+                        ;;
+                --config)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--config requires a path"
+                        fi
+                        CONFIG_FILE="$2"
+                        shift 2
+                        ;;
 		-v | --verbose)
 			VERBOSITY=2
 			shift
@@ -147,14 +144,13 @@ parse_args() {
 			VERBOSITY=0
 			shift
 			;;
-		--)
-			shift
-			break
-			;;
-		-*)
-			log "ERROR" "Unknown option" "$1"
-			exit 1
-			;;
+                --)
+                        shift
+                        break
+                        ;;
+                -*)
+                        die "cli" "usage" "Unknown option: ${1}"
+                        ;;
 		*)
 			positional+=("$1")
 			shift
@@ -166,10 +162,9 @@ parse_args() {
 		USER_QUERY="${positional[*]}"
 	else
 		USER_QUERY="$*"
-	fi
+        fi
 
-	if [[ "${COMMAND}" == "run" && -z "${USER_QUERY:-}" ]]; then
-		log "ERROR" "A user query is required. See --help for usage."
-		exit 1
-	fi
+        if [[ "${COMMAND}" == "run" && -z "${USER_QUERY:-}" ]]; then
+                die "cli" "usage" "A user query is required. See --help for usage."
+        fi
 }

--- a/src/config.sh
+++ b/src/config.sh
@@ -36,15 +36,14 @@ detect_config_file() {
 	# Parse the config path early so subsequent helpers can honor user-provided
 	# locations before any other arguments are interpreted.
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		--config)
-			if [[ $# -lt 2 ]]; then
-				log "ERROR" "--config requires a path"
-				exit 1
-			fi
-			CONFIG_FILE="$2"
-			shift 2
-			;;
+                case "$1" in
+                --config)
+                        if [[ $# -lt 2 ]]; then
+                                die "config" "usage" "--config requires a path"
+                        fi
+                        CONFIG_FILE="$2"
+                        shift 2
+                        ;;
 		--config=*)
 			CONFIG_FILE="${1#*=}"
 			shift

--- a/src/errors.sh
+++ b/src/errors.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Error handling helpers for the okso assistant CLI and tool scripts.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/errors.sh}/errors.sh"
+#
+# Environment variables:
+#   ERROR_CONTEXT (string): optional override for the emitting component name.
+#   TOOL_NAME (string): optional tool identifier used when ERROR_CONTEXT is unset.
+#
+# Dependencies:
+#   - bash 5+
+#   - jq
+#
+# Exit codes:
+#   die exits non-zero with the provided status (default: 1).
+#   warn returns a non-zero status (default: 1) so callers can surface failures.
+#   log_debug returns 0.
+
+emit_error_envelope() {
+        # Emits a JSON error envelope with consistent metadata.
+        # Arguments:
+        #   $1 - context (string; optional; defaults to ERROR_CONTEXT/TOOL_NAME/runtime)
+        #   $2 - category (string; required)
+        #   $3 - message (string; required)
+        local context category message
+        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+        category="$2"
+        message="$3"
+
+        jq -cn \
+                --arg name "${context}" \
+                --arg category "${category}" \
+                --arg message "${message}" \
+                '{name:$name, category:$category, message:$message}'
+}
+
+die() {
+        # Emits an error envelope and exits with a non-zero code.
+        # Arguments:
+        #   $1 - context (string; optional)
+        #   $2 - category (string; required)
+        #   $3 - message (string; required)
+        #   $4 - exit code (int; optional; default: 1)
+        local context category message status
+        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+        category="$2"
+        message="$3"
+        status=${4:-1}
+
+        emit_error_envelope "${context}" "${category}" "${message}" >&2
+        exit "${status}"
+}
+
+warn() {
+        # Emits an error envelope and returns a non-zero status for soft failures.
+        # Arguments:
+        #   $1 - context (string; optional)
+        #   $2 - category (string; required)
+        #   $3 - message (string; required)
+        #   $4 - exit code (int; optional; default: 1)
+        local context category message status
+        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+        category="$2"
+        message="$3"
+        status=${4:-1}
+
+        emit_error_envelope "${context}" "${category}" "${message}" >&2
+        return "${status}"
+}
+
+log_debug() {
+        # Emits a debug envelope without altering control flow.
+        # Arguments:
+        #   $1 - context (string; optional)
+        #   $2 - message (string; required)
+        local context message
+        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+        message="$2"
+
+        emit_error_envelope "${context}" "debug" "${message}" >&2
+}

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -17,6 +17,9 @@
 # Exit codes:
 #   None directly; callers handle failures.
 
+# shellcheck source=./errors.sh disable=SC1091
+source "${BASH_SOURCE[0]%/logging.sh}/errors.sh"
+
 log() {
 	# Arguments:
 	#   $1 - level (string)

--- a/src/main.sh
+++ b/src/main.sh
@@ -48,6 +48,8 @@ resolve_script_dir() {
 }
 
 SCRIPT_DIR=$(resolve_script_dir)
+# shellcheck source=./errors.sh disable=SC1091
+source "${SCRIPT_DIR}/errors.sh"
 # shellcheck source=./logging.sh disable=SC1091
 source "${SCRIPT_DIR}/logging.sh"
 # shellcheck source=./config.sh disable=SC1091

--- a/src/planner.sh
+++ b/src/planner.sh
@@ -24,6 +24,8 @@
 # Exit codes:
 #   Functions return non-zero on misuse; fatal errors logged by caller.
 
+# shellcheck source=./errors.sh disable=SC1091
+source "${BASH_SOURCE[0]%/planner.sh}/errors.sh"
 # shellcheck source=./logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/planner.sh}/logging.sh"
 # shellcheck source=./tools.sh disable=SC1091

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -41,6 +41,9 @@
 # Exit codes:
 #   0 for success, non-zero bubbled from downstream helpers.
 
+# shellcheck source=./errors.sh disable=SC1091
+source "${BASH_SOURCE[0]%/runtime.sh}/errors.sh"
+
 create_default_settings() {
 	# Arguments:
 	#   $1 - name of associative array to populate

--- a/src/tools.sh
+++ b/src/tools.sh
@@ -21,6 +21,8 @@
 #   Functions emit errors via log and return non-zero when misused.
 
 TOOLS_DIR="${BASH_SOURCE[0]%/tools.sh}/tools"
+# shellcheck source=./errors.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools.sh}/errors.sh"
 # shellcheck source=./logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools.sh}/logging.sh"
 # shellcheck source=./tools/registry.sh disable=SC1091

--- a/tests/test_errors.bats
+++ b/tests/test_errors.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+#
+# Focused tests for shared error envelope helpers.
+#
+# Usage: bats tests/test_errors.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "die surfaces exit codes from failed pipelines" {
+        run bash -lc '
+                set -o pipefail
+                source ./src/errors.sh
+                ERROR_CONTEXT="runtime"
+
+                { false | true; } || die "${ERROR_CONTEXT}" "pipeline" "upstream pipeline failure" 17
+        '
+
+        [ "$status" -eq 17 ]
+        [[ "$output" == *'"name":"runtime"'* ]]
+        [[ "$output" == *'"category":"pipeline"'* ]]
+        [[ "$output" == *'"message":"upstream pipeline failure"'* ]]
+}
+
+@test "die exits from subshells with serialized envelope" {
+        run bash -lc '
+                source ./src/errors.sh
+
+                (die "tool_runner" "fatal" "subshell explosion" 23)
+        '
+
+        [ "$status" -eq 23 ]
+        [[ "$output" == *'"name":"tool_runner"'* ]]
+        [[ "$output" == *'"category":"fatal"'* ]]
+        [[ "$output" == *'"message":"subshell explosion"'* ]]
+}


### PR DESCRIPTION
## Summary
- add a shared errors.sh module that emits JSON error envelopes and integrate it across the runtime, planner, and tools
- replace CLI/config error exits with envelope-based helpers and document the envelope structure
- add Bats coverage to prove pipeline and subshell failures propagate explicit exit codes

## Testing
- bats tests/test_errors.bats
- bats tests/test_all.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363c526ee88325b997577117118f63)