### PR TITLE
Add sandboxed Python REPL tool

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3,6 +3,7 @@
 The planner registers these tools (each implemented under `src/tools/<name>.sh`):
 
 - `terminal`: persistent working directory with `pwd`, `ls`, `cd`, `find`, `grep`, `stat`, `wc`, `du`, `base64 encode|decode`, and guarded mutations (`rm -i`, `mkdir`, `mv`, `cp`, `touch`). Uses `open` on macOS.
+- `python_repl`: run Python snippets in an ephemeral sandbox using `python -i` and startup guards that confine writes.
 - `file_search`: search for files and contents using `fd`/`rg` fallbacks.
 - `clipboard_copy` / `clipboard_paste`: macOS clipboard helpers.
 - `notes_*`: create, append, list, read, or search Apple Notes entries.
@@ -15,6 +16,10 @@ The planner registers these tools (each implemented under `src/tools/<name>.sh`)
 ## Terminal tool
 
 The `terminal` tool keeps a per-query working directory so subsequent calls share context. The default `status` command shows the current directory and a listing. Mutation commands validate arguments and keep `rm` interactive by default.
+
+## Python REPL tool
+
+`python_repl` feeds `TOOL_QUERY` to `python -i` after installing a startup hook that changes into a temporary sandbox directory and wraps `open` so write modes only succeed inside that sandbox. On success it returns the interpreter output; uncaught exceptions exit non-zero and surface the traceback. Prefer short, single-purpose statements; long-running interpreters will be torn down once the session exits.
 
 ## macOS helpers
 

--- a/src/lib/tools.sh
+++ b/src/lib/tools.sh
@@ -132,9 +132,10 @@ initialize_tools() {
 		return 1
 	fi
 
-	register_terminal
-	register_file_search
-	register_clipboard_copy
+        register_terminal
+        register_python_repl
+        register_file_search
+        register_clipboard_copy
 	register_clipboard_paste
 	register_notes_suite
 	register_reminders_suite

--- a/src/tools/python_repl.sh
+++ b/src/tools/python_repl.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Restricted Python REPL tool using an isolated sandbox directory.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/tools/python_repl.sh}/tools/python_repl.sh"
+#
+# Environment variables:
+#   TOOL_QUERY (string): Python statements executed in the REPL session.
+#
+# Dependencies:
+#   - bash 5+
+#   - python 3+
+#   - mktemp
+#   - logging helpers from logging.sh
+#   - register_tool from tools/registry.sh
+#
+# Exit codes:
+#   Returns non-zero when sandbox creation or interpreter startup fails.
+
+# shellcheck source=../lib/logging.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/python_repl.sh}/lib/logging.sh"
+# shellcheck source=./registry.sh disable=SC1091
+source "${BASH_SOURCE[0]%/python_repl.sh}/registry.sh"
+
+python_repl_create_sandbox() {
+        # Outputs the sandbox path.
+        local sandbox_dir # string temporary directory path
+        sandbox_dir=$(mktemp -d "${TMPDIR:-/tmp}/python_repl.XXXXXX") || return 1
+        printf '%s\n' "${sandbox_dir}"
+}
+
+python_repl_write_startup() {
+        # Arguments:
+        #   $1 - sandbox directory (string)
+        # Outputs the startup file path.
+        local sandbox_dir startup_path # string
+        sandbox_dir="$1"
+        startup_path="${sandbox_dir}/startup.py"
+        cat <<'PY' >"${startup_path}" || return 1
+import builtins
+import os
+import pathlib
+import sys
+
+_SANDBOX = pathlib.Path(os.environ["PYTHON_REPL_SANDBOX"]).resolve()
+_original_open = builtins.open
+
+
+def _guarded_open(file, mode="r", buffering=-1, encoding=None, errors=None, newline=None, closefd=True, opener=None):
+    path = pathlib.Path(file)
+    if not path.is_absolute():
+        path = (_SANDBOX / path).resolve()
+    else:
+        path = path.resolve()
+
+    if any(flag in mode for flag in ("w", "a", "x", "+")):
+        if _SANDBOX != path and _SANDBOX not in path.parents:
+            raise PermissionError(f"File writes restricted to sandbox: {path}")
+
+    return _original_open(path, mode, buffering, encoding, errors, newline, closefd, opener)
+
+
+builtins.open = _guarded_open
+os.chdir(_SANDBOX)
+print(f"Python REPL sandbox: {_SANDBOX}")
+sys.stdout.flush()
+PY
+        printf '%s\n' "${startup_path}"
+}
+
+python_repl_wrap_query() {
+        # Arguments:
+        #   $1 - user-supplied Python statements (string)
+        # Outputs a wrapped script that captures exceptions with exit codes.
+        local raw_query wrapped # strings
+        raw_query="$1"
+        wrapped=$'import sys\nimport traceback\ntry:\n'
+
+        if [[ -z "${raw_query//[[:space:]]/}" ]]; then
+                wrapped+=$'    pass\n'
+        else
+                while IFS= read -r line; do
+                        wrapped+="    ${line}"$'\n'
+                done <<<"${raw_query}"
+        fi
+
+        wrapped+=$'except SystemExit as exc:\n    code = exc.code if isinstance(exc.code, int) else 1\n    sys.exit(code)\n'
+        wrapped+=$'except BaseException:\n    traceback.print_exc()\n    sys.exit(1)\n'
+
+        printf '%s' "${wrapped}"
+}
+
+tool_python_repl() {
+        local query sandbox_dir startup_file repl_input status # strings and status code
+        query=${TOOL_QUERY:-""}
+
+        sandbox_dir=$(python_repl_create_sandbox) || {
+                log "ERROR" "Failed to create sandbox" "${query}" || true
+                return 1
+        }
+
+        startup_file=$(python_repl_write_startup "${sandbox_dir}") || {
+                log "ERROR" "Failed to write startup script" "${sandbox_dir}" || true
+                rm -rf "${sandbox_dir}"
+                return 1
+        }
+
+        repl_input=$(python_repl_wrap_query "${query}")
+        repl_input+=$'\n\nexit()\n'
+
+        PYTHONSTARTUP="${startup_file}" \
+                PYTHON_REPL_SANDBOX="${sandbox_dir}" \
+                PYTHONNOUSERSITE=1 \
+                python -i <<<"${repl_input}"
+        status=$?
+        rm -rf "${sandbox_dir}"
+        return "${status}"
+}
+
+register_python_repl() {
+        register_tool \
+                "python_repl" \
+                "Execute Python statements in a temporary sandbox via python -i." \
+                "python -i with startup sandbox" \
+                "Writes are confined to an ephemeral sandbox directory." \
+                tool_python_repl
+}

