### PR TITLE
Make render_box POSIX-compatible

### DIFF
--- a/src/lib/formatting.sh
+++ b/src/lib/formatting.sh
@@ -67,10 +67,16 @@ render_box() {
 		width_limit=20
 	fi
 
-	mapfile -t lines < <(printf '%s\n' "${content}" | fold -s -w "${width_limit}")
-	if ((${#lines[@]} == 0)); then
-		lines=("")
-	fi
+        lines=()
+        while IFS= read -r line || [ -n "${line}" ]; do
+                lines+=("${line}")
+        done <<EOF
+$(printf '%s\n' "${content}" | fold -s -w "${width_limit}")
+EOF
+
+        if ((${#lines[@]} == 0)); then
+                lines=("")
+        fi
 
 	max_line_length=0
 	for line in "${lines[@]}"; do

--- a/tests/lib/test_render_box.sh
+++ b/tests/lib/test_render_box.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+#
+# Tests for render_box compatibility with older Bash versions.
+#
+# Usage:
+#   bats tests/lib/test_render_box.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 3+
+
+@test "render_box works without mapfile builtin (Bash 3 compatibility)" {
+        run bash -lc '
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+                enable -n mapfile 2>/dev/null || true
+                source ./src/lib/formatting.sh
+                render_box "Legacy compatibility"
+        '
+        [ "$status" -eq 0 ]
+        [[ "${output}" == *"Legacy compatibility"* ]]
+        [[ "${output}" == *"┌"* ]]
+        [[ "${output}" == *"└"* ]]
+}


### PR DESCRIPTION
## Summary
- replace the mapfile usage in render_box with a POSIX-compatible loop so Bash 3 works
- add a Bats test that disables mapfile to simulate older Bash compatibility

## Testing
- bats tests/lib/test_summary.sh tests/lib/test_render_box.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ace376b488325833bd177f6cbd7d2)