### PR TITLE
Refine planner normalization and fallback coverage

### DIFF
--- a/src/lib/planner.sh
+++ b/src/lib/planner.sh
@@ -58,11 +58,11 @@ normalize_planner_plan() {
 
 	raw="$(cat)"
 
-	# Extract the first bracketed JSON array (non-greedy) across newlines.
-	plan="$(
-		printf '%s' "$raw" |
-			perl -0777 -ne 'if (/\[[\s\S]*?\]/) { print $& }'
-	)"
+        # Extract the first bracketed JSON array (non-greedy) across newlines using jq only.
+        plan="$(
+                printf '%s' "$raw" |
+                        jq -Rsr -r '(match("(?s)\\[[\\s\\S]*?\\]") // {string:""}).string'
+        )"
 
 	if [[ -z "${plan:-}" ]]; then
 		log "ERROR" "normalize_planner_plan: no JSON array found in planner output" "" >&2

--- a/tests/core/test_planner.bats
+++ b/tests/core/test_planner.bats
@@ -28,13 +28,37 @@
 }
 
 @test "append_final_answer_step emits array with final step" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; plan_json=$"[\"alpha via terminal\"]"; with_final=$(append_final_answer_step "${plan_json}"); outline=$(plan_json_to_outline "${with_final}"); [[ "${outline}" == *"1. alpha via terminal"* ]]; [[ "${outline}" == *"Use final_answer to summarize the result for the user."* ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; plan_json=$"[\"alpha via terminal\"]"; with_final=$(append_final_answer_step "${plan_json}"); outline=$(plan_json_to_outline "${with_final}"); [[ "${outline}" == *"1. alpha via terminal"* ]]; [[ "${outline}" == *"Use final_answer to summarize the result for the user."* ]]'
+        [ "$status" -eq 0 ]
+}
+
+@test "normalize_planner_plan falls back when no JSON array present" {
+        run bash -lc '
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+                source ./src/lib/planner.sh
+
+                plan_json="$(printf "1) First thing\n- second thing\n" | normalize_planner_plan)"
+
+                [[ "${plan_json}" == "[\"First thing\",\"second thing\"]" ]]
+        '
+
+        [ "$status" -eq 0 ]
+}
+
+@test "normalize_planner_plan fails when fallback outline is empty" {
+        run bash -lc '
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+                source ./src/lib/planner.sh
+
+                printf "\n\n" | normalize_planner_plan
+        '
+
+        [ "$status" -eq 1 ]
 }
 
 @test "build_plan_entries_from_tools omits final_answer" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; entries=$(build_plan_entries_from_tools $'"'"'alpha\nbeta\nfinal_answer'"'"' "Tell me"); first=$(printf "%s" "${entries}" | sed -n "1p"); second=$(printf "%s" "${entries}" | sed -n "2p"); [[ "${first}" == "alpha|Tell me|0" ]]; [[ "${second}" == "beta|Tell me|0" ]]; [[ "${entries}" != *"final_answer"* ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; entries=$(build_plan_entries_from_tools $'"'"'alpha\nbeta\nfinal_answer'"'"' "Tell me"); first=$(printf "%s" "${entries}" | sed -n "1p"); second=$(printf "%s" "${entries}" | sed -n "2p"); [[ "${first}" == "alpha|Tell me|0" ]]; [[ "${second}" == "beta|Tell me|0" ]]; [[ "${entries}" != *"final_answer"* ]]'
+        [ "$status" -eq 0 ]
 }
 
 @test "should_prompt_for_tool respects execution toggles" {


### PR DESCRIPTION
## Summary
- replace the Perl-based planner output extraction with a jq-only approach
- add tests verifying fallback JSON derivation when planner output lacks an array
- confirm failure behavior when fallback outlines are empty

## Testing
- bats tests/core/test_planner.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939dc971bbc83259e25c8743b7e96a2)