### PR TITLE
Refactor settings and registry to JSON

### DIFF
--- a/src/tools/registry.sh
+++ b/src/tools/registry.sh
@@ -11,6 +11,7 @@
 #
 # Dependencies:
 #   - bash 3+
+#   - jq
 #   - logging helpers from logging.sh
 #
 # Exit codes:
@@ -19,83 +20,92 @@
 # shellcheck source=../logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/registry.sh}/logging.sh"
 
-# shellcheck disable=SC2034
-TOOLS=()
+if [[ -z "${TOOL_REGISTRY_JSON:-}" ]]; then
+        TOOL_REGISTRY_JSON='{"names":[],"registry":{}}'
+fi
+
+tool_registry_json() {
+        local default_json
+        default_json='{"names":[],"registry":{}}'
+        printf '%s' "${TOOL_REGISTRY_JSON:-${default_json}}"
+}
+
+tool_names() {
+        jq -r '.names[]?' <<<"$(tool_registry_json)"
+}
 
 tool_description() {
-	local name var_name
-	name="$1"
-	var_name="TOOL_DESCRIPTION_${name}"
-	printf '%s' "${!var_name:-}"
+        local name
+        name="$1"
+        jq -r --arg name "${name}" '.registry[$name].description // ""' <<<"$(tool_registry_json)"
 }
 
 tool_command() {
-	local name var_name
-	name="$1"
-	var_name="TOOL_COMMAND_${name}"
-	printf '%s' "${!var_name:-}"
+        local name
+        name="$1"
+        jq -r --arg name "${name}" '.registry[$name].command // ""' <<<"$(tool_registry_json)"
 }
 
 tool_safety() {
-	local name var_name
-	name="$1"
-	var_name="TOOL_SAFETY_${name}"
-	printf '%s' "${!var_name:-}"
+        local name
+        name="$1"
+        jq -r --arg name "${name}" '.registry[$name].safety // ""' <<<"$(tool_registry_json)"
 }
 
 tool_handler() {
-	local name var_name
-	name="$1"
-	var_name="TOOL_HANDLER_${name}"
-	printf '%s' "${!var_name:-}"
+        local name
+        name="$1"
+        jq -r --arg name "${name}" '.registry[$name].handler // ""' <<<"$(tool_registry_json)"
 }
 
 init_tool_registry() {
-	local name
-	for name in "${TOOLS[@]}"; do
-		unset "TOOL_DESCRIPTION_${name}" "TOOL_COMMAND_${name}" "TOOL_SAFETY_${name}" "TOOL_HANDLER_${name}"
-	done
-	TOOLS=()
+        TOOL_REGISTRY_JSON='{"names":[],"registry":{}}'
 }
 
 register_tool() {
-	# Arguments:
-	#   $1 - name
-	#   $2 - description
-	#   $3 - invocation command (string)
-	#   $4 - safety notes
-	#   $5 - handler function name
-	if [[ $# -lt 5 ]]; then
-		log "ERROR" "register_tool requires five arguments" "$*"
-		return 1
-	fi
+        # Arguments:
+        #   $1 - name
+        #   $2 - description
+        #   $3 - invocation command (string)
+        #   $4 - safety notes
+        #   $5 - handler function name
+        if [[ $# -lt 5 ]]; then
+                log "ERROR" "register_tool requires five arguments" "$*"
+                return 1
+        fi
 
-	local name
-	name="$1"
+        local name
+        name="$1"
 
-	if [[ ! "${name}" =~ ^[a-z0-9_]+$ ]]; then
-		log "ERROR" "tool names must be alphanumeric with underscores" "${name}" || true
-		return 1
-	fi
+        if [[ ! "${name}" =~ ^[a-z0-9_]+$ ]]; then
+                log "ERROR" "tool names must be alphanumeric with underscores" "${name}" || true
+                return 1
+        fi
 
-	if [[ -n "${TOOL_NAME_ALLOWLIST[*]:-}" ]]; then
-		local allowed
-		allowed=false
-		for allowed in "${TOOL_NAME_ALLOWLIST[@]}"; do
-			if [[ "${name}" == "${allowed}" ]]; then
-				allowed=true
-				break
-			fi
-		done
+        if [[ -n "${TOOL_NAME_ALLOWLIST[*]:-}" ]]; then
+                local allowed
+                allowed=false
+                for allowed in "${TOOL_NAME_ALLOWLIST[@]}"; do
+                        if [[ "${name}" == "${allowed}" ]]; then
+                                allowed=true
+                                break
+                        fi
+                done
 
-		if [[ "${allowed}" != true ]]; then
-			log "ERROR" "tool name not in allowlist" "${name}" || true
-			return 1
-		fi
-	fi
-	TOOLS+=("${name}")
-	printf -v "TOOL_DESCRIPTION_${name}" '%s' "$2"
-	printf -v "TOOL_COMMAND_${name}" '%s' "$3"
-	printf -v "TOOL_SAFETY_${name}" '%s' "$4"
-	printf -v "TOOL_HANDLER_${name}" '%s' "${5:-}"
+                if [[ "${allowed}" != true ]]; then
+                                log "ERROR" "tool name not in allowlist" "${name}" || true
+                                return 1
+                fi
+        fi
+
+        TOOL_REGISTRY_JSON=$(jq -c \
+                --arg name "${name}" \
+                --arg description "$2" \
+                --arg command "$3" \
+                --arg safety "$4" \
+                --arg handler "$5" \
+                '(.names //= [])
+                | (.registry //= {})
+                | (if (.names | index($name)) == null then .names += [$name] else . end)
+                | .registry[$name] = {description:$description, command:$command, safety:$safety, handler:$handler}' <<<"$(tool_registry_json)")
 }

--- a/tests/test_planner.bats
+++ b/tests/test_planner.bats
@@ -13,8 +13,8 @@
 #   Inherits Bats semantics; individual tests assert helper outcomes.
 
 @test "extract_tools_from_plan dedupes and enforces final_answer" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; TOOLS=(alpha beta final_answer); plan=$"1. Use Alpha\n2. Use alpha\n3. Then beta"; mapfile -t tools < <(extract_tools_from_plan "${plan}"); [[ ${#tools[@]} -eq 3 ]]; [[ "${tools[0]}" == "alpha" ]]; [[ "${tools[1]}" == "beta" ]]; [[ "${tools[2]}" == "final_answer" ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; TOOL_NAME_ALLOWLIST=(); init_tool_registry; register_tool alpha "desc" "cmd" "safe" handler; register_tool beta "desc" "cmd" "safe" handler; register_tool final_answer "desc" "cmd" "safe" handler; plan=$"1. Use Alpha\n2. Use alpha\n3. Then beta"; mapfile -t tools < <(extract_tools_from_plan "${plan}"); [[ ${#tools[@]} -eq 3 ]]; [[ "${tools[0]}" == "alpha" ]]; [[ "${tools[1]}" == "beta" ]]; [[ "${tools[2]}" == "final_answer" ]]'
+        [ "$status" -eq 0 ]
 }
 
 @test "build_plan_entries_from_tools omits final_answer" {
@@ -28,11 +28,11 @@
 }
 
 @test "initialize_react_state seeds defaults" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; state_prefix=state; initialize_react_state "${state_prefix}" "answer me" $"alpha" "alpha|query|0" "1. alpha"; [[ "${state_user_query}" == "answer me" ]]; [[ "${state_allowed_tools}" == "alpha" ]]; [[ "${state_plan_index}" == "0" ]]; [[ "${state_max_steps}" -eq ${MAX_STEPS:-6} ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; state_prefix=state; initialize_react_state "${state_prefix}" "answer me" $"alpha" "alpha|query|0" "1. alpha"; [[ "$(state_get "${state_prefix}" "user_query")" == "answer me" ]]; [[ "$(state_get "${state_prefix}" "allowed_tools")" == "alpha" ]]; [[ "$(state_get "${state_prefix}" "plan_index")" == "0" ]]; [[ "$(state_get "${state_prefix}" "max_steps")" -eq ${MAX_STEPS:-6} ]]'
+        [ "$status" -eq 0 ]
 }
 
 @test "validate_tool_permission records disallowed tools" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; state_prefix=state; initialize_react_state "${state_prefix}" "answer me" $"alpha" "" "1. alpha"; validate_tool_permission "${state_prefix}" beta; [[ "$?" -eq 1 ]]; [[ "${state_history}" == *"not permitted"* ]]'
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/planner.sh; state_prefix=state; initialize_react_state "${state_prefix}" "answer me" $"alpha" "" "1. alpha"; validate_tool_permission "${state_prefix}" beta; [[ "$?" -eq 1 ]]; [[ "$(state_get "${state_prefix}" "history")" == *"not permitted"* ]]'
 	[ "$status" -eq 0 ]
 }

--- a/tests/test_settings.bats
+++ b/tests/test_settings.bats
@@ -1,14 +1,27 @@
 #!/usr/bin/env bats
 
 @test "settings helpers store and retrieve values without associative arrays" {
-	run bash -lc 'source ./src/runtime.sh; create_default_settings compat; settings_set compat sample "value"; printf "%s" "$(settings_get compat sample)"'
-	[ "$status" -eq 0 ]
-	[ "$output" = "value" ]
+        run bash -lc 'source ./src/runtime.sh; create_default_settings compat; settings_set_json compat sample "value"; json="$(settings_get_json_document compat)"; printf "%s|%s" "$(settings_get_json compat sample)" "$(jq -r ".sample" <<<"${json}")"'
+        [ "$status" -eq 0 ]
+        [ "$output" = "value|value" ]
+}
+
+@test "create_default_settings wires derived defaults" {
+        run bash -lc 'source ./src/runtime.sh; create_default_settings compat; config_dir="$(settings_get_json compat config_dir)"; config_file="$(settings_get_json compat config_file)"; printf "%s\n%s" "${config_dir}" "${config_file}"'
+        [ "$status" -eq 0 ]
+        [[ "${lines[1]}" = "${lines[0]}/config.env" ]]
+}
+
+@test "settings json helpers round-trip through globals" {
+        run bash -lc 'source ./src/runtime.sh; create_default_settings compat; settings_set_json compat llama_bin "/custom/bin"; apply_settings_to_globals compat; before="${LLAMA_BIN}"; LLAMA_BIN="/changed/bin"; capture_globals_into_settings compat; after="$(settings_get_json compat llama_bin)"; printf "%s\n%s" "${before}" "${after}"'
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "/custom/bin" ]
+        [ "${lines[1]}" = "/changed/bin" ]
 }
 
 @test "render_plan_outputs sets action when plan-only is enabled" {
-	run bash -lc 'source ./src/runtime.sh; create_default_settings compat; settings_set compat plan_only true; render_plan_outputs action compat "terminal" "tool|echo 1|0.2" "outline"; printf "%s" "${action}"'
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"exit" ]]
-	[[ "$output" == *"Suggested tools"* ]]
+        run bash -lc 'source ./src/runtime.sh; create_default_settings compat; settings_set compat plan_only true; render_plan_outputs action compat "terminal" "tool|echo 1|0.2" "outline"; printf "%s" "${action}"'
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"exit" ]]
+        [[ "$output" == *"Suggested tools"* ]]
 }

--- a/tests/test_tools_registry.bats
+++ b/tests/test_tools_registry.bats
@@ -13,16 +13,21 @@
 #   Inherits Bats semantics; individual tests assert registry behavior.
 
 @test "register_tool enforces required arguments" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe"'
-	[ "$status" -eq 1 ]
-}
-
-@test "init_tool_registry resets shared arrays" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe" handler_alpha; register_tool beta "describe" "cmd" "safe" handler_beta; init_tool_registry; [[ ${#TOOLS[@]} -eq 0 ]]; [[ -z "${TOOL_HANDLER_alpha:-}" ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe"'
+        [ "$status" -eq 1 ]
 }
 
 @test "register_tool captures handler and descriptors" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; init_tool_registry; register_tool alpha "describe" "cmd" "safe" handler_alpha; [[ "$(tool_description alpha)" == "describe" ]]; [[ "$(tool_command alpha)" == "cmd" ]]; [[ "$(tool_safety alpha)" == "safe" ]]; [[ "$(tool_handler alpha)" == "handler_alpha" ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; init_tool_registry; register_tool alpha "describe" "cmd" "safe" handler_alpha; [[ "$(tool_description alpha)" == "describe" ]]; [[ "$(tool_command alpha)" == "cmd" ]]; [[ "$(tool_safety alpha)" == "safe" ]]; [[ "$(tool_handler alpha)" == "handler_alpha" ]]; mapfile -t names < <(tool_names); [[ ${names[0]} == "alpha" ]]'
+        [ "$status" -eq 0 ]
+}
+
+@test "init_tool_registry resets shared registry" {
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; register_tool alpha "describe" "cmd" "safe" handler_alpha; register_tool beta "describe" "cmd" "safe" handler_beta; init_tool_registry; [[ -z "$(tool_names)" ]]; [[ "$(tool_description alpha)" = "" ]]'
+        [ "$status" -eq 0 ]
+}
+
+@test "register_tool enforces allowlist" {
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/tools/registry.sh; TOOL_NAME_ALLOWLIST=(alpha); register_tool beta "describe" "cmd" "safe" handler_beta'
+        [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
## Summary
- refactor runtime settings helpers to use JSON documents with jq and update default handling
- replace the tool registry globals with a JSON-backed store and adjust planner/tool consumers
- migrate planner state helpers to JSON, updating history handling and bats coverage

## Testing
- bats tests/test_settings.bats
- bats tests/test_tools_registry.bats
- bats tests/test_planner.bats
- bats tests/test_modules.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693775fa75d4832598288d15496fc976)