### PR TITLE
Default to llama-driven react loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,14 @@ Initialize a config file with your preferred model settings:
 ```
 
 More scenarios and reference material live in the [docs/](docs/index.md).
+
+## Execution model
+
+okso separates high-level planning from step-by-step execution:
+
+- **Planner pass:** drafts a numbered outline that mentions the tools to use.
+- **ReAct loop:** by default, llama.cpp is queried before each step to pick the next tool
+  and craft an appropriate call based on prior observations.
+
+If llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso falls back to a
+deterministic sequence that feeds the original user query to each planned tool.

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -150,7 +150,7 @@ create_default_settings() {
 	config_file="${config_dir}/config.env"
 	model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:${default_model_file}}"
 
-	new_settings_json=$(jq -c -n \
+        new_settings_json=$(jq -c -n \
 		--arg version "0.1.0" \
 		--arg llama_bin "${LLAMA_BIN:-llama-cli}" \
 		--arg default_model_file "${default_model_file}" \
@@ -159,7 +159,7 @@ create_default_settings() {
 		--arg model_spec "${model_spec}" \
 		--arg model_branch "${DEFAULT_MODEL_BRANCH_BASE:-main}" \
 		--arg notes_dir "${HOME}/.okso" \
-		--arg use_react_llama "${USE_REACT_LLAMA:-false}" \
+                --arg use_react_llama "${USE_REACT_LLAMA:-true}" \
 		'{
                         version: $version,
                         llama_bin: $llama_bin,

--- a/tests/runtime/test_settings.sh
+++ b/tests/runtime/test_settings.sh
@@ -7,14 +7,20 @@
 }
 
 @test "create_default_settings wires derived defaults" {
-	run bash -lc 'source ./src/lib/runtime.sh; create_default_settings compat; config_dir="$(settings_get_json compat config_dir)"; config_file="$(settings_get_json compat config_file)"; printf "%s\n%s" "${config_dir}" "${config_file}"'
-	[ "$status" -eq 0 ]
-	[[ "${lines[1]}" = "${lines[0]}/config.env" ]]
+        run bash -lc 'source ./src/lib/runtime.sh; create_default_settings compat; config_dir="$(settings_get_json compat config_dir)"; config_file="$(settings_get_json compat config_file)"; printf "%s\n%s" "${config_dir}" "${config_file}"'
+        [ "$status" -eq 0 ]
+        [[ "${lines[1]}" = "${lines[0]}/config.env" ]]
+}
+
+@test "react llama assistance defaults to enabled" {
+        run bash -lc 'unset USE_REACT_LLAMA; source ./src/lib/runtime.sh; create_default_settings compat; printf "%s" "$(settings_get_json compat use_react_llama)"'
+        [ "$status" -eq 0 ]
+        [ "$output" = "true" ]
 }
 
 @test "settings json helpers round-trip through globals" {
-	run bash -lc 'source ./src/lib/runtime.sh; create_default_settings compat; settings_set_json compat llama_bin "/custom/bin"; apply_settings_to_globals compat; before="${LLAMA_BIN}"; LLAMA_BIN="/changed/bin"; capture_globals_into_settings compat; after="$(settings_get_json compat llama_bin)"; printf "%s\n%s" "${before}" "${after}"'
-	[ "$status" -eq 0 ]
-	[ "${lines[0]}" = "/custom/bin" ]
-	[ "${lines[1]}" = "/changed/bin" ]
+        run bash -lc 'source ./src/lib/runtime.sh; create_default_settings compat; settings_set_json compat llama_bin "/custom/bin"; apply_settings_to_globals compat; before="${LLAMA_BIN}"; LLAMA_BIN="/changed/bin"; capture_globals_into_settings compat; after="$(settings_get_json compat llama_bin)"; printf "%s\n%s" "${before}" "${after}"'
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "/custom/bin" ]
+        [ "${lines[1]}" = "/changed/bin" ]
 }


### PR DESCRIPTION
## Summary
- default the ReAct loop to use llama guidance when available so tool calls are tailored step-by-step
- document the execution model and fallback behavior when llama is disabled
- add a regression test capturing the new default for use_react_llama

## Testing
- bats tests/runtime/test_settings.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b67cff5348325bb0390947aa04050)