### PR TITLE
Enhance planner tool formatting with safety guidance

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -22,4 +22,4 @@ Clipboard, Notes, Reminders, Calendar, and Mail helpers rely on `osascript` and 
 
 ## Ranking
 
-When `LLAMA_BIN` is available, the planner asks `llama.cpp` to score tools with names, descriptions, and commands in a single prompt. Without `LLAMA_BIN`, a deterministic keyword heuristic ranks the tools. The resulting ordering drives suggestions and execution.
+When `LLAMA_BIN` is available, the planner asks `llama.cpp` to score tools with names, descriptions, commands, and key safety notes in a single prompt. Without `LLAMA_BIN`, a deterministic keyword heuristic ranks the tools. The resulting ordering drives suggestions and execution.

--- a/src/lib/formatting.sh
+++ b/src/lib/formatting.sh
@@ -22,9 +22,9 @@ LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${LIB_DIR}/logging.sh"
 
 format_tool_descriptions() {
-	# Arguments:
-	#   $1 - newline-delimited allowed tool names (string)
-	#   $2 - callback to format a single tool line (function name)
+        # Arguments:
+        #   $1 - newline-delimited allowed tool names (string)
+        #   $2 - callback to format a single tool line (function name)
 	local allowed_tools formatter tool_lines tool formatted_line
 	allowed_tools="$1"
 	formatter="$2"
@@ -48,7 +48,44 @@ format_tool_descriptions() {
 		fi
 	done <<<"${allowed_tools}"
 
-	printf '%s' "${tool_lines%$'\n'}"
+        printf '%s' "${tool_lines%$'\n'}"
+}
+
+format_tool_details() {
+        # Arguments:
+        #   $1 - tool name (string)
+        local tool description command safety
+        local -a details=()
+        local detail_text=""
+        tool="$1"
+        description="$(tool_description "${tool}")"
+        command="$(tool_command "${tool}")"
+        safety="$(tool_safety "${tool}")"
+
+        if [[ -n "${description}" ]]; then
+                details+=("${description}")
+        fi
+
+        if [[ -n "${command}" ]]; then
+                details+=("Example: ${command}")
+        fi
+
+        if [[ -n "${safety}" ]]; then
+                details+=("Safety: ${safety}")
+        fi
+
+        if ((${#details[@]} == 0)); then
+                return 0
+        fi
+
+        for i in "${!details[@]}"; do
+                if ((i > 0)); then
+                        detail_text+=' | '
+                fi
+                detail_text+="${details[i]}"
+        done
+
+        printf '%s' "${detail_text}"
 }
 
 render_box() {
@@ -146,17 +183,31 @@ emit_boxed_summary() {
 }
 
 format_tool_summary_line() {
-	# Arguments:
-	#   $1 - tool name (string)
-	local tool
-	tool="$1"
-	printf -- '- %s: %s' "${tool}" "$(tool_description "${tool}")"
+        # Arguments:
+        #   $1 - tool name (string)
+        local tool detail_text
+        tool="$1"
+        detail_text="$(format_tool_details "${tool}")"
+
+        if [[ -n "${detail_text}" ]]; then
+                printf -- '- %s: %s' "${tool}" "${detail_text}"
+                return 0
+        fi
+
+        printf -- '- %s' "${tool}"
 }
 
 format_tool_example_line() {
-	# Arguments:
-	#   $1 - tool name (string)
-	local tool
-	tool="$1"
-	printf -- '- %s: %s (example query: %s)' "${tool}" "$(tool_description "${tool}")" "$(tool_command "${tool}")"
+        # Arguments:
+        #   $1 - tool name (string)
+        local tool detail_text
+        tool="$1"
+        detail_text="$(format_tool_details "${tool}")"
+
+        if [[ -n "${detail_text}" ]]; then
+                printf -- '- %s: %s' "${tool}" "${detail_text}"
+                return 0
+        fi
+
+        printf -- '- %s' "${tool}"
 }

--- a/tests/lib/test_formatting.sh
+++ b/tests/lib/test_formatting.sh
@@ -13,29 +13,31 @@
 #   Inherits Bats semantics; individual tests assert helper outcomes.
 
 @test "format_tool_descriptions filters empty lines and applies formatter" {
-	run bash -s <<'EOF'
+        run bash -s <<'EOF'
 cd "$(git rev-parse --show-toplevel)" || exit 1
 source ./src/lib/formatting.sh
 tool_description() { printf "desc-%s" "$1"; }
 tool_command() { printf "cmd-%s" "$1"; }
+tool_safety() { printf "safe-%s" "$1"; }
 input=$'alpha\n\nbeta'
 output="$(format_tool_descriptions "${input}" format_tool_summary_line)"
-expected=$'- alpha: desc-alpha\n- beta: desc-beta'
+expected=$'- alpha: desc-alpha | Example: cmd-alpha | Safety: safe-alpha\n- beta: desc-beta | Example: cmd-beta | Safety: safe-beta'
 [[ "${output}" == "${expected}" ]]
 EOF
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
 }
 
 @test "format_tool_example_line includes command examples" {
-	run bash -lc '
+        run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 source ./src/lib/formatting.sh
                 tool_description() { printf "describe-%s" "$1"; }
                 tool_command() { printf "run-%s" "$1"; }
+                tool_safety() { printf "limit-%s" "$1"; }
                 line="$(format_tool_example_line "demo")"
-                [[ "${line}" == "- demo: describe-demo (example query: run-demo)" ]]
+                [[ "${line}" == "- demo: describe-demo | Example: run-demo | Safety: limit-demo" ]]
         '
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
 }
 
 @test "format_tool_descriptions rejects unknown formatter" {


### PR DESCRIPTION
## Summary
- add a reusable formatter that combines tool descriptions, example invocations, and safety notes for planner prompts
- update summary/example lines to use the richer formatting and refresh tool reference docs

## Testing
- bats tests/lib/test_formatting.sh
- shellcheck src/lib/formatting.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b3fb85b588325be6b846d34a1b00e)