### PR TITLE
Propagate llama.cpp failures to callers

### DIFF
--- a/tests/lib/test_llama_client.bats
+++ b/tests/lib/test_llama_client.bats
@@ -52,7 +52,7 @@ SCRIPT
 }
 
 @test "llama_infer uses grammar file flag for non-JSON grammars" {
-	run bash -lc '
+        run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 args_dir="$(mktemp -d)"
                 args_file="${args_dir}/args.txt"
@@ -73,5 +73,33 @@ SCRIPT
                 [[ "${args[*]}" == *"${args_dir}/grammar.gbnf"* ]]
                 [[ " ${args[*]} " != *" -r "* ]]
         '
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
+}
+
+@test "llama_infer returns llama exit code and logs stderr" {
+        run bash -lc '
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+                args_dir="$(mktemp -d)"
+                mock_binary="${args_dir}/mock_llama.sh"
+                cat >"${mock_binary}" <<SCRIPT
+#!/usr/bin/env bash
+echo "fatal llama error" >&2
+exit 42
+SCRIPT
+                chmod +x "${mock_binary}"
+                export LLAMA_AVAILABLE=true
+                export LLAMA_BIN="${mock_binary}"
+                export MODEL_REPO=demo/repo
+                export MODEL_FILE=model.gguf
+                source ./src/lib/llama_client.sh
+                llama_infer "prompt" "STOP" 5
+        '
+        [ "$status" -eq 42 ]
+        detail=$(printf '%s\n' "${output}" | jq -r '.detail')
+        [[ "${detail}" == *"mock_llama.sh"* ]]
+        [[ "${detail}" == *"--hf-repo demo/repo"* ]]
+        [[ "${detail}" == *"--hf-file model.gguf"* ]]
+        [[ "${detail}" == *"-p prompt"* ]]
+        [[ "${detail}" == *"-r STOP"* ]]
+        [[ "${detail}" == *"fatal llama error"* ]]
 }


### PR DESCRIPTION
## Summary
- capture llama.cpp invocation arguments and stderr when inference fails
- return the underlying llama.cpp exit code from llama_infer
- add bats coverage to verify failure propagation and logging contents

## Testing
- bats tests/lib/test_llama_client.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939da792ac883258bff21d3f1a8f922)