### PR TITLE
Fix installer offline installs and stabilize planner

### DIFF
--- a/tests/core/test_planner.bats
+++ b/tests/core/test_planner.bats
@@ -28,12 +28,12 @@
 }
 
 @test "append_final_answer_step emits array with final step" {
-        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; plan_json=$"[\"alpha via terminal\"]"; with_final=$(append_final_answer_step "${plan_json}"); outline=$(plan_json_to_outline "${with_final}"); [[ "${outline}" == *"1. alpha via terminal"* ]]; [[ "${outline}" == *"Use final_answer to summarize the result for the user."* ]]'
-        [ "$status" -eq 0 ]
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; plan_json=$"[\"alpha via terminal\"]"; with_final=$(append_final_answer_step "${plan_json}"); outline=$(plan_json_to_outline "${with_final}"); [[ "${outline}" == *"1. alpha via terminal"* ]]; [[ "${outline}" == *"Use final_answer to summarize the result for the user."* ]]'
+	[ "$status" -eq 0 ]
 }
 
 @test "normalize_planner_plan falls back when no JSON array present" {
-        run bash -lc '
+	run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 source ./src/lib/planner.sh
 
@@ -42,23 +42,23 @@
                 [[ "${plan_json}" == "[\"First thing\",\"second thing\"]" ]]
         '
 
-        [ "$status" -eq 0 ]
+	[ "$status" -eq 0 ]
 }
 
 @test "normalize_planner_plan fails when fallback outline is empty" {
-        run bash -lc '
+	run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 source ./src/lib/planner.sh
 
                 printf "\n\n" | normalize_planner_plan
         '
 
-        [ "$status" -eq 1 ]
+	[ "$status" -eq 1 ]
 }
 
 @test "build_plan_entries_from_tools omits final_answer" {
-        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; entries=$(build_plan_entries_from_tools $'"'"'alpha\nbeta\nfinal_answer'"'"' "Tell me"); first=$(printf "%s" "${entries}" | sed -n "1p"); second=$(printf "%s" "${entries}" | sed -n "2p"); [[ "${first}" == "alpha|Tell me|0" ]]; [[ "${second}" == "beta|Tell me|0" ]]; [[ "${entries}" != *"final_answer"* ]]'
-        [ "$status" -eq 0 ]
+	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/planner.sh; entries=$(build_plan_entries_from_tools $'"'"'alpha\nbeta\nfinal_answer'"'"' "Tell me"); first=$(printf "%s" "${entries}" | sed -n "1p"); second=$(printf "%s" "${entries}" | sed -n "2p"); [[ "${first}" == "alpha|Tell me|0" ]]; [[ "${second}" == "beta|Tell me|0" ]]; [[ "${entries}" != *"final_answer"* ]]'
+	[ "$status" -eq 0 ]
 }
 
 @test "should_prompt_for_tool respects execution toggles" {

--- a/tests/lib/test_llama_client.bats
+++ b/tests/lib/test_llama_client.bats
@@ -52,7 +52,7 @@ SCRIPT
 }
 
 @test "llama_infer uses grammar file flag for non-JSON grammars" {
-        run bash -lc '
+	run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 args_dir="$(mktemp -d)"
                 args_file="${args_dir}/args.txt"
@@ -73,11 +73,11 @@ SCRIPT
                 [[ "${args[*]}" == *"${args_dir}/grammar.gbnf"* ]]
                 [[ " ${args[*]} " != *" -r "* ]]
         '
-        [ "$status" -eq 0 ]
+	[ "$status" -eq 0 ]
 }
 
 @test "llama_infer returns llama exit code and logs stderr" {
-        run bash -lc '
+	run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 args_dir="$(mktemp -d)"
                 mock_binary="${args_dir}/mock_llama.sh"
@@ -94,18 +94,18 @@ SCRIPT
                 source ./src/lib/llama_client.sh
                 llama_infer "prompt" "STOP" 5
         '
-        [ "$status" -eq 42 ]
-        detail=$(printf '%s\n' "${output}" | jq -r '.detail')
-        [[ "${detail}" == *"mock_llama.sh"* ]]
-        [[ "${detail}" == *"--hf-repo demo/repo"* ]]
-        [[ "${detail}" == *"--hf-file model.gguf"* ]]
-        [[ "${detail}" == *"-p prompt"* ]]
-        [[ "${detail}" == *"-r STOP"* ]]
-        [[ "${detail}" == *"fatal llama error"* ]]
+	[ "$status" -eq 42 ]
+	detail=$(printf '%s\n' "${output}" | jq -r '.detail')
+	[[ "${detail}" == *"mock_llama.sh"* ]]
+	[[ "${detail}" == *"--hf-repo demo/repo"* ]]
+	[[ "${detail}" == *"--hf-file model.gguf"* ]]
+	[[ "${detail}" == *"-p prompt"* ]]
+	[[ "${detail}" == *"-r STOP"* ]]
+	[[ "${detail}" == *"fatal llama error"* ]]
 }
 
 @test "llama_infer interrupts hung llama when timeout configured" {
-        run bash -lc '
+	run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 args_dir="$(mktemp -d)"
                 mock_binary="${args_dir}/mock_llama.sh"
@@ -123,10 +123,10 @@ SCRIPT
                 source ./src/lib/llama_client.sh
                 llama_infer "prompt" "" 4
         '
-        [ "$status" -eq 124 ]
-        message=$(printf '%s\n' "${output}" | jq -r '.message')
-        [[ "${message}" == "llama inference timed out" ]]
-        detail=$(printf '%s\n' "${output}" | jq -r '.detail')
-        [[ "${detail}" == *"timeout_seconds=1"* ]]
-        [[ "${detail}" == *"elapsed_ms="* ]]
+	[ "$status" -eq 124 ]
+	message=$(printf '%s\n' "${output}" | jq -r '.message')
+	[[ "${message}" == "llama inference timed out" ]]
+	detail=$(printf '%s\n' "${output}" | jq -r '.detail')
+	[[ "${detail}" == *"timeout_seconds=1"* ]]
+	[[ "${detail}" == *"elapsed_ms="* ]]
 }


### PR DESCRIPTION
## Summary
- add installer support for custom prefixes, offline bundles, and copy-based installs while keeping self-tests aligned with the packaged layout
- capture llama.cpp output for inference calls and harden planner normalization of JSON plans
- refresh shell formatting across planner and llama client tests

## Testing
- bats tests/cli/test_all.sh tests/cli/test_install.bats tests/cli/test_main.bats tests/core/test_modules.bats tests/tools/test_notes.bats
- shellcheck $(find src scripts tests -type f \( -name '*.sh' -o -name '*.bats' -o -name 'okso' \) -print0 | xargs -0)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f3fcd08c8325bc05b7ad98fe8038)