### PR TITLE
Normalize shell formatting and osascript handling

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,8 +34,8 @@
 #   - core macOS utilities (cp, ln, mkdir, rm)
 
 if [ -z "${BASH_VERSION:-}" ]; then
-        # Re-exec with bash to ensure array and parameter expansion support.
-        exec /usr/bin/env bash "$0" "$@"
+	# Re-exec with bash to ensure array and parameter expansion support.
+	exec /usr/bin/env bash "$0" "$@"
 fi
 
 set -euo pipefail
@@ -52,9 +52,9 @@ DRY_RUN="false"
 
 SCRIPT_SOURCE="${BASH_SOURCE[0]-${0-}}"
 if [ -z "${SCRIPT_SOURCE}" ] || [ "${SCRIPT_SOURCE}" = "-" ] || [ ! -f "${SCRIPT_SOURCE}" ]; then
-        SCRIPT_DIR="${PWD}"
+	SCRIPT_DIR="${PWD}"
 else
-        SCRIPT_DIR=$(cd -- "$(dirname -- "${SCRIPT_SOURCE}")" && pwd)
+	SCRIPT_DIR=$(cd -- "$(dirname -- "${SCRIPT_SOURCE}")" && pwd)
 fi
 PROJECT_ROOT="${SCRIPT_DIR%/scripts}"
 SRC_DIR="${PROJECT_ROOT}/src"
