### PR TITLE
Add macOS llama runtime workflow and test

### DIFF
--- a/.github/workflows/macos_llama.yml
+++ b/.github/workflows/macos_llama.yml
@@ -1,0 +1,94 @@
+name: macOS llama.cpp runtime
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  MODEL_SPEC: TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF:tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+  MODEL_BRANCH: main
+  LLAMA_BIN: llama-cli
+  APPROVE_ALL: true
+  USE_REACT_LLAMA: true
+  HF_HOME: /Users/runner/Library/Caches/huggingface
+
+jobs:
+  macos-runtime:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Homebrew dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew update
+          brew install cmake pkg-config python jq coreutils git-lfs bats-core
+
+      - name: Build llama.cpp (llama-cli)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          exec > >(tee llama-build.log) 2>&1
+          git clone --depth 1 https://github.com/ggerganov/llama.cpp.git
+          cmake -S llama.cpp -B llama.cpp/build -DLLAMA_BUILD_SERVER=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_TESTS=OFF
+          cmake --build llama.cpp/build --target llama-cli --config Release
+          echo "${PWD}/llama.cpp/build/bin" >> "${GITHUB_PATH}"
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 -m pip install --upgrade pip
+          python3 -m pip install huggingface_hub
+
+      - name: Prime Hugging Face cache with tiny model
+        shell: bash
+        env:
+          MODEL_SPEC: ${{ env.MODEL_SPEC }}
+          MODEL_BRANCH: ${{ env.MODEL_BRANCH }}
+        run: |
+          set -euxo pipefail
+          exec > >(tee model-download.log) 2>&1
+          mkdir -p "${HF_HOME}"
+          python3 - <<'PY'
+import os
+from huggingface_hub import snapshot_download
+
+model_spec = os.environ.get("MODEL_SPEC", "")
+model_branch = os.environ.get("MODEL_BRANCH", "main")
+
+if ":" not in model_spec:
+    raise SystemExit("MODEL_SPEC must be in repo:filename format")
+
+repo_id, filename = model_spec.split(":", 1)
+snapshot_download(
+    repo_id=repo_id,
+    revision=model_branch,
+    allow_patterns=[filename],
+    local_dir=None,
+    local_dir_use_symlinks=False,
+)
+PY
+
+      - name: Run macOS llama runtime test
+        shell: bash
+        env:
+          MODEL_SPEC: ${{ env.MODEL_SPEC }}
+          MODEL_BRANCH: ${{ env.MODEL_BRANCH }}
+        run: |
+          set -euxo pipefail
+          bats --print-output-on-failure tests/runtime/test_macos_tiny_llama.bats | tee macos-e2e.log
+
+      - name: Upload macOS artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-llama-debug
+          path: |
+            llama-build.log
+            model-download.log
+            macos-e2e.log
+            ${{ env.HF_HOME }}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -10,3 +10,7 @@
   with `[notes_create executed]` when called with a reminder query.
 - `mock_llama_relevance.sh`: emits a JSON map of tool names to booleans for
   grammar-constrained relevance tests.
+
+## macOS tiny-model cache
+
+The macOS GitHub Actions job downloads a small GGUF (`TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF:tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf`) into the default Hugging Face cache under `~/Library/Caches/huggingface/hub`. The cache keeps the runtime Bats test fast while exercising the full `llama.cpp` pipeline. To update the model, edit the `MODEL_SPEC`, `MODEL_BRANCH`, and `HF_HOME` entries in `.github/workflows/macos_llama.yml` to point at the new artifact and cache location.

--- a/tests/runtime/test_macos_tiny_llama.bats
+++ b/tests/runtime/test_macos_tiny_llama.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# macOS llama.cpp end-to-end smoke test.
+#
+# Usage:
+#   bats tests/runtime/test_macos_tiny_llama.bats
+#
+# Environment variables:
+#   MODEL_SPEC (string): Hugging Face repo[:file] identifier for the model.
+#   MODEL_BRANCH (string): Branch or tag to fetch from the repo.
+#   LLAMA_BIN (string): Path to the llama.cpp binary (default: llama-cli).
+#   APPROVE_ALL (bool string): When true, skip interactive confirmations.
+#   USE_REACT_LLAMA (bool string): When true, enable the React loop strategy.
+#
+# Dependencies:
+#   - bats
+#   - jq
+#   - llama.cpp binary available on PATH
+#
+# Exit codes:
+#   Follows Bats semantics; individual tests assert exit statuses explicitly.
+
+load ../helpers/log_parsing.sh
+
+setup() {
+	if [[ "$(uname -s)" != "Darwin" ]]; then
+		skip "macOS-specific runtime smoke test"
+	fi
+
+	if ! command -v "${LLAMA_BIN:-llama-cli}" >/dev/null 2>&1; then
+		skip "llama.cpp binary not available on PATH"
+	fi
+
+	export TEST_ROOT="${BATS_TMPDIR}/okso-macos-e2e"
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}"
+}
+
+@test "tiny llama model drives planner and react loop" {
+	export MODEL_SPEC="${MODEL_SPEC:-TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF:tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf}"
+	export MODEL_BRANCH="${MODEL_BRANCH:-main}"
+	export LLAMA_BIN="${LLAMA_BIN:-llama-cli}"
+	export APPROVE_ALL="${APPROVE_ALL:-true}"
+	export USE_REACT_LLAMA="${USE_REACT_LLAMA:-true}"
+	export VERBOSITY="${VERBOSITY:-1}"
+
+	run ./src/bin/okso --yes --model "${MODEL_SPEC}" --model-branch "${MODEL_BRANCH}" -- "summarize this repository layout"
+
+	[ "$status" -eq 0 ]
+
+	planner_tools="$(parse_json_logs <<<"${output}" | jq -r 'try (map(select(.message=="Planner identified tools"))[0].detail) catch ""')"
+	final_answer="$(parse_json_logs <<<"${output}" | jq -r 'try (map(select(.message=="Final answer"))[0].detail) catch ""')"
+	tool_executions="$(parse_json_logs <<<"${output}" | jq -r 'map(select(.message=="Recorded tool execution")) | length')"
+
+	[[ -n "${planner_tools}" ]]
+	[[ -n "${final_answer}" ]]
+	[ "${tool_executions}" -ge 1 ]
+}


### PR DESCRIPTION
## Summary
- add a macOS workflow that builds llama.cpp, downloads a tiny GGUF model, and runs the new runtime smoke test
- document the tiny model cache location for the macOS workflow
- introduce a macOS-specific Bats test that exercises the okso React loop end-to-end

## Testing
- bats tests/runtime/test_macos_tiny_llama.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c934faf208325a69ce89f3e165adf)