### PR TITLE
Add Bash version guard to okso entrypoint

### DIFF
--- a/src/bin/okso
+++ b/src/bin/okso
@@ -24,12 +24,40 @@
 #   LLAMA_BIN       llama.cpp binary (default: llama-cli).
 #
 # Dependencies:
-#   - bash 5+
+#   - bash 3.2+ (matches the macOS system baseline)
 #   - Optional: llama.cpp binary available on PATH for real scoring.
 #   - Optional: fd, rg for faster search tooling.
 #
 # Exit codes:
 #   0 on success, non-zero on argument or runtime errors.
+
+MIN_BASH_MAJOR=3
+MIN_BASH_MINOR=2
+MIN_BASH_VERSION_STRING="${MIN_BASH_MAJOR}.${MIN_BASH_MINOR}"
+
+if [[ -n "${OKSO_BASH_VERSION_OVERRIDE:-}" ]]; then
+        if [[ "${OKSO_BASH_VERSION_OVERRIDE}" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                current_bash_major="${BASH_REMATCH[1]}"
+                current_bash_minor="${BASH_REMATCH[2]}"
+        else
+                printf 'okso requires a parsable bash version override (expected MAJOR.MINOR); received "%s".\n' "${OKSO_BASH_VERSION_OVERRIDE}" >&2
+                exit 1
+        fi
+else
+        if [[ -z "${BASH_VERSINFO[0]:-}" || -z "${BASH_VERSINFO[1]:-}" ]]; then
+                printf 'okso requires bash %s or newer (documented baseline for macOS); unable to detect the current shell version.\n' "${MIN_BASH_VERSION_STRING}" >&2
+                exit 1
+        fi
+
+        current_bash_major="${BASH_VERSINFO[0]}"
+        current_bash_minor="${BASH_VERSINFO[1]}"
+fi
+
+if (( current_bash_major < MIN_BASH_MAJOR || (current_bash_major == MIN_BASH_MAJOR && current_bash_minor < MIN_BASH_MINOR) )); then
+        printf 'okso requires bash %s or newer (documented baseline for macOS system shells); detected %s.%s. Please upgrade bash or run with the supported version.\n' "${MIN_BASH_VERSION_STRING}" "${current_bash_major}" "${current_bash_minor}" >&2
+        exit 1
+fi
+
 set -euo pipefail
 
 resolve_script_dir() {

--- a/tests/cli/test_main.sh
+++ b/tests/cli/test_main.sh
@@ -17,11 +17,27 @@ EOF
 }
 load ../helpers/log_parsing.sh
 
+@test "allows macOS baseline bash version" {
+        run env OKSO_BASH_VERSION_OVERRIDE=3.2 ./src/bin/okso --help -- "example query"
+
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Usage: ./src/bin/okso"* ]]
+        [[ "$output" != *"requires bash"* ]]
+}
+
+@test "fails fast with descriptive message on too-old bash" {
+        run env OKSO_BASH_VERSION_OVERRIDE=3.1 ./src/bin/okso --help -- "example query"
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"bash 3.2"* ]]
+        [[ "$output" == *"detected 3.1"* ]]
+}
+
 @test "shows help text" {
-	run ./src/bin/okso --help -- "example query"
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"Usage: ./src/bin/okso"* ]]
-	[[ "$output" != *"DO_MODEL"* ]]
+        run ./src/bin/okso --help -- "example query"
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Usage: ./src/bin/okso"* ]]
+        [[ "$output" != *"DO_MODEL"* ]]
 }
 
 @test "includes default model spec in help" {


### PR DESCRIPTION
## Summary
- add an early Bash version guard in the okso entrypoint and update documented dependency baseline
- support testable version overrides so the script exits with a clear message on unsupported shells
- expand CLI bats coverage for baseline and unsupported Bash versions

## Testing
- bats tests/cli/test_main.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b5167afb883258cbb1e45135e8607)