@@ -62,279 +62,279 @@ SOURCE_PAYLOAD_DIR="${SRC_DIR}"
 TEMP_ARCHIVE_DIR=""
 
 BREW_PACKAGES=(
-        "llama.cpp"
-        "tesseract"
-        "pandoc"
-        "poppler"
-        "yq"
-        "bash"
-        "coreutils"
-        "jq"
-        "gum"
+	"llama.cpp"
+	"tesseract"
+	"pandoc"
+	"poppler"
+	"yq"
+	"bash"
+	"coreutils"
+	"jq"
+	"gum"
 )
 
 log() {
-        # $1: level, $2: message
-        printf '[%s] %s\n' "$1" "$2"
+	# $1: level, $2: message
+	printf '[%s] %s\n' "$1" "$2"
 }
 
 log_dry_run() {
-        # $1: description of the skipped action
-        if [ "${DRY_RUN}" = "true" ]; then
-                printf '[DRYRUN] %s\n' "$1"
-        fi
+	# $1: description of the skipped action
+	if [ "${DRY_RUN}" = "true" ]; then
+		printf '[DRYRUN] %s\n' "$1"
+	fi
 }
 
 detect_macos() {
-        local uname_bin
-        uname_bin=$(command -v uname || true)
+	local uname_bin
+	uname_bin=$(command -v uname || true)
 
-        if [ -n "${uname_bin}" ] && [ "$(${uname_bin} -s)" = "Darwin" ]; then
-                printf 'true\n'
-                return 0
-        fi
+	if [ -n "${uname_bin}" ] && [ "$(${uname_bin} -s)" = "Darwin" ]; then
+		printf 'true\n'
+		return 0
+	fi
 
-        printf 'false\n'
+	printf 'false\n'
 }
 
 IS_MACOS=$(detect_macos)
 
 read_lines_into_array() {
-        # $1: destination array name
-        local target line
-        target="$1"
+	# $1: destination array name
+	local target line
+	target="$1"
 
-        if command -v mapfile >/dev/null 2>&1; then
-                mapfile -t "${target}"
-                return
-        fi
+	if command -v mapfile >/dev/null 2>&1; then
+		mapfile -t "${target}"
+		return
+	fi
 
-        eval "${target}=()"
-        while IFS= read -r line; do
-                eval "${target}+=(\"${line}\")"
-        done
+	eval "${target}=()"
+	while IFS= read -r line; do
+		eval "${target}+=(\"${line}\")"
+	done
 }
 
 cleanup_temp_dir() {
-        if [ -n "${TEMP_ARCHIVE_DIR}" ] && [ -d "${TEMP_ARCHIVE_DIR}" ]; then
-                rm -rf "${TEMP_ARCHIVE_DIR}"
-        fi
+	if [ -n "${TEMP_ARCHIVE_DIR}" ] && [ -d "${TEMP_ARCHIVE_DIR}" ]; then
+		rm -rf "${TEMP_ARCHIVE_DIR}"
+	fi
 }
 
 resolve_project_archive_url() {
-        local archive_url
+	local archive_url
 
-        if [ -n "${DEFAULT_PROJECT_ARCHIVE_URL}" ]; then
-                printf '%s\n' "${DEFAULT_PROJECT_ARCHIVE_URL}"
-                return 0
-        fi
+	if [ -n "${DEFAULT_PROJECT_ARCHIVE_URL}" ]; then
+		printf '%s\n' "${DEFAULT_PROJECT_ARCHIVE_URL}"
+		return 0
+	fi
 
-        log "ERROR" "Source directory missing and no archive URL configured."
-        log "ERROR" "Set DO_PROJECT_ARCHIVE_URL to a tar.gz containing the project (for GitHub Pages: \"${DO_INSTALLER_BASE_URL:-https://example.github.io/okso}/okso.tar.gz\")."
-        exit 2
+	log "ERROR" "Source directory missing and no archive URL configured."
+	log "ERROR" "Set DO_PROJECT_ARCHIVE_URL to a tar.gz containing the project (for GitHub Pages: \"${DO_INSTALLER_BASE_URL:-https://example.github.io/okso}/okso.tar.gz\")."
+	exit 2
 }
 
 has_network() {
-        if [ "${DO_INSTALLER_ASSUME_OFFLINE:-false}" = "true" ]; then
-                return 1
-        fi
-        curl --head --silent --connect-timeout 3 --max-time 5 https://brew.sh >/dev/null 2>&1
+	if [ "${DO_INSTALLER_ASSUME_OFFLINE:-false}" = "true" ]; then
+		return 1
+	fi
+	curl --head --silent --connect-timeout 3 --max-time 5 https://brew.sh >/dev/null 2>&1
 }
 
 fetch_sidecar_file() {
-        # $1: archive URL, $2: extension (e.g., .sha256), $3: destination path
-        local archive_url ext dest_path sidecar_url
-        archive_url="$1"
-        ext="$2"
-        dest_path="$3"
+	# $1: archive URL, $2: extension (e.g., .sha256), $3: destination path
+	local archive_url ext dest_path sidecar_url
+	archive_url="$1"
+	ext="$2"
+	dest_path="$3"
 
-        if [[ "${archive_url}" == file://* ]]; then
-                local file_path
-                file_path="${archive_url#file://}"
-                sidecar_url="${file_path}${ext}"
-                if [ -f "${sidecar_url}" ]; then
-                        cp "${sidecar_url}" "${dest_path}"
-                        return 0
-                fi
-                return 1
-        fi
+	if [[ "${archive_url}" == file://* ]]; then
+		local file_path
+		file_path="${archive_url#file://}"
+		sidecar_url="${file_path}${ext}"
+		if [ -f "${sidecar_url}" ]; then
+			cp "${sidecar_url}" "${dest_path}"
+			return 0
+		fi
+		return 1
+	fi
 
-        if ! has_network; then
-                return 1
-        fi
+	if ! has_network; then
+		return 1
+	fi
 
-        sidecar_url="${archive_url}${ext}"
-        if curl -fsSL "${sidecar_url}" -o "${dest_path}"; then
-                return 0
-        fi
+	sidecar_url="${archive_url}${ext}"
+	if curl -fsSL "${sidecar_url}" -o "${dest_path}"; then
+		return 0
+	fi
 
-        return 1
+	return 1
 }
 
 compute_sha256() {
-        # $1: file path
-        local target
-        target="$1"
-        if command -v sha256sum >/dev/null 2>&1; then
-                sha256sum "${target}" | awk '{print $1}'
-        elif command -v shasum >/dev/null 2>&1; then
-                shasum -a 256 "${target}" | awk '{print $1}'
-        else
-                log "ERROR" "No SHA-256 utility found for checksum verification"
-                return 1
-        fi
+	# $1: file path
+	local target
+	target="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "${target}" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "${target}" | awk '{print $1}'
+	else
+		log "ERROR" "No SHA-256 utility found for checksum verification"
+		return 1
+	fi
 }
 
 verify_download_integrity() {
-        # $1: downloaded archive path, $2: original archive URL
-        local archive_path archive_url checksum_path signature_path expected_checksum actual_checksum
-        archive_path="$1"
-        archive_url="$2"
+	# $1: downloaded archive path, $2: original archive URL
+	local archive_path archive_url checksum_path signature_path expected_checksum actual_checksum
+	archive_path="$1"
+	archive_url="$2"
 
-        checksum_path="$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.sha256")"
-        signature_path="$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.asc")"
+	checksum_path="$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.sha256")"
+	signature_path="$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.asc")"
 
-        local checksum_available signature_available
-        checksum_available=false
-        signature_available=false
+	local checksum_available signature_available
+	checksum_available=false
+	signature_available=false
 
-        if fetch_sidecar_file "${archive_url}" ".sha256" "${checksum_path}"; then
-                checksum_available=true
-        else
-                rm -f "${checksum_path}"
-        fi
+	if fetch_sidecar_file "${archive_url}" ".sha256" "${checksum_path}"; then
+		checksum_available=true
+	else
+		rm -f "${checksum_path}"
+	fi
 
-        if fetch_sidecar_file "${archive_url}" ".asc" "${signature_path}"; then
-                if [ "${DO_INSTALLER_VERIFY_SIGNATURES:-false}" = "true" ]; then
-                        signature_available=true
-                else
-                        log "INFO" "Signature file detected but verification is disabled (set DO_INSTALLER_VERIFY_SIGNATURES=true to enforce)."
-                        signature_available=false
-                        rm -f "${signature_path}"
-                fi
-        else
-                rm -f "${signature_path}"
-        fi
+	if fetch_sidecar_file "${archive_url}" ".asc" "${signature_path}"; then
+		if [ "${DO_INSTALLER_VERIFY_SIGNATURES:-false}" = "true" ]; then
+			signature_available=true
+		else
+			log "INFO" "Signature file detected but verification is disabled (set DO_INSTALLER_VERIFY_SIGNATURES=true to enforce)."
+			signature_available=false
+			rm -f "${signature_path}"
+		fi
+	else
+		rm -f "${signature_path}"
+	fi
 
-        if [ "${checksum_available}" = true ]; then
-                expected_checksum="$(head -n 1 "${checksum_path}" | awk '{print $1}')"
-                if [[ ! ${expected_checksum} =~ ^[A-Fa-f0-9]{64}$ ]]; then
-                        log "ERROR" "Checksum file invalid or malformed"
-                        exit 2
-                fi
-        fi
+	if [ "${checksum_available}" = true ]; then
+		expected_checksum="$(head -n 1 "${checksum_path}" | awk '{print $1}')"
+		if [[ ! ${expected_checksum} =~ ^[A-Fa-f0-9]{64}$ ]]; then
+			log "ERROR" "Checksum file invalid or malformed"
+			exit 2
+		fi
+	fi
 
-        if [ "${checksum_available}" = true ]; then
-                actual_checksum="$(compute_sha256 "${archive_path}")"
-                if [ -z "${expected_checksum}" ] || [ -z "${actual_checksum}" ] || [ "${expected_checksum}" != "${actual_checksum}" ]; then
-                        log "ERROR" "Archive checksum verification failed"
-                        exit 2
-                fi
-                log "INFO" "Checksum verification passed"
-        else
-                log "INFO" "No checksum found; proceeding without SHA-256 verification"
-        fi
+	if [ "${checksum_available}" = true ]; then
+		actual_checksum="$(compute_sha256 "${archive_path}")"
+		if [ -z "${expected_checksum}" ] || [ -z "${actual_checksum}" ] || [ "${expected_checksum}" != "${actual_checksum}" ]; then
+			log "ERROR" "Archive checksum verification failed"
+			exit 2
+		fi
+		log "INFO" "Checksum verification passed"
+	else
+		log "INFO" "No checksum found; proceeding without SHA-256 verification"
+	fi
 
-        if [ "${signature_available}" = true ]; then
-                if ! grep -q "BEGIN PGP SIGNATURE" "${signature_path}" 2>/dev/null; then
-                        log "WARN" "Signature file invalid; skipping verification"
-                        signature_available=false
-                fi
-        fi
+	if [ "${signature_available}" = true ]; then
+		if ! grep -q "BEGIN PGP SIGNATURE" "${signature_path}" 2>/dev/null; then
+			log "WARN" "Signature file invalid; skipping verification"
+			signature_available=false
+		fi
+	fi
 
-        if [ "${signature_available}" = true ]; then
-                if command -v gpg >/dev/null 2>&1; then
-                        if ! gpg --verify "${signature_path}" "${archive_path}" >/dev/null 2>&1; then
-                                log "ERROR" "Signature verification failed"
-                                exit 2
-                        fi
-                        log "INFO" "Signature verification passed"
-                else
-                        log "WARN" "Signature provided but gpg is unavailable; skipping verification"
-                fi
-        fi
+	if [ "${signature_available}" = true ]; then
+		if command -v gpg >/dev/null 2>&1; then
+			if ! gpg --verify "${signature_path}" "${archive_path}" >/dev/null 2>&1; then
+				log "ERROR" "Signature verification failed"
+				exit 2
+			fi
+			log "INFO" "Signature verification passed"
+		else
+			log "WARN" "Signature provided but gpg is unavailable; skipping verification"
+		fi
+	fi
 
-        rm -f "${checksum_path}" "${signature_path}"
+	rm -f "${checksum_path}" "${signature_path}"
 }
 
 prepare_source_payload() {
-        if [ -d "${SRC_DIR}" ] && [ -f "${SRC_DIR}/main.sh" ]; then
-                SOURCE_PAYLOAD_DIR="${SRC_DIR}"
-                return 0
-        fi
+	if [ -d "${SRC_DIR}" ] && [ -f "${SRC_DIR}/main.sh" ]; then
+		SOURCE_PAYLOAD_DIR="${SRC_DIR}"
+		return 0
+	fi
 
-        local archive_url archive_path
-        archive_url=$(resolve_project_archive_url)
-        archive_path=$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.tar.gz")
-        TEMP_ARCHIVE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/okso-src-XXXXXX")
-        trap cleanup_temp_dir EXIT
+	local archive_url archive_path
+	archive_url=$(resolve_project_archive_url)
+	archive_path=$(mktemp "${TMPDIR:-/tmp}/okso-archive-XXXXXX.tar.gz")
+	TEMP_ARCHIVE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/okso-src-XXXXXX")
+	trap cleanup_temp_dir EXIT
 
-        download_project_archive "${archive_url}" "${archive_path}"
-        verify_download_integrity "${archive_path}" "${archive_url}"
-        if ! tar -xzf "${archive_path}" -C "${TEMP_ARCHIVE_DIR}"; then
-                log "ERROR" "Failed to extract project archive from ${archive_url}"
-                exit 2
-        fi
+	download_project_archive "${archive_url}" "${archive_path}"
+	verify_download_integrity "${archive_path}" "${archive_url}"
+	if ! tar -xzf "${archive_path}" -C "${TEMP_ARCHIVE_DIR}"; then
+		log "ERROR" "Failed to extract project archive from ${archive_url}"
+		exit 2
+	fi
 
-        SOURCE_PAYLOAD_DIR=$(derive_source_root "${TEMP_ARCHIVE_DIR}")
+	SOURCE_PAYLOAD_DIR=$(derive_source_root "${TEMP_ARCHIVE_DIR}")
 }
 
 verify_checksum_file_present() {
-        # Backwards compatibility shim: this function is retained to avoid breaking
-        # callers that expect checksum utilities to be present.
-        :
+	# Backwards compatibility shim: this function is retained to avoid breaking
+	# callers that expect checksum utilities to be present.
+	:
 }
 
 download_project_archive() {
-        # $1: archive URL, $2: destination path
-        local archive_url dest_path
-        archive_url="$1"
-        dest_path="$2"
+	# $1: archive URL, $2: destination path
+	local archive_url dest_path
+	archive_url="$1"
+	dest_path="$2"
 
-        if [[ "${archive_url}" == file://* ]]; then
-                local file_path
-                file_path="${archive_url#file://}"
-                if [ ! -f "${file_path}" ]; then
-                        log "ERROR" "Archive not found at ${file_path}"
-                        exit 2
-                fi
-                cp "${file_path}" "${dest_path}"
-                return 0
-        fi
+	if [[ "${archive_url}" == file://* ]]; then
+		local file_path
+		file_path="${archive_url#file://}"
+		if [ ! -f "${file_path}" ]; then
+			log "ERROR" "Archive not found at ${file_path}"
+			exit 2
+		fi
+		cp "${file_path}" "${dest_path}"
+		return 0
+	fi
 
-        if ! has_network; then
-                log "ERROR" "Network connectivity required to fetch ${archive_url}"
-                exit 4
-        fi
+	if ! has_network; then
+		log "ERROR" "Network connectivity required to fetch ${archive_url}"
+		exit 4
+	fi
 
-        if ! curl -fsSL "${archive_url}" -o "${dest_path}"; then
-                log "ERROR" "Failed to download project archive from ${archive_url}"
-                exit 2
-        fi
+	if ! curl -fsSL "${archive_url}" -o "${dest_path}"; then
+		log "ERROR" "Failed to download project archive from ${archive_url}"
+		exit 2
+	fi
 }
 
 derive_source_root() {
-        # $1: extraction root
-        local extraction_root archive_root
-        extraction_root="$1"
+	# $1: extraction root
+	local extraction_root archive_root
+	extraction_root="$1"
 
-        if [ -d "${extraction_root}/src" ]; then
-                printf '%s\n' "${extraction_root}/src"
-                return 0
-        fi
+	if [ -d "${extraction_root}/src" ]; then
+		printf '%s\n' "${extraction_root}/src"
+		return 0
+	fi
 
-        archive_root=$(find "${extraction_root}" -maxdepth 1 -mindepth 1 -type d | head -n 1)
-        if [ -n "${archive_root}" ] && [ -d "${archive_root}/src" ]; then
-                printf '%s\n' "${archive_root}/src"
-                return 0
-        fi
+	archive_root=$(find "${extraction_root}" -maxdepth 1 -mindepth 1 -type d | head -n 1)
+	if [ -n "${archive_root}" ] && [ -d "${archive_root}/src" ]; then
+		printf '%s\n' "${archive_root}/src"
+		return 0
+	fi
 
-        log "ERROR" "Extracted archive does not contain a src directory"
-        exit 2
+	log "ERROR" "Extracted archive does not contain a src directory"
+	exit 2
 }
 
 usage() {
-        cat <<'USAGE'
+	cat <<'USAGE'
 Usage: scripts/install.sh [options]
 
 Options:
@@ -356,290 +356,290 @@ USAGE
 }
 
 require_macos() {
-        if [ "${IS_MACOS}" != "true" ]; then
-                log "ERROR" "This installer only supports macOS."
-                exit 3
-        fi
+	if [ "${IS_MACOS}" != "true" ]; then
+		log "ERROR" "This installer only supports macOS."
+		exit 3
+	fi
 }
 
 ensure_homebrew() {
-        if command -v brew >/dev/null 2>&1; then
-                log "INFO" "Homebrew detected."
-                return 0
-        fi
+	if command -v brew >/dev/null 2>&1; then
+		log "INFO" "Homebrew detected."
+		return 0
+	fi
 
-        if ! has_network; then
-                log "ERROR" "Homebrew is missing and network connectivity is unavailable."
-                exit 4
-        fi
+	if ! has_network; then
+		log "ERROR" "Homebrew is missing and network connectivity is unavailable."
+		exit 4
+	fi
 
-        log "INFO" "Installing Homebrew..."
-        local tmp_script
-        tmp_script="$(mktemp)"
-        trap 'rm -f -- "${tmp_script}"' EXIT
-        if ! curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "${tmp_script}"; then
-                log "ERROR" "Failed to download Homebrew installer."
-                exit 2
-        fi
-        NONINTERACTIVE=1 /bin/bash "${tmp_script}" >/dev/null
-        log "INFO" "Homebrew installation complete."
+	log "INFO" "Installing Homebrew..."
+	local tmp_script
+	tmp_script="$(mktemp)"
+	trap 'rm -f -- "${tmp_script}"' EXIT
+	if ! curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "${tmp_script}"; then
+		log "ERROR" "Failed to download Homebrew installer."
+		exit 2
+	fi
+	NONINTERACTIVE=1 /bin/bash "${tmp_script}" >/dev/null
+	log "INFO" "Homebrew installation complete."
 }
 
 install_brew_packages() {
-        local missing=()
-        for pkg in "${BREW_PACKAGES[@]}"; do
-                if ! brew list --formula --versions "${pkg}" >/dev/null 2>&1; then
-                        missing+=("${pkg}")
-                fi
-        done
+	local missing=()
+	for pkg in "${BREW_PACKAGES[@]}"; do
+		if ! brew list --formula --versions "${pkg}" >/dev/null 2>&1; then
+			missing+=("${pkg}")
+		fi
+	done
 
-        if [ ${#missing[@]} -eq 0 ]; then
-                log "INFO" "Required Homebrew packages already installed."
-                return 0
-        fi
+	if [ ${#missing[@]} -eq 0 ]; then
+		log "INFO" "Required Homebrew packages already installed."
+		return 0
+	fi
 
-        if ! has_network; then
-                log "ERROR" "Network connectivity is required to install: ${missing[*]}"
-                exit 4
-        fi
+	if ! has_network; then
+		log "ERROR" "Network connectivity is required to install: ${missing[*]}"
+		exit 4
+	fi
 
-        log "INFO" "Installing required packages: ${missing[*]}"
-        if ! HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install "${missing[@]}"; then
-                log "ERROR" "Failed to install Homebrew dependencies."
-                exit 2
-        fi
+	log "INFO" "Installing required packages: ${missing[*]}"
+	if ! HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install "${missing[@]}"; then
+		log "ERROR" "Failed to install Homebrew dependencies."
+		exit 2
+	fi
 }
 
 ensure_prefix_writable() {
-        # $1: path to check
-        local path="$1"
-        if [ -w "${path}" ]; then
-                return 0
-        fi
-        if [ ! -d "${path}" ]; then
-                mkdir -p "${path}" 2>/dev/null || true
-        fi
-        if [ -w "${path}" ]; then
-                return 0
-        fi
-        if command -v sudo >/dev/null 2>&1; then
-                return 0
-        fi
-        log "ERROR" "Insufficient permissions to modify ${path} and sudo not available."
-        exit 5
+	# $1: path to check
+	local path="$1"
+	if [ -w "${path}" ]; then
+		return 0
+	fi
+	if [ ! -d "${path}" ]; then
+		mkdir -p "${path}" 2>/dev/null || true
+	fi
+	if [ -w "${path}" ]; then
+		return 0
+	fi
+	if command -v sudo >/dev/null 2>&1; then
+		return 0
+	fi
+	log "ERROR" "Insufficient permissions to modify ${path} and sudo not available."
+	exit 5
 }
 
 copy_project_files() {
-        # $1: prefix
-        local prefix="$1"
-        ensure_prefix_writable "${prefix}"
-        if [ ! -d "${SOURCE_PAYLOAD_DIR}" ]; then
-                log "ERROR" "Source directory missing at ${SOURCE_PAYLOAD_DIR}"
-                exit 2
-        fi
+	# $1: prefix
+	local prefix="$1"
+	ensure_prefix_writable "${prefix}"
+	if [ ! -d "${SOURCE_PAYLOAD_DIR}" ]; then
+		log "ERROR" "Source directory missing at ${SOURCE_PAYLOAD_DIR}"
+		exit 2
+	fi
 
-        log "INFO" "Installing project files into ${prefix}"
-        if [ -w "${prefix}" ]; then
-                mkdir -p "${prefix}"
-                cp -R "${SOURCE_PAYLOAD_DIR}/." "${prefix}/"
-        else
-                sudo mkdir -p "${prefix}"
-                sudo cp -R "${SOURCE_PAYLOAD_DIR}/." "${prefix}/"
-        fi
+	log "INFO" "Installing project files into ${prefix}"
+	if [ -w "${prefix}" ]; then
+		mkdir -p "${prefix}"
+		cp -R "${SOURCE_PAYLOAD_DIR}/." "${prefix}/"
+	else
+		sudo mkdir -p "${prefix}"
+		sudo cp -R "${SOURCE_PAYLOAD_DIR}/." "${prefix}/"
+	fi
 }
 
 create_symlink() {
-        # $1: target prefix, $2: link path
-        local prefix="$1"
-        local link_path="$2"
-        local target="${prefix}/main.sh"
+	# $1: target prefix, $2: link path
+	local prefix="$1"
+	local link_path="$2"
+	local target="${prefix}/main.sh"
 
-        if [ ! -f "${target}" ]; then
-                log "ERROR" "Entrypoint missing at ${target}"
-                exit 2
-        fi
+	if [ ! -f "${target}" ]; then
+		log "ERROR" "Entrypoint missing at ${target}"
+		exit 2
+	fi
 
-        local link_dir
-        link_dir="$(dirname "${link_path}")"
-        ensure_prefix_writable "${link_dir}"
-        if [ -w "${link_dir}" ]; then
-                mkdir -p "${link_dir}"
-                ln -sf "${target}" "${link_path}"
-        else
-                sudo mkdir -p "${link_dir}"
-                sudo ln -sf "${target}" "${link_path}"
-        fi
-        log "INFO" "Symlinked ${link_path} -> ${target}"
+	local link_dir
+	link_dir="$(dirname "${link_path}")"
+	ensure_prefix_writable "${link_dir}"
+	if [ -w "${link_dir}" ]; then
+		mkdir -p "${link_dir}"
+		ln -sf "${target}" "${link_path}"
+	else
+		sudo mkdir -p "${link_dir}"
+		sudo ln -sf "${target}" "${link_path}"
+	fi
+	log "INFO" "Symlinked ${link_path} -> ${target}"
 }
 
 uninstall() {
-        local prefix="$1"
-        local link_path="$2"
+	local prefix="$1"
+	local link_path="$2"
 
-        if [ -e "${link_path}" ]; then
-                if [ -w "${link_path}" ]; then
-                        rm -f "${link_path}"
-                elif command -v sudo >/dev/null 2>&1; then
-                        sudo rm -f "${link_path}"
-                else
-                        log "ERROR" "Cannot remove ${link_path}; insufficient permissions."
-                        exit 5
-                fi
-                log "INFO" "Removed symlink ${link_path}"
-        fi
+	if [ -e "${link_path}" ]; then
+		if [ -w "${link_path}" ]; then
+			rm -f "${link_path}"
+		elif command -v sudo >/dev/null 2>&1; then
+			sudo rm -f "${link_path}"
+		else
+			log "ERROR" "Cannot remove ${link_path}; insufficient permissions."
+			exit 5
+		fi
+		log "INFO" "Removed symlink ${link_path}"
+	fi
 
-        if [ -d "${prefix}" ]; then
-                if [ -w "${prefix}" ]; then
-                        rm -rf "${prefix}"
-                elif command -v sudo >/dev/null 2>&1; then
-                        sudo rm -rf "${prefix}"
-                else
-                        log "ERROR" "Cannot remove ${prefix}; insufficient permissions."
-                        exit 5
-                fi
-                log "INFO" "Removed installation prefix ${prefix}"
-        fi
+	if [ -d "${prefix}" ]; then
+		if [ -w "${prefix}" ]; then
+			rm -rf "${prefix}"
+		elif command -v sudo >/dev/null 2>&1; then
+			sudo rm -rf "${prefix}"
+		else
+			log "ERROR" "Cannot remove ${prefix}; insufficient permissions."
+			exit 5
+		fi
+		log "INFO" "Removed installation prefix ${prefix}"
+	fi
 }
 
 self_test_install() {
-        # $1: installation prefix, $2: link path
-        local prefix link_path grammar_path_output temp_root query_output
-        prefix="$1"
-        link_path="$2"
+	# $1: installation prefix, $2: link path
+	local prefix link_path grammar_path_output temp_root query_output
+	prefix="$1"
+	link_path="$2"
 
-        log "INFO" "Running installer self-test"
+	log "INFO" "Running installer self-test"
 
-        if [ ! -x "${prefix}/main.sh" ]; then
-                log "ERROR" "Installed main.sh is missing or not executable"
-                exit 2
-        fi
+	if [ ! -x "${prefix}/main.sh" ]; then
+		log "ERROR" "Installed main.sh is missing or not executable"
+		exit 2
+	fi
 
-        if [ ! -f "${prefix}/grammars/planner_plan.gbnf" ]; then
-                log "ERROR" "Planner grammar missing from installation"
-                exit 2
-        fi
+	if [ ! -f "${prefix}/grammars/planner_plan.gbnf" ]; then
+		log "ERROR" "Planner grammar missing from installation"
+		exit 2
+	fi
 
-        grammar_path_output="$(bash -c "source \"${prefix}/grammar.sh\" && grammar_path planner_plan" 2>/dev/null || true)"
-        if [ "${grammar_path_output}" != "${prefix}/grammars/planner_plan.gbnf" ]; then
-                log "ERROR" "Grammar resolution failed during self-test"
-                exit 2
-        fi
+	grammar_path_output="$(bash -c "source \"${prefix}/grammar.sh\" && grammar_path planner_plan" 2>/dev/null || true)"
+	if [ "${grammar_path_output}" != "${prefix}/grammars/planner_plan.gbnf" ]; then
+		log "ERROR" "Grammar resolution failed during self-test"
+		exit 2
+	fi
 
-        temp_root="$(mktemp -d "${TMPDIR:-/tmp}/okso-selftest-XXXXXX")"
-        query_output=$(env \
-                LLAMA_AVAILABLE=false \
-                XDG_CONFIG_HOME="${temp_root}/config" \
-                NOTES_DIR="${temp_root}/notes" \
-                DEFAULT_MODEL_SPEC_BASE="self/test:model.gguf" \
-                DEFAULT_MODEL_BRANCH_BASE="main" \
-                DEFAULT_MODEL_FILE_BASE="model.gguf" \
-                "${prefix}/main.sh" --plan-only -- "Self-test query" 2>&1 || true)
+	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/okso-selftest-XXXXXX")"
+	query_output=$(env \
+		LLAMA_AVAILABLE=false \
+		XDG_CONFIG_HOME="${temp_root}/config" \
+		NOTES_DIR="${temp_root}/notes" \
+		DEFAULT_MODEL_SPEC_BASE="self/test:model.gguf" \
+		DEFAULT_MODEL_BRANCH_BASE="main" \
+		DEFAULT_MODEL_FILE_BASE="model.gguf" \
+		"${prefix}/main.sh" --plan-only -- "Self-test query" 2>&1 || true)
 
-        if [ -z "${query_output}" ]; then
-                log "ERROR" "Self-test query produced no output"
-                exit 2
-        fi
+	if [ -z "${query_output}" ]; then
+		log "ERROR" "Self-test query produced no output"
+		exit 2
+	fi
 
-        if ! printf '%s' "${query_output}" | grep -q "Plan outline"; then
-                log "ERROR" "Self-test query did not complete as expected"
-                exit 2
-        fi
+	if ! printf '%s' "${query_output}" | grep -q "Plan outline"; then
+		log "ERROR" "Self-test query did not complete as expected"
+		exit 2
+	fi
 
-        if [ ! -L "${link_path}" ] && [ ! -x "${link_path}" ]; then
-                log "WARN" "CLI link not present; continuing"
-        fi
+	if [ ! -L "${link_path}" ] && [ ! -x "${link_path}" ]; then
+		log "WARN" "CLI link not present; continuing"
+	fi
 
-        log "INFO" "Installer self-test passed"
+	log "INFO" "Installer self-test passed"
 }
 
 main() {
-        local prefix="${DEFAULT_PREFIX}"
-        local mode="install"
+	local prefix="${DEFAULT_PREFIX}"
+	local mode="install"
 
-        while [ $# -gt 0 ]; do
-                case "$1" in
-                --prefix)
-                        if [ $# -lt 2 ]; then
-                                usage
-                                exit 1
-                        fi
-                        prefix="$2"
-                        shift 2
-                        ;;
-                --upgrade)
-                        mode="upgrade"
-                        shift
-                        ;;
-                --uninstall)
-                        mode="uninstall"
-                        shift
-                        ;;
-                --dry-run)
-                        DRY_RUN="true"
-                        shift
-                        ;;
-                --help | -h)
-                        usage
-                        exit 0
-                        ;;
-                *)
-                        usage
-                        exit 1
-                        ;;
-                esac
-        done
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		--prefix)
+			if [ $# -lt 2 ]; then
+				usage
+				exit 1
+			fi
+			prefix="$2"
+			shift 2
+			;;
+		--upgrade)
+			mode="upgrade"
+			shift
+			;;
+		--uninstall)
+			mode="uninstall"
+			shift
+			;;
+		--dry-run)
+			DRY_RUN="true"
+			shift
+			;;
+		--help | -h)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			exit 1
+			;;
+		esac
+	done
 
