### PR TITLE
Refactor mail recipient parsing for Bash 3 compatibility

### DIFF
--- a/src/tools/mail/draft.sh
+++ b/src/tools/mail/draft.sh
@@ -47,7 +47,10 @@ tool_mail_draft() {
 		return 1
 	fi
 
-	mapfile -t recipients < <(mail_build_recipient_args "${recipients_line}")
+        local -a recipients
+        while IFS= read -r recipient; do
+                recipients+=("${recipient}")
+        done < <(mail_build_recipient_args "${recipients_line}")
 
 	log "INFO" "Creating Apple Mail draft" "${subject}" || true
 	mail_run_script "${subject}" "${body}" "${recipients[@]}" <<'APPLESCRIPT'

--- a/src/tools/mail/send.sh
+++ b/src/tools/mail/send.sh
@@ -40,7 +40,10 @@ tool_mail_send() {
 		return 1
 	fi
 
-	mapfile -t recipients < <(mail_split_recipients "${recipients_line}")
+        local -a recipients
+        while IFS= read -r recipient; do
+                recipients+=("${recipient}")
+        done < <(mail_split_recipients "${recipients_line}")
 	if ((${#recipients[@]} == 0)); then
 		log "ERROR" "At least one recipient is required to send" "${TOOL_QUERY:-}" || true
 		return 1

--- a/tests/tools/test_mail.sh
+++ b/tests/tools/test_mail.sh
@@ -12,49 +12,83 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "mail tools warn when run off macOS" {
-	run bash -lc 'source ./src/tools/mail/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_QUERY=$'"'"'a'"'"'; tool_mail_list_inbox'
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"Apple Mail is only available on macOS"* ]]
+  run bash -lc 'source ./src/tools/mail/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_QUERY=$'"'"'a'"'"'; tool_mail_list_inbox'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Apple Mail is only available on macOS"* ]]
 }
 
 @test "mail_draft forwards recipients subject and body to osascript" {
-	run bash -lc '
-                export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
-                export MAIL_STUB_LOG="$(mktemp)"
-                export IS_MACOS=true
-                export VERBOSITY=0
-                TOOL_QUERY=$'"'"'a@example.com, b@example.com\nSubject line\nBody text'"'"'
-                source ./src/tools/mail/index.sh
-                tool_mail_draft
-                cat "${MAIL_STUB_LOG}"
-        '
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"ARGS: - Subject\\ line Body\\ text a@example.com b@example.com"* ]]
-	[[ "$output" == *"Body\\ text"* ]]
+  run bash -lc '
+    export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+    export MAIL_STUB_LOG="$(mktemp)"
+    export IS_MACOS=true
+    export VERBOSITY=0
+    TOOL_QUERY=$'"'"'a@example.com, b@example.com\nSubject line\nBody text'"'"'
+    source ./src/tools/mail/index.sh
+    tool_mail_draft
+    cat "${MAIL_STUB_LOG}"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ARGS: - Subject\\ line Body\\ text a@example.com b@example.com"* ]]
+  [[ "$output" == *"Body\\ text"* ]]
+}
+
+@test "mail_draft parses recipients without mapfile (Bash 3 compatible)" {
+  run bash -lc '
+    enable -n mapfile
+    export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+    export MAIL_STUB_LOG="$(mktemp)"
+    export IS_MACOS=true
+    export VERBOSITY=0
+    TOOL_QUERY=$'"'"'a@example.com , b@example.com , , c@example.com\nSubject line\nBody text'"'"'
+    source ./src/tools/mail/index.sh
+    tool_mail_draft
+    cat "${MAIL_STUB_LOG}"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ARGS: - Subject\\ line Body\\ text a@example.com b@example.com c@example.com"* ]]
+  [[ "$output" == *"Body\\ text"* ]]
 }
 
 @test "mail_send requires a recipient" {
-	run bash -lc '
-                export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
-                export IS_MACOS=true
-                export VERBOSITY=1
-                TOOL_QUERY=$'"'"'\nSubject only'"'"'
-                source ./src/tools/mail/index.sh
-                tool_mail_send
-        '
-	[ "$status" -eq 1 ]
-	[[ "$output" == *"Unable to parse mail envelope"* ]]
+  run bash -lc '
+    export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+    export IS_MACOS=true
+    export VERBOSITY=1
+    TOOL_QUERY=$'"'"'\nSubject only'"'"'
+    source ./src/tools/mail/index.sh
+    tool_mail_send
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unable to parse mail envelope"* ]]
+}
+
+@test "mail_send parses recipients without mapfile (Bash 3 compatible)" {
+  run bash -lc '
+    enable -n mapfile
+    export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+    export MAIL_STUB_LOG="$(mktemp)"
+    export IS_MACOS=true
+    export VERBOSITY=0
+    TOOL_QUERY=$'"'"'first@example.com,second@example.com\nSubject line\nBody text'"'"'
+    source ./src/tools/mail/index.sh
+    tool_mail_send
+    cat "${MAIL_STUB_LOG}"
+  '
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ARGS: - Subject\\ line Body\\ text first@example.com second@example.com"* ]]
+  [[ "$output" == *"Body\\ text"* ]]
 }
 
 @test "mail_search requires a search term" {
-	run bash -lc '
-                export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
-                export IS_MACOS=true
-                export VERBOSITY=1
-                TOOL_QUERY="   "
-                source ./src/tools/mail/index.sh
-                tool_mail_search
-        '
-	[ "$status" -eq 1 ]
-	[[ "$output" == *"Search term is required"* ]]
+  run bash -lc '
+    export MAIL_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+    export IS_MACOS=true
+    export VERBOSITY=1
+    TOOL_QUERY="   "
+    source ./src/tools/mail/index.sh
+    tool_mail_search
+  '
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Search term is required"* ]]
 }


### PR DESCRIPTION
## Summary
- replace mapfile usage in mail_send and mail_draft with portable loops
- keep recipient validation behavior intact while supporting older Bash versions
- add bats coverage for recipient parsing when mapfile is unavailable

## Testing
- bats tests/tools/test_mail.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ace35dfe88325a50cb02141d2553a)