### PR TITLE
Add coverage reporting and targeted bash tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,15 +15,18 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt bats
+          sudo apt-get install -y shellcheck shfmt bats bc
+          gem install bashcov simplecov-cobertura
 
       - name: Check formatting
         run: |
           shfmt -d \
-            src/main.sh \
-            scripts/install.sh \
+            src/*.sh \
+            src/tools/*.sh \
+            src/tools/notes/*.sh \
+            scripts/*.sh \
+            tests/*.bats \
             tests/test_all.sh \
-            tests/test_main.bats \
             tests/test_install.bats
 
       - name: Run shellcheck
@@ -33,8 +36,19 @@ jobs:
             scripts/install.sh \
             tests/test_all.sh \
             tests/test_main.bats \
-            tests/test_install.bats
+            tests/test_install.bats \
+            tests/test_config.bats \
+            tests/test_planner.bats \
+            tests/test_tools_registry.bats \
+            scripts/coverage.sh
 
-      - name: Run Bats suite
+      - name: Run Bats suite with coverage
         run: |
-          bats tests/test_main.bats tests/test_all.sh tests/test_install.bats
+          ./scripts/coverage.sh
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bash-coverage
+          path: coverage/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 # If your scripts generate specific output files, add them here.
 # For example:
 # my_script_output.txt
+coverage/
+.bats-tmp/
 
 # Sensitive data or configuration files that should not be committed
 # If your scripts use local configuration files or store sensitive data,

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,22 @@
+require 'simplecov'
+require 'simplecov_json_formatter'
+require 'simplecov-cobertura'
+
+SimpleCov.coverage_dir ENV.fetch('COVERAGE_DIR', 'coverage')
+SimpleCov.enable_coverage :branch
+
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::JSONFormatter,
+    SimpleCov::Formatter::CoberturaFormatter
+  ]
+)
+
+SimpleCov.start do
+  root ENV.fetch('SIMPLECOV_ROOT', Dir.pwd)
+  add_filter %r{^/tmp/}
+  add_filter %r{^/usr/}
+  add_filter %r{^/var/}
+  track_files 'src/**/*.sh'
+end

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,16 @@ The Bats suite covers CLI help/version output, confirmation prompts, determinist
 
 Set `TESTING_PASSTHROUGH=true` when running the suite to disable llama.cpp invocation and surface test-only code paths without muting runtime errors that depend on llama availability.
 
+### Coverage collection
+
+Generate HTML, JSON, and Cobertura coverage reports with bashcov:
+
+```bash
+./scripts/coverage.sh
+```
+
+Artifacts are written to `coverage/` (HTML + XML + JSON). Set `COVERAGE_THRESHOLD=75` to warn when totals dip below 75%, and enable `COVERAGE_STRICT=true` to fail the run when the threshold is not met. The script defaults to `TESTING_PASSTHROUGH=false` while pointing `LLAMA_BIN` at the mocked binary used in tests.
+
 ## Planning workflow
 
 The planner now drives execution through an explicit, tool-aware outline:

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Run the Bats suite with bashcov to collect coverage artifacts.
+#
+# Usage:
+#   ./scripts/coverage.sh
+#
+# Environment variables:
+#   COVERAGE_DIR (string): output directory for coverage reports. Default: coverage
+#   COVERAGE_THRESHOLD (float): warn when total coverage is below this percent. Default: 0 (no check)
+#   COVERAGE_STRICT (bool): fail when coverage is below the threshold when set to "true".
+#   TESTING_PASSTHROUGH (bool): disable llama.cpp calls during coverage runs. Default: false
+#
+# Dependencies:
+#   - bash 5+
+#   - bats
+#   - bashcov (Ruby gem)
+#   - jq
+#   - bc
+#
+# Exit codes:
+#   0 on success, 1 when coverage enforcement fails or bats exits non-zero.
+
+set -eo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+COVERAGE_DIR="${COVERAGE_DIR:-${ROOT_DIR}/coverage}"
+COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-0}"
+COVERAGE_STRICT="${COVERAGE_STRICT:-false}"
+COVERAGE_TARGETS="${COVERAGE_TARGETS:-tests/test_main.bats tests/test_all.sh tests/test_install.bats tests/test_config.bats tests/test_planner.bats tests/test_tools_registry.bats}"
+
+export COVERAGE_DIR
+export SIMPLECOV_ROOT="${ROOT_DIR}"
+export TESTING_PASSTHROUGH="${TESTING_PASSTHROUGH:-false}"
+export LLAMA_BIN="${LLAMA_BIN:-${ROOT_DIR}/tests/fixtures/mock_llama_relevance.sh}"
+export BATS_TMPDIR="${ROOT_DIR}/.bats-tmp"
+
+rm -rf "${COVERAGE_DIR}" "${BATS_TMPDIR}"
+mkdir -p "${COVERAGE_DIR}" "${BATS_TMPDIR}"
+
+read -r -a coverage_files <<<"${COVERAGE_TARGETS}"
+bashcov --root "${ROOT_DIR}" --command-name "bats" -- bats "${coverage_files[@]}"
+
+coverage_summary=$(
+	python - <<PY
+import json
+from pathlib import Path
+
+result_path = Path("${COVERAGE_DIR}") / "coverage.json"
+fallback_path = Path("${COVERAGE_DIR}") / ".resultset.json"
+coverage_percent = 0.0
+
+if result_path.exists():
+    data = json.loads(result_path.read_text())
+    coverage_data = data.get("coverage", {})
+    covered = 0
+    total = 0
+    for file_cov in coverage_data.values():
+        for hit in file_cov.get("lines", []):
+            if hit is None:
+                continue
+            total += 1
+            if hit > 0:
+                covered += 1
+    if total:
+        coverage_percent = (covered / total) * 100
+elif fallback_path.exists():
+    raw = json.loads(fallback_path.read_text())
+    first_result = next(iter(raw.values()))
+    covered = 0
+    total = 0
+    for line_hits in first_result.get("coverage", {}).values():
+        for hit in line_hits:
+            if hit is None:
+                continue
+            total += 1
+            if hit > 0:
+                covered += 1
+    if total:
+        coverage_percent = (covered / total) * 100
+
+print(f"{coverage_percent:.2f}")
+PY
+)
+
+echo "Total coverage: ${coverage_summary}%"
+
+threshold_numeric=$(printf '%.2f' "${COVERAGE_THRESHOLD}")
+if (($(echo "${threshold_numeric} > 0" | bc -l))); then
+	below_threshold=$(echo "${coverage_summary} < ${threshold_numeric}" | bc -l)
+	if ((below_threshold)); then
+		>&2 echo "Coverage ${coverage_summary}% is below threshold ${threshold_numeric}%"
+		if [[ "${COVERAGE_STRICT}" == true ]]; then
+			exit 1
+		fi
+	fi
+fi