-        if [ "${DRY_RUN}" = "true" ]; then
-                log "INFO" "Dry run enabled; no changes will be made."
-        fi
+	if [ "${DRY_RUN}" = "true" ]; then
+		log "INFO" "Dry run enabled; no changes will be made."
+	fi
 
-        if [ "${mode}" != "uninstall" ]; then
-                if [ "${DRY_RUN}" = "true" ]; then
-                        log_dry_run "Would verify macOS compatibility"
-                        log_dry_run "Would ensure Homebrew is installed"
-                        log_dry_run "Would install Homebrew packages: ${BREW_PACKAGES[*]}"
-                else
-                        require_macos
-                        ensure_homebrew
-                        install_brew_packages
-                fi
-        elif [ "${IS_MACOS}" != "true" ] && [ "${DRY_RUN}" != "true" ]; then
-                log "ERROR" "Uninstall is only supported on macOS."
-                exit 3
-        fi
+	if [ "${mode}" != "uninstall" ]; then
+		if [ "${DRY_RUN}" = "true" ]; then
+			log_dry_run "Would verify macOS compatibility"
+			log_dry_run "Would ensure Homebrew is installed"
+			log_dry_run "Would install Homebrew packages: ${BREW_PACKAGES[*]}"
+		else
+			require_macos
+			ensure_homebrew
+			install_brew_packages
+		fi
+	elif [ "${IS_MACOS}" != "true" ] && [ "${DRY_RUN}" != "true" ]; then
+		log "ERROR" "Uninstall is only supported on macOS."
+		exit 3
+	fi
 
