### PR TITLE
Add jq dependency guard to runtime helpers

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -12,6 +12,8 @@ bats tests/cli/test_all.sh tests/cli/test_install.sh tests/cli/test_main.sh test
 
 The Bats suite covers CLI help/version output, confirmation prompts, deterministic mock scoring via `tests/fixtures/mock_llama.sh`, and graceful handling when `LLAMA_BIN` is missing.
 
+Sourcing runtime helpers now enforces the presence of `jq` and will exit with a structured dependency error when the binary is unavailable; ensure your development environment installs `jq` before running the scripts.
+
 Set `TESTING_PASSTHROUGH=true` when running the suite to disable llama.cpp invocation and surface test-only code paths without muting runtime errors that depend on llama availability.
 
 ### Coverage collection

--- a/src/lib/errors.sh
+++ b/src/lib/errors.sh
@@ -20,21 +20,37 @@
 #   log_debug returns 0.
 
 emit_error_envelope() {
-	# Emits a JSON error envelope with consistent metadata.
-	# Arguments:
-	#   $1 - context (string; optional; defaults to ERROR_CONTEXT/TOOL_NAME/runtime)
-	#   $2 - category (string; required)
-	#   $3 - message (string; required)
-	local context category message
-	context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
-	category="$2"
-	message="$3"
+        # Emits a JSON error envelope with consistent metadata.
+        # Arguments:
+        #   $1 - context (string; optional; defaults to ERROR_CONTEXT/TOOL_NAME/runtime)
+        #   $2 - category (string; required)
+        #   $3 - message (string; required)
+        local context category message escaped_context escaped_category escaped_message
+        context=${1:-${ERROR_CONTEXT:-${TOOL_NAME:-runtime}}}
+        category="$2"
+        message="$3"
 
-	jq -cn \
-		--arg name "${context}" \
-		--arg category "${category}" \
-		--arg message "${message}" \
-		'{name:$name, category:$category, message:$message}'
+        if command -v jq >/dev/null 2>&1; then
+                jq -cn \
+                        --arg name "${context}" \
+                        --arg category "${category}" \
+                        --arg message "${message}" \
+                        '{name:$name, category:$category, message:$message}'
+                return
+        fi
+
+        escaped_context=${context//\\/\\\\}
+        escaped_context=${escaped_context//"/\\"}
+        escaped_context=${escaped_context//$'\n'/\\n}
+        escaped_category=${category//\\/\\\\}
+        escaped_category=${escaped_category//"/\\"}
+        escaped_category=${escaped_category//$'\n'/\\n}
+        escaped_message=${message//\\/\\\\}
+        escaped_message=${escaped_message//"/\\"}
+        escaped_message=${escaped_message//$'\n'/\\n}
+
+        printf '{"name":"%s","category":"%s","message":"%s"}\n' \
+                "${escaped_context}" "${escaped_category}" "${escaped_message}"
 }
 
 die() {

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -47,6 +47,10 @@ LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./errors.sh disable=SC1091
 source "${LIB_DIR}/errors.sh"
 
+if ! command -v jq >/dev/null 2>&1; then
+        die runtime dependency "Missing jq dependency. Install jq with your package manager (e.g., apt-get install jq or brew install jq) and re-run."
+fi
+
 # Simple namespaced settings helpers backed by JSON blobs to avoid
 # associative-array dependencies on macOS's legacy Bash 3.2. All values are
 # stored on ${namespace}_json and accessed via jq for durability.

--- a/tests/runtime/test_jq_dependency.sh
+++ b/tests/runtime/test_jq_dependency.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+@test "runtime guard emits structured error when jq is missing" {
+        run bash --noprofile --norc -c '
+                temp_path="$(mktemp -d)"
+                ln -s /bin/dirname "${temp_path}/dirname"
+                PATH="${temp_path}"
+                export PATH
+                source ./src/lib/runtime.sh
+        '
+
+        [ "$status" -ne 0 ]
+        [ "$output" = '{"name":"runtime","category":"dependency","message":"Missing jq dependency. Install jq with your package manager (e.g., apt-get install jq or brew install jq) and re-run."}' ]
+}


### PR DESCRIPTION
## Summary
- add a jq-free fallback when emitting structured errors
- guard runtime helpers to exit with actionable guidance when jq is missing
- document the enforced jq check and cover it with a runtime Bats test

## Testing
- bats tests/runtime/test_settings.sh tests/runtime/test_jq_dependency.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a22eee35083259d88744889011683)