### PR TITLE
Harden osascript handling and tool configuration

### DIFF
--- a/src/tools.sh
+++ b/src/tools.sh
@@ -25,6 +25,35 @@ TOOLS_DIR="${BASH_SOURCE[0]%/tools.sh}/tools"
 source "${BASH_SOURCE[0]%/tools.sh}/logging.sh"
 # shellcheck source=./tools/registry.sh disable=SC1091
 source "${TOOLS_DIR}/registry.sh"
+# shellcheck disable=SC2034
+TOOL_NAME_ALLOWLIST=(
+        "terminal"
+        "file_search"
+        "clipboard_copy"
+        "clipboard_paste"
+        "notes_create"
+        "notes_append"
+        "notes_list"
+        "notes_search"
+        "notes_read"
+        "reminders_create"
+        "reminders_list"
+        "reminders_complete"
+        "calendar_create"
+        "calendar_list"
+        "calendar_search"
+        "mail_draft"
+        "mail_send"
+        "mail_search"
+        "mail_list_inbox"
+        "mail_list_unread"
+        "applescript"
+        "final_answer"
+)
+TOOL_WRITABLE_DIRECTORY_ALLOWLIST=(
+        "${HOME}/.okso"
+        "${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+)
 # shellcheck source=./tools/terminal.sh disable=SC1091
 source "${TOOLS_DIR}/terminal.sh"
 # shellcheck source=./tools/file_search.sh disable=SC1091
@@ -44,10 +73,63 @@ source "${TOOLS_DIR}/applescript.sh"
 # shellcheck source=./tools/final_answer.sh disable=SC1091
 source "${TOOLS_DIR}/final_answer.sh"
 
+tools_normalize_path() {
+        # Returns a normalized absolute path for allowlist checks.
+        # Arguments:
+        #   $1 - path to normalize (string)
+        if command -v realpath >/dev/null 2>&1; then
+                realpath -m "$1"
+                return
+        fi
+
+        python - "$1" <<'PY'
+import os, sys
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
+tools_writable_directory_allowed() {
+        # Validates that a directory is within the writable allowlist.
+        # Arguments:
+        #   $1 - target directory (string)
+        local candidate normalized allowed normalized_allowed
+        candidate="$1"
+        normalized=$(tools_normalize_path "${candidate}") || return 1
+
+        for allowed in "${TOOL_WRITABLE_DIRECTORY_ALLOWLIST[@]}"; do
+                normalized_allowed=$(tools_normalize_path "${allowed}") || continue
+                if [[ "${normalized}" == "${normalized_allowed}"* ]]; then
+                        return 0
+                fi
+        done
+
+        log "ERROR" "Writable directory not allowed" "${candidate}" || true
+        return 1
+}
+
+validate_writable_directories() {
+        # Confirms all configured writable directories are allowlisted.
+        local candidate
+        for candidate in "${NOTES_DIR:-${HOME}/.okso}" "${CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/okso}"; do
+                if [[ -z "${candidate}" ]]; then
+                        continue
+                fi
+                if ! tools_writable_directory_allowed "${candidate}"; then
+                        return 1
+                fi
+        done
+
+        return 0
+}
+
 initialize_tools() {
-	register_terminal
-	register_file_search
-	register_clipboard_copy
+        if ! validate_writable_directories; then
+                return 1
+        fi
+
+        register_terminal
+        register_file_search
+        register_clipboard_copy
 	register_clipboard_paste
 	register_notes_suite
 	register_reminders_suite

--- a/src/tools/applescript.sh
+++ b/src/tools/applescript.sh
@@ -38,8 +38,10 @@ tool_applescript() {
 		return 0
 	fi
 
-	log "INFO" "Executing AppleScript" "${query}"
-	osascript -e "${query}"
+        log "INFO" "Executing AppleScript" "${query}"
+        if ! osascript_run_evaluated "osascript" "${query}"; then
+                return 1
+        fi
 }
 
 register_applescript() {

--- a/src/tools/calendar/common.sh
+++ b/src/tools/calendar/common.sh
@@ -17,12 +17,15 @@
 #   - bash 5+
 #   - osascript (optional; required on macOS)
 #   - logging helpers from logging.sh
+#   - osascript helpers from osascript_helpers.sh
 #
 # Exit codes:
 #   Functions emit errors via log and return non-zero on misuse.
 
 # shellcheck source=../../logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/calendar/common.sh}/logging.sh"
+# shellcheck source=../osascript_helpers.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/calendar/common.sh}/tools/osascript_helpers.sh"
 
 calendar_name() {
 	# Prints the resolved Apple Calendar name.
@@ -73,12 +76,12 @@ calendar_extract_event_fields() {
 }
 
 calendar_run_script() {
-	# Runs an AppleScript provided on stdin, passing through all arguments.
-	# Arguments:
-	#   $@ - parameters forwarded to osascript
-	local bin
-	bin=${CALENDAR_OSASCRIPT_BIN:-osascript}
-	"${bin}" - "$@"
+        # Runs an AppleScript provided on stdin, passing through all arguments.
+        # Arguments:
+        #   $@ - parameters forwarded to osascript
+        local bin
+        bin=${CALENDAR_OSASCRIPT_BIN:-osascript}
+        osascript_run_piped "${bin}" "$@"
 }
 
 calendar_resolve_calendar_script() {

--- a/src/tools/mail/common.sh
+++ b/src/tools/mail/common.sh
@@ -16,12 +16,15 @@
 #   - bash 5+
 #   - osascript (optional; required on macOS)
 #   - logging helpers from logging.sh
+#   - osascript helpers from osascript_helpers.sh
 #
 # Exit codes:
 #   Functions emit errors via log and return non-zero on misuse.
 
 # shellcheck source=../../logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/mail/common.sh}/logging.sh"
+# shellcheck source=../osascript_helpers.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/mail/common.sh}/tools/osascript_helpers.sh"
 
 mail_require_platform() {
 	# Ensures Apple Mail tools only run on macOS with osascript available.
@@ -110,10 +113,10 @@ mail_split_recipients() {
 }
 
 mail_run_script() {
-	# Runs an AppleScript provided on stdin, passing through all arguments.
-	# Arguments:
-	#   $@ - parameters forwarded to osascript
-	local bin
-	bin=${MAIL_OSASCRIPT_BIN:-osascript}
-	"${bin}" - "$@"
+        # Runs an AppleScript provided on stdin, passing through all arguments.
+        # Arguments:
+        #   $@ - parameters forwarded to osascript
+        local bin
+        bin=${MAIL_OSASCRIPT_BIN:-osascript}
+        osascript_run_piped "${bin}" "$@"
 }

--- a/src/tools/notes/common.sh
+++ b/src/tools/notes/common.sh
@@ -72,8 +72,8 @@ notes_run_script() {
 	# Arguments:
 	#   $@ - parameters forwarded to osascript
 	local bin
-	bin=${NOTES_OSASCRIPT_BIN:-osascript}
-	"${bin}" - "$@"
+        bin=${NOTES_OSASCRIPT_BIN:-osascript}
+        osascript_run_piped "${bin}" "$@"
 }
 
 notes_resolve_folder_script() {

--- a/src/tools/osascript_helpers.sh
+++ b/src/tools/osascript_helpers.sh
@@ -9,6 +9,7 @@
 # Environment variables:
 #   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
 #   VERBOSITY (int): logging verbosity; see logging.sh.
+#   OSASCRIPT_ALLOWED_FLAGS (array): optional allowlist for flags forwarded to osascript.
 #
 # Dependencies:
 #   - bash 5+
@@ -49,5 +50,92 @@ assert_osascript_available() {
 		return 1
 	fi
 
-	return 0
+        return 0
+}
+
+osascript_disallow_argument() {
+        # Rejects suspect arguments that could alter osascript invocation.
+        # Arguments:
+        #   $1 - argument to validate (string)
+        # Returns:
+        #   0 when the argument is safe to pass, 1 otherwise.
+        local argument allowed_flag
+        argument="$1"
+
+        if [[ "${argument}" == *$'\n'* ]]; then
+                log "ERROR" "osascript arguments must not span multiple lines" "${argument}" || true
+                return 1
+        fi
+
+        if [[ "${argument}" == -* ]]; then
+                if [[ -z "${OSASCRIPT_ALLOWED_FLAGS[*]:-}" ]]; then
+                        log "ERROR" "osascript flags are disallowed" "${argument}" || true
+                        return 1
+                fi
+
+                for allowed_flag in "${OSASCRIPT_ALLOWED_FLAGS[@]}"; do
+                        if [[ "${argument}" == "${allowed_flag}" ]]; then
+                                return 0
+                        fi
+                done
+
+                log "ERROR" "osascript flag not allowed" "${argument}" || true
+                return 1
+        fi
+
+        if [[ "${argument}" == *'`'* || "${argument}" == *'$('* ]]; then
+                log "ERROR" "osascript arguments may not include shell substitution" "${argument}" || true
+                return 1
+        fi
+
+        return 0
+}
+
+sanitize_osascript_arguments() {
+        # Validates all provided arguments using osascript_disallow_argument.
+        # Arguments:
+        #   $@ - candidate arguments destined for osascript
+        local argument
+        for argument in "$@"; do
+                if ! osascript_disallow_argument "${argument}"; then
+                        return 1
+                fi
+        done
+        return 0
+}
+
+osascript_run_evaluated() {
+        # Invokes osascript with a single -e expression after sanitizing inputs.
+        # Arguments:
+        #   $1 - osascript binary (string; defaults to "osascript")
+        #   $2 - script expression (string; required)
+        #   $@ - additional arguments passed through after validation
+        local bin expression
+        bin="${1:-osascript}"
+        expression="$2"
+        shift 2
+
+        OSASCRIPT_ALLOWED_FLAGS=("-e")
+        if ! sanitize_osascript_arguments "-e" "${expression}" "$@"; then
+                return 1
+        fi
+
+        "${bin}" -e "${expression}" "$@"
+}
+
+osascript_run_piped() {
+        # Invokes osascript reading a script from stdin after sanitizing inputs.
+        # Arguments:
+        #   $1 - osascript binary (string; defaults to "osascript")
+        #   $@ - arguments forwarded to osascript after validation
+        local bin
+        bin="${1:-osascript}"
+        shift
+
+        OSASCRIPT_ALLOWED_FLAGS=("-")
+        if ! sanitize_osascript_arguments "-" "$@"; then
+                return 1
+        fi
+
+        "${bin}" - "$@"
 }

--- a/src/tools/registry.sh
+++ b/src/tools/registry.sh
@@ -52,6 +52,27 @@ register_tool() {
 
 	local name
 	name="$1"
+
+	if [[ ! "${name}" =~ ^[a-z0-9_]+$ ]]; then
+		log "ERROR" "tool names must be alphanumeric with underscores" "${name}" || true
+		return 1
+	fi
+
+	if [[ -n "${TOOL_NAME_ALLOWLIST[*]:-}" ]]; then
+		local allowed
+		allowed=false
+		for allowed in "${TOOL_NAME_ALLOWLIST[@]}"; do
+			if [[ "${name}" == "${allowed}" ]]; then
+				allowed=true
+				break
+			fi
+		done
+
+		if [[ "${allowed}" != true ]]; then
+			log "ERROR" "tool name not in allowlist" "${name}" || true
+			return 1
+		fi
+	fi
 	# shellcheck disable=SC2034
 	TOOLS+=("${name}")
 	# shellcheck disable=SC2034

--- a/src/tools/reminders/common.sh
+++ b/src/tools/reminders/common.sh
@@ -16,12 +16,15 @@
 #   - bash 5+
 #   - osascript (optional; required on macOS)
 #   - logging helpers from logging.sh
+#   - osascript helpers from osascript_helpers.sh
 #
 # Exit codes:
 #   Functions emit errors via log and return non-zero on misuse.
 
 # shellcheck source=../../logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/reminders/common.sh}/logging.sh"
+# shellcheck source=../osascript_helpers.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/reminders/common.sh}/tools/osascript_helpers.sh"
 
 reminders_list_name() {
 	# Prints the resolved Apple Reminders list name.
@@ -68,12 +71,12 @@ reminders_extract_title_and_body() {
 }
 
 reminders_run_script() {
-	# Runs an AppleScript provided on stdin, passing through all arguments.
-	# Arguments:
-	#   $@ - parameters forwarded to osascript
-	local bin
-	bin=${REMINDERS_OSASCRIPT_BIN:-osascript}
-	"${bin}" - "$@"
+        # Runs an AppleScript provided on stdin, passing through all arguments.
+        # Arguments:
+        #   $@ - parameters forwarded to osascript
+        local bin
+        bin=${REMINDERS_OSASCRIPT_BIN:-osascript}
+        osascript_run_piped "${bin}" "$@"
 }
 
 reminders_resolve_list_script() {

--- a/tests/test_security.bats
+++ b/tests/test_security.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+#
+# Security regression tests for sanitization and allowlists.
+#
+# Usage: bats tests/test_security.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "osascript helpers reject shell substitution attempts" {
+        run bash -lc '
+                VERBOSITY=1
+                source ./src/tools/osascript_helpers.sh
+                malicious=$'"'"'display dialog `whoami`'"'"'
+                sanitize_osascript_arguments "${malicious}"
+        '
+
+        [ "$status" -eq 1 ]
+        [ "$(echo "${output}" | jq -r '.message')" = "osascript arguments may not include shell substitution" ]
+}
+
+@test "initialize_tools fails when writable directory leaves allowlist" {
+        run bash -lc '
+                VERBOSITY=1
+                NOTES_DIR="/tmp/okso/../../etc"
+                source ./src/tools.sh
+                initialize_tools
+        '
+
+        [ "$status" -eq 1 ]
+        [ "$(echo "${output}" | jq -r '.message')" = "Writable directory not allowed" ]
+}


### PR DESCRIPTION
## Summary
- add osascript argument sanitization helpers and wire AppleScript tools through them
- enforce allowlists for tool names and writable directories during tool initialization
- add bats coverage for injection and directory traversal attempts

## Testing
- bats tests/test_security.bats
- bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363c79c07483259c538bf7c70f8d3e)