-        case "${mode}" in
-        install | upgrade)
-                if [ "${DRY_RUN}" = "true" ]; then
-                        log_dry_run "Would prepare source payload"
-                        log_dry_run "Would copy project files to ${prefix}"
-                        log_dry_run "Would create symlink at ${DEFAULT_LINK_PATH}"
-                        log_dry_run "Would run installer self-test"
-                        log "INFO" "${APP_NAME} installer completed (dry-run)."
-                        exit 0
-                fi
+	case "${mode}" in
+	install | upgrade)
+		if [ "${DRY_RUN}" = "true" ]; then
+			log_dry_run "Would prepare source payload"
+			log_dry_run "Would copy project files to ${prefix}"
+			log_dry_run "Would create symlink at ${DEFAULT_LINK_PATH}"
+			log_dry_run "Would run installer self-test"
+			log "INFO" "${APP_NAME} installer completed (dry-run)."
+			exit 0
+		fi
 
-                prepare_source_payload
-                copy_project_files "${prefix}"
-                create_symlink "${prefix}" "${DEFAULT_LINK_PATH}"
-                if [ "${DO_INSTALLER_SKIP_SELF_TEST:-false}" != "true" ]; then
-                        self_test_install "${prefix}" "${DEFAULT_LINK_PATH}"
-                else
-                        log "WARN" "Skipping installer self-test due to DO_INSTALLER_SKIP_SELF_TEST"
-                fi
-                ;;
-        uninstall)
-                if [ "${DRY_RUN}" = "true" ]; then
-                        log_dry_run "Would remove symlink ${DEFAULT_LINK_PATH}"
-                        log_dry_run "Would remove installation prefix ${prefix}"
-                        log "INFO" "${APP_NAME} installer completed (dry-run uninstall)."
-                        exit 0
-                fi
-                uninstall "${prefix}" "${DEFAULT_LINK_PATH}"
-                ;;
-        esac
+		prepare_source_payload
+		copy_project_files "${prefix}"
+		create_symlink "${prefix}" "${DEFAULT_LINK_PATH}"
+		if [ "${DO_INSTALLER_SKIP_SELF_TEST:-false}" != "true" ]; then
+			self_test_install "${prefix}" "${DEFAULT_LINK_PATH}"
+		else
+			log "WARN" "Skipping installer self-test due to DO_INSTALLER_SKIP_SELF_TEST"
+		fi
+		;;
+	uninstall)
+		if [ "${DRY_RUN}" = "true" ]; then
+			log_dry_run "Would remove symlink ${DEFAULT_LINK_PATH}"
+			log_dry_run "Would remove installation prefix ${prefix}"
+			log "INFO" "${APP_NAME} installer completed (dry-run uninstall)."
+			exit 0
+		fi
+		uninstall "${prefix}" "${DEFAULT_LINK_PATH}"
+		;;
+	esac
 