--- a/tests/tools_python_repl.bats
+++ b/tests/tools_python_repl.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+#
+# Tests for the Python REPL tool sandbox behavior.
+#
+# Usage:
+#   bats tests/tools_python_repl.bats
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#   - python 3+
+#
+# Exit codes:
+#   Inherits Bats semantics; assertions verify interpreter behavior.
+
+@test "executes code inside sandbox directory" {
+        run bash -lc '
+                set -e
+                source ./src/tools/python_repl.sh
+                VERBOSITY=0
+                TOOL_QUERY=$'"'"'import os; print(os.getcwd())'"'"'
+                tool_python_repl
+        '
+        [ "$status" -eq 0 ]
+        sandbox_path=$(printf '%s\n' "${output}" | grep "Python REPL sandbox:" | head -n1 | awk '{print $4}')
+        [[ -n "${sandbox_path}" ]]
+        printf '%s\n' "${output}" | grep -F "${sandbox_path}" >/dev/null
+}
+
+@test "returns non-zero on Python errors" {
+        run bash -lc '
+                source ./src/tools/python_repl.sh
+                VERBOSITY=0
+                TOOL_QUERY=$'"'"'raise RuntimeError("boom")'"'"'
+                tool_python_repl
+        '
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"RuntimeError: boom"* ]]
+}
+
+@test "blocks writes outside the sandbox" {
+        run bash -lc '
+                source ./src/tools/python_repl.sh
+                VERBOSITY=0
+                rm -f /tmp/python_repl_forbidden.txt
+                TOOL_QUERY=$'"'"'open("/tmp/python_repl_forbidden.txt", "w").write("nope")'"'"'
+                tool_python_repl
+                exit_status=$?
+                test ! -e /tmp/python_repl_forbidden.txt || exit 3
+                exit "${exit_status}"
+        '
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"File writes restricted to sandbox"* ]]
+}


### PR DESCRIPTION
## Summary
- add a python_repl tool that runs python -i in a temporary sandbox with startup guards and registry entry
- document the new tool with usage and safety notes
- cover successful execution, error propagation, and sandbox isolation in bats tests

## Testing
- bats tests/tools_python_repl.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b61e419a08325bb1ee584ab7d31ce)