### PR TITLE
Run installer tests on macOS with fewer mocks

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   installer:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -17,8 +17,8 @@ jobs:
         
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck shfmt
+          brew update
+          brew install shellcheck shfmt
 
       - name: Lint installer
         run: |

--- a/tests/install/test_install_features.bats
+++ b/tests/install/test_install_features.bats
@@ -14,86 +14,41 @@
 #   Inherits Bats semantics; individual tests assert script exit codes explicitly.
 
 setup() {
-	TEST_ROOT="${BATS_TMPDIR}/okso-install-feature"
-	mkdir -p "${TEST_ROOT}" "${TEST_ROOT}/bin"
-	export DO_INSTALLER_SKIP_SELF_TEST=true
-	export DO_LINK_DIR="${TEST_ROOT}/bin"
+        TEST_ROOT="${BATS_TMPDIR}/okso-install-feature"
+        mkdir -p "${TEST_ROOT}" "${TEST_ROOT}/bin"
+        if [ "$(uname -s)" != "Darwin" ]; then
+                skip "Installer tests require macOS"
+        fi
+        export DO_INSTALLER_SKIP_SELF_TEST=true
+        export DO_LINK_DIR="${TEST_ROOT}/bin"
 }
 
 teardown() {
-	rm -rf "${TEST_ROOT}" 2>/dev/null || true
-}
-
-create_mock_macos_tools() {
-	local mock_path="$1"
-	mkdir -p "${mock_path}"
-
-	cat >"${mock_path}/uname" <<'EOM_UNAME'
-#!/usr/bin/env bash
-echo "Darwin"
-EOM_UNAME
-	chmod +x "${mock_path}/uname"
-}
-
-create_mock_brew() {
-	local mock_path="$1"
-	local install_dir="$2"
-	mkdir -p "${mock_path}" "${install_dir}/src/bin" "${install_dir}/grammars" "${install_dir}/lib"
-
-	cp src/bin/okso "${install_dir}/src/bin/okso"
-	cp -R src/grammars/* "${install_dir}/grammars/"
-	cp src/lib/grammar.sh "${install_dir}/lib/grammar.sh"
-
-	cat >"${mock_path}/brew" <<'EOM_BREW'
-#!/usr/bin/env bash
-if [ "$1" = "install" ]; then
-        exit 0
-fi
-if [ "$1" = "uninstall" ]; then
-        rm -rf "$INSTALL_DIR"
-        exit 0
-fi
-if [ "$1" = "--prefix" ] || [ "$1" = "prefix" ]; then
-        if [ "$2" = "okso" ]; then
-                printf '%s\n' "$INSTALL_DIR"
-                exit 0
-        fi
-fi
-exit 0
-EOM_BREW
-	sed -i "1iINSTALL_DIR=${install_dir}" "${mock_path}/brew"
-	chmod +x "${mock_path}/brew"
+        rm -rf "${TEST_ROOT}" 2>/dev/null || true
 }
 
 @test "supports dry-run without modifying filesystem" {
-	local mock_path="${TEST_ROOT}/mock-bin"
-	create_mock_macos_tools "${mock_path}"
-	PATH="${mock_path}:${PATH}" run ./scripts/install.sh --dry-run
+        run ./scripts/install.sh --dry-run --prefix "${TEST_ROOT}/prefix"
 
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"Dry run enabled"* ]]
-	[ ! -L "${DO_LINK_DIR}/okso" ]
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Dry run enabled"* ]]
+        [ ! -L "${DO_LINK_DIR}/okso" ]
 }
 
 @test "fails when Homebrew is unavailable" {
-	local mock_path="${TEST_ROOT}/mock-bin"
-	create_mock_macos_tools "${mock_path}"
-	PATH="${mock_path}:${PATH}" run ./scripts/install.sh
+        local limited_path="/usr/bin:/bin"
+        PATH="${limited_path}" run ./scripts/install.sh --prefix "${TEST_ROOT}/prefix"
 
-	[ "$status" -eq 2 ]
-	[[ "$output" == *"Homebrew is required"* ]]
+        [ "$status" -eq 2 ]
+        [[ "$output" == *"Homebrew is required"* ]]
 }
 
 @test "installs via Homebrew formula and links binary" {
-	local mock_path="${TEST_ROOT}/mock-bin"
-	local install_dir="${TEST_ROOT}/brew-cellar"
+        local install_dir="${TEST_ROOT}/brew-cellar"
 
-	create_mock_macos_tools "${mock_path}"
-	create_mock_brew "${mock_path}" "${install_dir}"
+        run ./scripts/install.sh --prefix "${install_dir}"
 
-	PATH="${mock_path}:${PATH}" run ./scripts/install.sh
-
-	[ "$status" -eq 0 ]
-	[ -L "${DO_LINK_DIR}/okso" ]
-	[ "$(readlink "${DO_LINK_DIR}/okso")" = "${install_dir}/src/bin/okso" ]
+        [ "$status" -eq 0 ]
+        [ -L "${DO_LINK_DIR}/okso" ]
+        [ "$(readlink "${DO_LINK_DIR}/okso")" = "${install_dir}/bin/okso" ]
 }


### PR DESCRIPTION
## Summary
- move installer workflow to macOS runners and install dependencies via Homebrew
- simplify installer bats tests to rely on the macOS environment instead of extensive mocking
- skip installer tests automatically when not running on macOS

## Testing
- bats tests/cli/test_install.bats tests/install/test_install_features.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a07f4e0848325b6196d01c014cee8)