### PR TITLE
Fix react action schema type property

### DIFF
--- a/src/grammars/react_action.schema.json
+++ b/src/grammars/react_action.schema.json
@@ -6,7 +6,7 @@
   "additionalProperties": false,
   "required": ["type", "tool", "query"],
   "properties": {
-    "action_type": {
+    "type": {
       "type": "string",
       "enum": ["tool"]
     },


### PR DESCRIPTION
## Summary
- update the React action schema to constrain the `type` property instead of `action_type`
- keep schema aligned with existing prompts and jq validation

## Testing
- bats tests/core/test_modules.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5066f1a08325ba91965ee2b31e20)