-        log "INFO" "${APP_NAME} installer completed (${mode})."
+	log "INFO" "${APP_NAME} installer completed (${mode})."
 }
 
 main "$@"

--- a/src/cli.sh
+++ b/src/cli.sh
@@ -115,27 +115,27 @@ parse_args() {
 			DRY_RUN=true
 			shift
 			;;
-                -m | --model)
-                        if [[ $# -lt 2 ]]; then
-                                die "cli" "usage" "--model requires an HF repo[:file] value"
-                        fi
-                        MODEL_SPEC="$2"
-                        shift 2
-                        ;;
-                --model-branch)
-                        if [[ $# -lt 2 ]]; then
-                                die "cli" "usage" "--model-branch requires a branch or tag"
-                        fi
-                        MODEL_BRANCH="$2"
-                        shift 2
-                        ;;
-                --config)
-                        if [[ $# -lt 2 ]]; then
-                                die "cli" "usage" "--config requires a path"
-                        fi
-                        CONFIG_FILE="$2"
-                        shift 2
-                        ;;
+		-m | --model)
+			if [[ $# -lt 2 ]]; then
+				die "cli" "usage" "--model requires an HF repo[:file] value"
+			fi
+			MODEL_SPEC="$2"
+			shift 2
+			;;
+		--model-branch)
+			if [[ $# -lt 2 ]]; then
+				die "cli" "usage" "--model-branch requires a branch or tag"
+			fi
+			MODEL_BRANCH="$2"
+			shift 2
+			;;
+		--config)
+			if [[ $# -lt 2 ]]; then
+				die "cli" "usage" "--config requires a path"
+			fi
+			CONFIG_FILE="$2"
+			shift 2
+			;;
 		-v | --verbose)
 			VERBOSITY=2
 			shift
@@ -144,13 +144,13 @@ parse_args() {
 			VERBOSITY=0
 			shift
 			;;
-                --)
-                        shift
-                        break
-                        ;;
-                -*)
-                        die "cli" "usage" "Unknown option: ${1}"
-                        ;;
+		--)
+			shift
+			break
+			;;
+		-*)
+			die "cli" "usage" "Unknown option: ${1}"
+			;;
 		*)
 			positional+=("$1")
 			shift
@@ -162,9 +162,9 @@ parse_args() {
 		USER_QUERY="${positional[*]}"
 	else
 		USER_QUERY="$*"
-        fi
+	fi
 
-        if [[ "${COMMAND}" == "run" && -z "${USER_QUERY:-}" ]]; then
-                die "cli" "usage" "A user query is required. See --help for usage."
-        fi
+	if [[ "${COMMAND}" == "run" && -z "${USER_QUERY:-}" ]]; then
+		die "cli" "usage" "A user query is required. See --help for usage."
+	fi
 }

--- a/src/config.sh
+++ b/src/config.sh
@@ -36,14 +36,14 @@ detect_config_file() {
 	# Parse the config path early so subsequent helpers can honor user-provided
 	# locations before any other arguments are interpreted.
 	while [[ $# -gt 0 ]]; do
-                case "$1" in
-                --config)
-                        if [[ $# -lt 2 ]]; then
-                                die "config" "usage" "--config requires a path"
-                        fi
-                        CONFIG_FILE="$2"
-                        shift 2
-                        ;;
+		case "$1" in
+		--config)
+			if [[ $# -lt 2 ]]; then
+				die "config" "usage" "--config requires a path"
+			fi
+			CONFIG_FILE="$2"
+			shift 2
+			;;
 		--config=*)
 			CONFIG_FILE="${1#*=}"
 			shift

--- a/src/errors.sh
+++ b/src/errors.sh
@@ -20,65 +20,65 @@
 #   log_debug returns 0.
 
 emit_error_envelope() {
-        # Emits a JSON error envelope with consistent metadata.
-        # Arguments:
-        #   $1 - context (string; optional; defaults to ERROR_CONTEXT/TOOL_NAME/runtime)
-        #   $2 - category (string; required)
-        #   $3 - message (string; required)
-        local context category message
-        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
-        category="$2"
-        message="$3"
+	# Emits a JSON error envelope with consistent metadata.
+	# Arguments:
+	#   $1 - context (string; optional; defaults to ERROR_CONTEXT/TOOL_NAME/runtime)
+	#   $2 - category (string; required)
+	#   $3 - message (string; required)
+	local context category message
+	context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+	category="$2"
+	message="$3"
 
-        jq -cn \
-                --arg name "${context}" \
-                --arg category "${category}" \
-                --arg message "${message}" \
-                '{name:$name, category:$category, message:$message}'
+	jq -cn \
+		--arg name "${context}" \
+		--arg category "${category}" \
+		--arg message "${message}" \
+		'{name:$name, category:$category, message:$message}'
 }
 
 die() {
-        # Emits an error envelope and exits with a non-zero code.
-        # Arguments:
-        #   $1 - context (string; optional)
-        #   $2 - category (string; required)
-        #   $3 - message (string; required)
-        #   $4 - exit code (int; optional; default: 1)
-        local context category message status
-        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
-        category="$2"
-        message="$3"
-        status=${4:-1}
+	# Emits an error envelope and exits with a non-zero code.
+	# Arguments:
+	#   $1 - context (string; optional)
+	#   $2 - category (string; required)
+	#   $3 - message (string; required)
+	#   $4 - exit code (int; optional; default: 1)
+	local context category message status
+	context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+	category="$2"
+	message="$3"
+	status=${4:-1}
 
-        emit_error_envelope "${context}" "${category}" "${message}" >&2
-        exit "${status}"
+	emit_error_envelope "${context}" "${category}" "${message}" >&2
+	exit "${status}"
 }
 
 warn() {
-        # Emits an error envelope and returns a non-zero status for soft failures.
-        # Arguments:
-        #   $1 - context (string; optional)
-        #   $2 - category (string; required)
-        #   $3 - message (string; required)
-        #   $4 - exit code (int; optional; default: 1)
-        local context category message status
-        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
-        category="$2"
-        message="$3"
-        status=${4:-1}
+	# Emits an error envelope and returns a non-zero status for soft failures.
+	# Arguments:
+	#   $1 - context (string; optional)
+	#   $2 - category (string; required)
+	#   $3 - message (string; required)
+	#   $4 - exit code (int; optional; default: 1)
+	local context category message status
+	context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+	category="$2"
+	message="$3"
+	status=${4:-1}
 
-        emit_error_envelope "${context}" "${category}" "${message}" >&2
-        return "${status}"
+	emit_error_envelope "${context}" "${category}" "${message}" >&2
+	return "${status}"
 }
 
 log_debug() {
-        # Emits a debug envelope without altering control flow.
-        # Arguments:
-        #   $1 - context (string; optional)
-        #   $2 - message (string; required)
-        local context message
-        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
-        message="$2"
+	# Emits a debug envelope without altering control flow.
+	# Arguments:
+	#   $1 - context (string; optional)
+	#   $2 - message (string; required)
+	local context message
+	context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+	message="$2"
 
-        emit_error_envelope "${context}" "debug" "${message}" >&2
+	emit_error_envelope "${context}" "debug" "${message}" >&2
 }

--- a/src/grammar.sh
+++ b/src/grammar.sh
@@ -17,44 +17,44 @@
 
 # Returns the absolute path to the grammar directory.
 grammar_root_dir() {
-        local script_dir
-        script_dir="${BASH_SOURCE[0]%/grammar.sh}"
-        cd "${script_dir}/grammars" && pwd
+	local script_dir
+	script_dir="${BASH_SOURCE[0]%/grammar.sh}"
+	cd "${script_dir}/grammars" && pwd
 }
 
 # Resolves a grammar name to its file path.
 # Arguments:
 #   $1 - grammar key (string)
 grammar_path() {
-        local grammar_name grammar_file
-        grammar_name="$1"
+	local grammar_name grammar_file
+	grammar_name="$1"
 
-        case "${grammar_name}" in
-        react_action)
-                grammar_file="react_action.gbnf"
-                ;;
-        planner_plan)
-                grammar_file="planner_plan.gbnf"
-                ;;
-        concise_response)
-                grammar_file="concise_response.gbnf"
-                ;;
-        *)
-                printf 'Unknown grammar requested: %s\n' "${grammar_name}" >&2
-                return 1
-                ;;
-        esac
+	case "${grammar_name}" in
+	react_action)
+		grammar_file="react_action.gbnf"
+		;;
+	planner_plan)
+		grammar_file="planner_plan.gbnf"
+		;;
+	concise_response)
+		grammar_file="concise_response.gbnf"
+		;;
+	*)
+		printf 'Unknown grammar requested: %s\n' "${grammar_name}" >&2
+		return 1
+		;;
+	esac
 