--- a/tests/test_planner.bats
+++ b/tests/test_planner.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+#
+# Tests for planning and ReAct helpers.
+#
+# Usage:
+#   bats tests/test_planner.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert helper outcomes.
+
+@test "extract_tools_from_plan dedupes and enforces final_answer" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; TOOLS=(alpha beta final_answer); plan=$"1. Use Alpha\n2. Use alpha\n3. Then beta"; mapfile -t tools < <(extract_tools_from_plan "${plan}"); [[ ${#tools[@]} -eq 3 ]]; [[ "${tools[0]}" == "alpha" ]]; [[ "${tools[1]}" == "beta" ]]; [[ "${tools[2]}" == "final_answer" ]]'
+	[ "$status" -eq 0 ]
+}
+
+@test "build_plan_entries_from_tools omits final_answer" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; entries=$(build_plan_entries_from_tools $'"'"'alpha\nbeta\nfinal_answer'"'"' "Tell me"); first=$(printf "%s" "${entries}" | sed -n "1p"); second=$(printf "%s" "${entries}" | sed -n "2p"); [[ "${first}" == "alpha|Tell me|0" ]]; [[ "${second}" == "beta|Tell me|0" ]]; [[ "${entries}" != *"final_answer"* ]]'
+	[ "$status" -eq 0 ]
+}
+
+@test "should_prompt_for_tool respects execution toggles" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; PLAN_ONLY=true DRY_RUN=false APPROVE_ALL=false FORCE_CONFIRM=false should_prompt_for_tool; first=$?; PLAN_ONLY=false DRY_RUN=false APPROVE_ALL=true FORCE_CONFIRM=false should_prompt_for_tool; second=$?; PLAN_ONLY=false DRY_RUN=false APPROVE_ALL=false FORCE_CONFIRM=true should_prompt_for_tool; third=$?; [[ ${first} -eq 1 ]]; [[ ${second} -eq 1 ]]; [[ ${third} -eq 0 ]]'
+	[ "$status" -eq 0 ]
+}
+
+@test "initialize_react_state seeds defaults" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; declare -A state; initialize_react_state state "answer me" $"alpha" "alpha|query|0" "1. alpha"; [[ "${state[user_query]}" == "answer me" ]]; [[ "${state[allowed_tools]}" == "alpha" ]]; [[ "${state[plan_index]}" == "0" ]]; [[ "${state[max_steps]}" -eq ${MAX_STEPS:-6} ]]'
+	[ "$status" -eq 0 ]
+}
+
+@test "validate_tool_permission records disallowed tools" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; declare -A state; initialize_react_state state "answer me" $"alpha" "" "1. alpha"; validate_tool_permission state beta; [[ "$?" -eq 1 ]]; [[ "${state[history]}" == *"not permitted"* ]]'
+	[ "$status" -eq 0 ]
+}

--- a/tests/test_tools_registry.bats
+++ b/tests/test_tools_registry.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Tests for the shared tool registry utilities.
+#
+# Usage:
+#   bats tests/test_tools_registry.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert registry behavior.
+
+@test "register_tool enforces required arguments" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe"'
+	[ "$status" -eq 1 ]
+}
+
+@test "init_tool_registry resets shared arrays" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe" handler_alpha; register_tool beta "describe" "cmd" "safe" handler_beta; init_tool_registry; [[ ${#TOOLS[@]} -eq 0 ]]; [[ -z "${TOOL_HANDLER[alpha]:-}" ]]'
+	[ "$status" -eq 0 ]
+}
+
+@test "register_tool captures handler and descriptors" {
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; init_tool_registry; register_tool alpha "describe" "cmd" "safe" handler_alpha; [[ "${TOOL_DESCRIPTION[alpha]}" == "describe" ]]; [[ "${TOOL_COMMAND[alpha]}" == "cmd" ]]; [[ "${TOOL_SAFETY[alpha]}" == "safe" ]]; [[ "${TOOL_HANDLER[alpha]}" == "handler_alpha" ]]'
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- integrate bash coverage generation via bashcov with HTML/JSON/Cobertura outputs
- add targeted Bats tests covering planner, config, and registry helpers
- upload coverage artifacts in CI and ignore local coverage build outputs

## Testing
- ./scripts/coverage.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363c6a0c148325a34e6c34a5c22955)