### PR TITLE
Remove mapfile usage in planner outline

### DIFF
--- a/src/lib/planner.sh
+++ b/src/lib/planner.sh
@@ -121,11 +121,15 @@ generate_plan_outline() {
 	local -a planner_tools=()
 	user_query="$1"
 
-	if declare -p TOOLS >/dev/null 2>&1; then
-		planner_tools=("${TOOLS[@]}")
-	else
-		mapfile -t planner_tools < <(tool_names)
-	fi
+        if declare -p TOOLS >/dev/null 2>&1; then
+                planner_tools=("${TOOLS[@]}")
+        else
+                planner_tools=()
+                while IFS= read -r tool_name; do
+                        [[ -z "${tool_name}" ]] && continue
+                        planner_tools+=("${tool_name}")
+                done < <(tool_names)
+        fi
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "WARN" "Using static plan outline because llama is unavailable" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}" >&2

--- a/tests/planner/test_generate_plan_outline.sh
+++ b/tests/planner/test_generate_plan_outline.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+#
+# Regression tests for generate_plan_outline.
+#
+# Usage:
+#   bats tests/planner/test_generate_plan_outline.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+
+@test "generate_plan_outline works when mapfile builtin is unavailable" {
+        run bash -lc '
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+                enable -n mapfile 2>/dev/null || true
+
+                source ./src/lib/planner.sh
+
+                log() { :; }
+
+                LLAMA_AVAILABLE=false
+                output="$(generate_plan_outline "Summarize request")"
+                [[ "${output}" == "1. Use final_answer to respond directly to the user request." ]]
+        '
+        [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- replace the planner outline tool collection logic with a portable read loop instead of `mapfile`
- add a regression bats test ensuring generate_plan_outline works when `mapfile` is unavailable

## Testing
- bats tests/planner/test_generate_plan_outline.sh
- bats tests/planner/test_summary.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae22979f8832599ab169ec571704d)