-        printf '%s/%s' "$(grammar_root_dir)" "${grammar_file}"
+	printf '%s/%s' "$(grammar_root_dir)" "${grammar_file}"
 }
 
 # Reads a grammar file and writes it to stdout.
 # Arguments:
 #   $1 - grammar key (string)
 load_grammar_text() {
-        local grammar_name grammar_file_path
-        grammar_name="$1"
-        grammar_file_path="$(grammar_path "${grammar_name}")" || return 1
+	local grammar_name grammar_file_path
+	grammar_name="$1"
+	grammar_file_path="$(grammar_path "${grammar_name}")" || return 1
 
-        cat "${grammar_file_path}"
+	cat "${grammar_file_path}"
 }

--- a/src/planner.sh
+++ b/src/planner.sh
@@ -154,7 +154,7 @@ generate_plan_outline() {
 	user_query="$1"
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
-		log "INFO" "Using static plan outline because llama is unavailable" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
+		log "DEBUG" "Using static plan outline because llama is unavailable" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}" >&2
 		printf '1. Use final_answer to respond directly to the user request.'
 		return 0
 	fi

--- a/src/respond.sh
+++ b/src/respond.sh
@@ -24,24 +24,24 @@ source "${BASH_SOURCE[0]%/respond.sh}/prompts.sh"
 source "${BASH_SOURCE[0]%/respond.sh}/grammar.sh"
 
 respond_text() {
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - number of tokens to generate (int)
-        local user_query prompt number_of_tokens concise_grammar_path
-        user_query="$1"
-        number_of_tokens="$2"
-        concise_grammar_path="$(grammar_path concise_response)"
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - number of tokens to generate (int)
+	local user_query prompt number_of_tokens concise_grammar_path
+	user_query="$1"
+	number_of_tokens="$2"
+	concise_grammar_path="$(grammar_path concise_response)"
 
-        if [[ "${LLAMA_AVAILABLE}" != true ]]; then
-                log "WARN" "llama unavailable; returning deterministic response" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
-                printf 'LLM unavailable. Request received: %s\n' "${user_query}"
-                return 0
-        fi
+	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
+		log "WARN" "llama unavailable; returning deterministic response" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
+		printf 'LLM unavailable. Request received: %s\n' "${user_query}"
+		return 0
+	fi
 
-        if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
-                printf 'Responding directly to: %s\n' "${user_query}"
-                return 0
-        fi
+	if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
+		printf 'Responding directly to: %s\n' "${user_query}"
+		return 0
+	fi
 
 	prompt="$(build_concise_response_prompt "${user_query}")"
 	llama_infer "${prompt}" "\n" "${number_of_tokens}" "${concise_grammar_path}"

--- a/src/tools.sh
+++ b/src/tools.sh
@@ -29,32 +29,32 @@ source "${BASH_SOURCE[0]%/tools.sh}/logging.sh"
 source "${TOOLS_DIR}/registry.sh"
 # shellcheck disable=SC2034
 TOOL_NAME_ALLOWLIST=(
-        "terminal"
-        "file_search"
-        "clipboard_copy"
-        "clipboard_paste"
-        "notes_create"
-        "notes_append"
-        "notes_list"
-        "notes_search"
-        "notes_read"
-        "reminders_create"
-        "reminders_list"
-        "reminders_complete"
-        "calendar_create"
-        "calendar_list"
-        "calendar_search"
-        "mail_draft"
-        "mail_send"
-        "mail_search"
-        "mail_list_inbox"
-        "mail_list_unread"
-        "applescript"
-        "final_answer"
+	"terminal"
+	"file_search"
+	"clipboard_copy"
+	"clipboard_paste"
+	"notes_create"
+	"notes_append"
+	"notes_list"
+	"notes_search"
+	"notes_read"
+	"reminders_create"
+	"reminders_list"
+	"reminders_complete"
+	"calendar_create"
+	"calendar_list"
+	"calendar_search"
+	"mail_draft"
+	"mail_send"
+	"mail_search"
+	"mail_list_inbox"
+	"mail_list_unread"
+	"applescript"
+	"final_answer"
 )
 TOOL_WRITABLE_DIRECTORY_ALLOWLIST=(
-        "${HOME}/.okso"
-        "${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+	"${HOME}/.okso"
+	"${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
 )
 # shellcheck source=./tools/terminal.sh disable=SC1091
 source "${TOOLS_DIR}/terminal.sh"
@@ -76,62 +76,62 @@ source "${TOOLS_DIR}/applescript.sh"
 source "${TOOLS_DIR}/final_answer.sh"
 
 tools_normalize_path() {
-        # Returns a normalized absolute path for allowlist checks.
-        # Arguments:
-        #   $1 - path to normalize (string)
-        if command -v realpath >/dev/null 2>&1; then
-                realpath -m "$1"
-                return
-        fi
+	# Returns a normalized absolute path for allowlist checks.
+	# Arguments:
+	#   $1 - path to normalize (string)
+	if command -v realpath >/dev/null 2>&1; then
+		realpath -m "$1"
+		return
+	fi
 
-        python - "$1" <<'PY'
+	python - "$1" <<'PY'
 import os, sys
 print(os.path.realpath(sys.argv[1]))
 PY
 }
 
 tools_writable_directory_allowed() {
-        # Validates that a directory is within the writable allowlist.
-        # Arguments:
-        #   $1 - target directory (string)
-        local candidate normalized allowed normalized_allowed
-        candidate="$1"
-        normalized=$(tools_normalize_path "${candidate}") || return 1
+	# Validates that a directory is within the writable allowlist.
+	# Arguments:
+	#   $1 - target directory (string)
+	local candidate normalized allowed normalized_allowed
+	candidate="$1"
+	normalized=$(tools_normalize_path "${candidate}") || return 1
 
-        for allowed in "${TOOL_WRITABLE_DIRECTORY_ALLOWLIST[@]}"; do
-                normalized_allowed=$(tools_normalize_path "${allowed}") || continue
-                if [[ "${normalized}" == "${normalized_allowed}"* ]]; then
-                        return 0
-                fi
-        done
+	for allowed in "${TOOL_WRITABLE_DIRECTORY_ALLOWLIST[@]}"; do
+		normalized_allowed=$(tools_normalize_path "${allowed}") || continue
+		if [[ "${normalized}" == "${normalized_allowed}"* ]]; then
+			return 0
+		fi
+	done
 
-        log "ERROR" "Writable directory not allowed" "${candidate}" || true
-        return 1
+	log "ERROR" "Writable directory not allowed" "${candidate}" || true
+	return 1
 }
 
 validate_writable_directories() {
-        # Confirms all configured writable directories are allowlisted.
-        local candidate
-        for candidate in "${NOTES_DIR:-${HOME}/.okso}" "${CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/okso}"; do
-                if [[ -z "${candidate}" ]]; then
-                        continue
-                fi
-                if ! tools_writable_directory_allowed "${candidate}"; then
-                        return 1
-                fi
-        done
+	# Confirms all configured writable directories are allowlisted.
+	local candidate
+	for candidate in "${NOTES_DIR:-${HOME}/.okso}" "${CONFIG_DIR:-${XDG_CONFIG_HOME:-${HOME}/.config}/okso}"; do
+		if [[ -z "${candidate}" ]]; then
+			continue
+		fi
+		if ! tools_writable_directory_allowed "${candidate}"; then
+			return 1
+		fi
+	done
 
-        return 0
+	return 0
 }
 
 initialize_tools() {
-        if ! validate_writable_directories; then
-                return 1
-        fi
+	if ! validate_writable_directories; then
+		return 1
+	fi
 
-        register_terminal
-        register_file_search
-        register_clipboard_copy
+	register_terminal
+	register_file_search
+	register_clipboard_copy
 	register_clipboard_paste
 	register_notes_suite
 	register_reminders_suite

--- a/src/tools/applescript.sh
+++ b/src/tools/applescript.sh
@@ -38,10 +38,10 @@ tool_applescript() {
 		return 0
 	fi
 
-        log "INFO" "Executing AppleScript" "${query}"
-        if ! osascript_run_evaluated "osascript" "${query}"; then
-                return 1
-        fi
+	log "INFO" "Executing AppleScript" "${query}"
+	if ! osascript_run_evaluated "osascript" "${query}"; then
+		return 1
+	fi
 }
 
 register_applescript() {

--- a/src/tools/calendar/common.sh
+++ b/src/tools/calendar/common.sh
@@ -76,12 +76,12 @@ calendar_extract_event_fields() {
 }
 
 calendar_run_script() {
-        # Runs an AppleScript provided on stdin, passing through all arguments.
-        # Arguments:
-        #   $@ - parameters forwarded to osascript
-        local bin
-        bin=${CALENDAR_OSASCRIPT_BIN:-osascript}
-        osascript_run_piped "${bin}" "$@"
+	# Runs an AppleScript provided on stdin, passing through all arguments.
+	# Arguments:
+	#   $@ - parameters forwarded to osascript
+	local bin
+	bin=${CALENDAR_OSASCRIPT_BIN:-osascript}
+	osascript_run_piped "${bin}" "$@"
 }
 
 calendar_resolve_calendar_script() {

--- a/src/tools/mail/common.sh
+++ b/src/tools/mail/common.sh
@@ -113,10 +113,10 @@ mail_split_recipients() {
 }
 
 mail_run_script() {
-        # Runs an AppleScript provided on stdin, passing through all arguments.
-        # Arguments:
-        #   $@ - parameters forwarded to osascript
-        local bin
-        bin=${MAIL_OSASCRIPT_BIN:-osascript}
-        osascript_run_piped "${bin}" "$@"
+	# Runs an AppleScript provided on stdin, passing through all arguments.
+	# Arguments:
+	#   $@ - parameters forwarded to osascript
+	local bin
+	bin=${MAIL_OSASCRIPT_BIN:-osascript}
+	osascript_run_piped "${bin}" "$@"
 }

--- a/src/tools/notes/common.sh
+++ b/src/tools/notes/common.sh
@@ -72,8 +72,8 @@ notes_run_script() {
 	# Arguments:
 	#   $@ - parameters forwarded to osascript
 	local bin
-        bin=${NOTES_OSASCRIPT_BIN:-osascript}
-        osascript_run_piped "${bin}" "$@"
+	bin=${NOTES_OSASCRIPT_BIN:-osascript}
+	osascript_run_piped "${bin}" "$@"
 }
 
 notes_resolve_folder_script() {

--- a/src/tools/osascript_helpers.sh
+++ b/src/tools/osascript_helpers.sh
@@ -50,92 +50,87 @@ assert_osascript_available() {
 		return 1
 	fi
 
-        return 0
+	return 0
 }
 
 osascript_disallow_argument() {
-        # Rejects suspect arguments that could alter osascript invocation.
-        # Arguments:
-        #   $1 - argument to validate (string)
-        # Returns:
-        #   0 when the argument is safe to pass, 1 otherwise.
-        local argument allowed_flag
-        argument="$1"
+	# Rejects suspect arguments that could alter osascript invocation.
+	# Arguments:
+	#   $1 - argument to validate (string)
+	# Returns:
+	#   0 when the argument is safe to pass, 1 otherwise.
+	local argument allowed_flag
+	argument="$1"
 
-        if [[ "${argument}" == *$'\n'* ]]; then
-                log "ERROR" "osascript arguments must not span multiple lines" "${argument}" || true
-                return 1
-        fi
+	if [[ "${argument}" == -* ]]; then
+		if [[ -z "${OSASCRIPT_ALLOWED_FLAGS[*]:-}" ]]; then
+			log "ERROR" "osascript flags are disallowed" "${argument}" || true
+			return 1
+		fi
 
-        if [[ "${argument}" == -* ]]; then
-                if [[ -z "${OSASCRIPT_ALLOWED_FLAGS[*]:-}" ]]; then
-                        log "ERROR" "osascript flags are disallowed" "${argument}" || true
-                        return 1
-                fi
+		for allowed_flag in "${OSASCRIPT_ALLOWED_FLAGS[@]}"; do
+			if [[ "${argument}" == "${allowed_flag}" ]]; then
+				return 0
+			fi
+		done
 
-                for allowed_flag in "${OSASCRIPT_ALLOWED_FLAGS[@]}"; do
-                        if [[ "${argument}" == "${allowed_flag}" ]]; then
-                                return 0
-                        fi
-                done
+		log "ERROR" "osascript flag not allowed" "${argument}" || true
+		return 1
+	fi
 
-                log "ERROR" "osascript flag not allowed" "${argument}" || true
-                return 1
-        fi
+	if [[ "${argument}" == *\`* || "${argument}" == *\$\(* ]]; then
+		log "ERROR" "osascript arguments may not include shell substitution" "${argument}" || true
+		return 1
+	fi
 
-        if [[ "${argument}" == *'`'* || "${argument}" == *'$('* ]]; then
-                log "ERROR" "osascript arguments may not include shell substitution" "${argument}" || true
-                return 1
-        fi
-
-        return 0
+	return 0
 }
 
 sanitize_osascript_arguments() {
-        # Validates all provided arguments using osascript_disallow_argument.
-        # Arguments:
-        #   $@ - candidate arguments destined for osascript
-        local argument
-        for argument in "$@"; do
-                if ! osascript_disallow_argument "${argument}"; then
-                        return 1
-                fi
-        done
-        return 0
+	# Validates all provided arguments using osascript_disallow_argument.
+	# Arguments:
+	#   $@ - candidate arguments destined for osascript
+	local argument
+	for argument in "$@"; do
+		if ! osascript_disallow_argument "${argument}"; then
+			return 1
+		fi
+	done
+	return 0
 }
 
 osascript_run_evaluated() {
-        # Invokes osascript with a single -e expression after sanitizing inputs.
-        # Arguments:
-        #   $1 - osascript binary (string; defaults to "osascript")
-        #   $2 - script expression (string; required)
-        #   $@ - additional arguments passed through after validation
-        local bin expression
-        bin="${1:-osascript}"
-        expression="$2"
-        shift 2
+	# Invokes osascript with a single -e expression after sanitizing inputs.
+	# Arguments:
+	#   $1 - osascript binary (string; defaults to "osascript")
+	#   $2 - script expression (string; required)
+	#   $@ - additional arguments passed through after validation
+	local bin expression
+	bin="${1:-osascript}"
+	expression="$2"
+	shift 2
 
-        OSASCRIPT_ALLOWED_FLAGS=("-e")
-        if ! sanitize_osascript_arguments "-e" "${expression}" "$@"; then
-                return 1
-        fi
+	OSASCRIPT_ALLOWED_FLAGS=("-e")
+	if ! sanitize_osascript_arguments "-e" "${expression}" "$@"; then
+		return 1
+	fi
 
-        "${bin}" -e "${expression}" "$@"
+	"${bin}" -e "${expression}" "$@"
 }
 
 osascript_run_piped() {
-        # Invokes osascript reading a script from stdin after sanitizing inputs.
-        # Arguments:
-        #   $1 - osascript binary (string; defaults to "osascript")
-        #   $@ - arguments forwarded to osascript after validation
-        local bin
-        bin="${1:-osascript}"
-        shift
+	# Invokes osascript reading a script from stdin after sanitizing inputs.
+	# Arguments:
+	#   $1 - osascript binary (string; defaults to "osascript")
+	#   $@ - arguments forwarded to osascript after validation
+	local bin
+	bin="${1:-osascript}"
+	shift
 
-        OSASCRIPT_ALLOWED_FLAGS=("-")
-        if ! sanitize_osascript_arguments "-" "$@"; then
-                return 1
-        fi
+	OSASCRIPT_ALLOWED_FLAGS=("-")
+	if ! sanitize_osascript_arguments "-" "$@"; then
+		return 1
+	fi
 
-        "${bin}" - "$@"
+	"${bin}" - "$@"
 }

--- a/src/tools/reminders/common.sh
+++ b/src/tools/reminders/common.sh
@@ -71,12 +71,12 @@ reminders_extract_title_and_body() {
 }
 
 reminders_run_script() {
-        # Runs an AppleScript provided on stdin, passing through all arguments.
-        # Arguments:
-        #   $@ - parameters forwarded to osascript
-        local bin
-        bin=${REMINDERS_OSASCRIPT_BIN:-osascript}
-        osascript_run_piped "${bin}" "$@"
+	# Runs an AppleScript provided on stdin, passing through all arguments.
+	# Arguments:
+	#   $@ - parameters forwarded to osascript
+	local bin
+	bin=${REMINDERS_OSASCRIPT_BIN:-osascript}
+	osascript_run_piped "${bin}" "$@"
 }
 
 reminders_resolve_list_script() {

--- a/tests/install/test_install_features.bats
+++ b/tests/install/test_install_features.bats
@@ -14,28 +14,28 @@
 #   Inherits Bats semantics; individual tests assert script exit codes explicitly.
 
 setup() {
-        TEST_ROOT="${BATS_TMPDIR}/okso-install-feature"
-        mkdir -p "${TEST_ROOT}"
-        export DO_INSTALLER_ASSUME_OFFLINE=true
-        export DO_LINK_DIR="${TEST_ROOT}/bin"
-        mkdir -p "${DO_LINK_DIR}"
+	TEST_ROOT="${BATS_TMPDIR}/okso-install-feature"
+	mkdir -p "${TEST_ROOT}"
+	export DO_INSTALLER_ASSUME_OFFLINE=true
+	export DO_LINK_DIR="${TEST_ROOT}/bin"
+	mkdir -p "${DO_LINK_DIR}"
 }
 
 teardown() {
-        rm -rf "${TEST_ROOT}" 2>/dev/null || true
+	rm -rf "${TEST_ROOT}" 2>/dev/null || true
 }
 
 create_mock_macos_tools() {
-        local mock_path="$1"
-        mkdir -p "${mock_path}" "$2"
+	local mock_path="$1"
+	mkdir -p "${mock_path}" "$2"
 
-        cat >"${mock_path}/uname" <<'EOM_UNAME'
+	cat >"${mock_path}/uname" <<'EOM_UNAME'
 #!/usr/bin/env bash
 echo "Darwin"
 EOM_UNAME
-        chmod +x "${mock_path}/uname"
+	chmod +x "${mock_path}/uname"
 
-        cat >"${mock_path}/brew" <<'EOM_BREW'
+	cat >"${mock_path}/brew" <<'EOM_BREW'
 #!/usr/bin/env bash
 if [ "$1" = "list" ]; then
         exit 0
@@ -45,50 +45,50 @@ if [ "$1" = "install" ]; then
 fi
 command -v "$1" >/dev/null 2>&1
 EOM_BREW
-        chmod +x "${mock_path}/brew"
+	chmod +x "${mock_path}/brew"
 }
 
 @test "supports dry-run without modifying filesystem" {
-        local prefix="${TEST_ROOT}/prefix-dry"
+	local prefix="${TEST_ROOT}/prefix-dry"
 
-        run ./scripts/install.sh --prefix "${prefix}" --dry-run
+	run ./scripts/install.sh --prefix "${prefix}" --dry-run
 
-        [ "$status" -eq 0 ]
-        [[ "$output" == *"Dry run enabled"* ]]
-        [ ! -d "${prefix}" ]
-        [ ! -L "${DO_LINK_DIR}/okso" ]
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Dry run enabled"* ]]
+	[ ! -d "${prefix}" ]
+	[ ! -L "${DO_LINK_DIR}/okso" ]
 }
 
 @test "fails when archive checksum mismatches" {
-        local mock_path="${TEST_ROOT}/mock-bin"
-        local remote_root="${TEST_ROOT}/remote"
-        local bundle_dir="${TEST_ROOT}/bundle"
-        local tarball="${bundle_dir}/okso.tar.gz"
-        local checksum_file="${tarball}.sha256"
+	local mock_path="${TEST_ROOT}/mock-bin"
+	local remote_root="${TEST_ROOT}/remote"
+	local bundle_dir="${TEST_ROOT}/bundle"
+	local tarball="${bundle_dir}/okso.tar.gz"
+	local checksum_file="${tarball}.sha256"
 
-        mkdir -p "${mock_path}" "${remote_root}/scripts" "${bundle_dir}" "${TEST_ROOT}/prefix"
+	mkdir -p "${mock_path}" "${remote_root}/scripts" "${bundle_dir}" "${TEST_ROOT}/prefix"
 
-        tar -czf "${tarball}" -C . src scripts README.md LICENSE
-        printf '%s\n' "deadbeef" >"${checksum_file}"
+	tar -czf "${tarball}" -C . src scripts README.md LICENSE
+	printf '%s\n' "deadbeef" >"${checksum_file}"
 
-        cp scripts/install.sh "${remote_root}/scripts/install.sh"
-        create_mock_macos_tools "${mock_path}" "${TEST_ROOT}/prefix"
+	cp scripts/install.sh "${remote_root}/scripts/install.sh"
+	create_mock_macos_tools "${mock_path}" "${TEST_ROOT}/prefix"
 
-        run env PATH="${mock_path}:${PATH}" DO_INSTALLER_BASE_URL="file://${bundle_dir}" bash "${remote_root}/scripts/install.sh" --prefix "${TEST_ROOT}/prefix"
+	run env PATH="${mock_path}:${PATH}" DO_INSTALLER_BASE_URL="file://${bundle_dir}" bash "${remote_root}/scripts/install.sh" --prefix "${TEST_ROOT}/prefix"
 
-        [ "$status" -eq 2 ]
-        [[ "$output" == *"Checksum file invalid or malformed"* ]]
+	[ "$status" -eq 2 ]
+	[[ "$output" == *"Checksum file invalid or malformed"* ]]
 }
 
 @test "runs installer self-test after install" {
-        local mock_path="${TEST_ROOT}/mock-bin"
+	local mock_path="${TEST_ROOT}/mock-bin"
 
-        mkdir -p "${TEST_ROOT}/prefix"
-        create_mock_macos_tools "${mock_path}" "${TEST_ROOT}/prefix"
+	mkdir -p "${TEST_ROOT}/prefix"
+	create_mock_macos_tools "${mock_path}" "${TEST_ROOT}/prefix"
 
-        run env PATH="${mock_path}:${PATH}" ./scripts/install.sh --prefix "${TEST_ROOT}/prefix"
+	run env PATH="${mock_path}:${PATH}" ./scripts/install.sh --prefix "${TEST_ROOT}/prefix"
 
-        [ "$status" -eq 0 ]
-        [[ "$output" == *"Installer self-test passed"* ]]
-        [[ "$output" == *"Running installer self-test"* ]]
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Installer self-test passed"* ]]
+	[[ "$output" == *"Running installer self-test"* ]]
 }

--- a/tests/test_errors.bats
+++ b/tests/test_errors.bats
@@ -12,7 +12,7 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "die surfaces exit codes from failed pipelines" {
-        run bash -lc '
+	run bash -lc '
                 set -o pipefail
                 source ./src/errors.sh
                 ERROR_CONTEXT="runtime"
@@ -20,21 +20,21 @@
                 { false | true; } || die "${ERROR_CONTEXT}" "pipeline" "upstream pipeline failure" 17
         '
 
-        [ "$status" -eq 17 ]
-        [[ "$output" == *'"name":"runtime"'* ]]
-        [[ "$output" == *'"category":"pipeline"'* ]]
-        [[ "$output" == *'"message":"upstream pipeline failure"'* ]]
+	[ "$status" -eq 17 ]
+	[[ "$output" == *'"name":"runtime"'* ]]
+	[[ "$output" == *'"category":"pipeline"'* ]]
+	[[ "$output" == *'"message":"upstream pipeline failure"'* ]]
 }
 
 @test "die exits from subshells with serialized envelope" {
-        run bash -lc '
+	run bash -lc '
                 source ./src/errors.sh
 
                 (die "tool_runner" "fatal" "subshell explosion" 23)
         '
 
-        [ "$status" -eq 23 ]
-        [[ "$output" == *'"name":"tool_runner"'* ]]
-        [[ "$output" == *'"category":"fatal"'* ]]
-        [[ "$output" == *'"message":"subshell explosion"'* ]]
+	[ "$status" -eq 23 ]
+	[[ "$output" == *'"name":"tool_runner"'* ]]
+	[[ "$output" == *'"category":"fatal"'* ]]
+	[[ "$output" == *'"message":"subshell explosion"'* ]]
 }

--- a/tests/test_install.bats
+++ b/tests/test_install.bats
@@ -134,7 +134,7 @@ echo "Darwin"
 EOM_UNAME
 	chmod +x "${mock_path}/uname"
 
-        cat >"${mock_path}/curl" <<EOM_CURL
+	cat >"${mock_path}/curl" <<EOM_CURL
 #!/usr/bin/env bash
 printf 'curl %s\n' "\$*" >>"${log_path}"
 printf 'args:' >>"${log_path}"

--- a/tests/test_security.bats
+++ b/tests/test_security.bats
@@ -12,25 +12,25 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "osascript helpers reject shell substitution attempts" {
-        run bash -lc '
+	run bash -lc '
                 VERBOSITY=1
                 source ./src/tools/osascript_helpers.sh
                 malicious=$'"'"'display dialog `whoami`'"'"'
                 sanitize_osascript_arguments "${malicious}"
         '
 
-        [ "$status" -eq 1 ]
-        [ "$(echo "${output}" | jq -r '.message')" = "osascript arguments may not include shell substitution" ]
+	[ "$status" -eq 1 ]
+	[ "$(echo "${output}" | jq -r '.message')" = "osascript arguments may not include shell substitution" ]
 }
 
 @test "initialize_tools fails when writable directory leaves allowlist" {
-        run bash -lc '
+	run bash -lc '
                 VERBOSITY=1
                 NOTES_DIR="/tmp/okso/../../etc"
                 source ./src/tools.sh
                 initialize_tools
         '
 
-        [ "$status" -eq 1 ]
-        [ "$(echo "${output}" | jq -r '.message')" = "Writable directory not allowed" ]
+	[ "$status" -eq 1 ]
+	[ "$(echo "${output}" | jq -r '.message')" = "Writable directory not allowed" ]
 }


### PR DESCRIPTION
## Summary
- format shell scripts across the project with shfmt to satisfy formatting checks
- allow multiline AppleScript arguments while still blocking shell substitution attempts
- lower static-plan fallback logging to debug to keep llama-unavailable output clean

## Testing
- shfmt -w .
- shellcheck src/*.sh src/tools/*.sh src/tools/notes/*.sh tests/*.bats tests/test_all.sh tests/test_install.bats tests/test_main.bats tests/test_modules.bats tests/test_notes.bats scripts/install.sh
- bats tests/*.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d55c4de08325bcb2bc7dc9ce36f3)