### PR TITLE
Refine planner logging emission

### DIFF
--- a/src/lib/planner.sh
+++ b/src/lib/planner.sh
@@ -500,10 +500,6 @@ finalize_react_result() {
 	fi
 
 	log_pretty "INFO" "Final answer" "$(state_get "${state_name}" "final_answer")"
-
-	if [[ -n "$(state_get "${state_name}" "plan_outline")" ]]; then
-		log_pretty "INFO" "Plan outline" "$(state_get "${state_name}" "plan_outline")"
-	fi
 	if [[ -z "$(state_get "${state_name}" "history")" ]]; then
 		log "INFO" "Execution summary" "No tool runs"
 	else


### PR DESCRIPTION
## Summary
- prevent finalize_react_result from re-logging the plan outline and keep execution summary emission focused on finalization
- add coverage to confirm plan outline logging happens once and that log messages follow execution order for direct and react flows

## Testing
- shellcheck src/lib/planner.sh tests/core/test_modules.sh
- bats tests/core/test_modules.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a2d970ecc8325b5b07e8c20d9090d)