### PR TITLE
Quiet python repl startup

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3,7 +3,7 @@
 The planner registers these tools (each implemented under `src/tools/<name>.sh`):
 
 - `terminal`: persistent working directory with `pwd`, `ls`, `cd`, `find`, `grep`, `stat`, `wc`, `du`, `base64 encode|decode`, and guarded mutations (`rm -i`, `mkdir`, `mv`, `cp`, `touch`). Uses `open` on macOS.
-- `python_repl`: run Python snippets in an ephemeral sandbox using `python -i` and startup guards that confine writes.
+- `python_repl`: run Python snippets in an ephemeral sandbox using quiet `python -i` startup guards that confine writes.
 - `file_search`: search for files and contents using `fd`/`rg` fallbacks.
 - `clipboard_copy` / `clipboard_paste`: macOS clipboard helpers.
 - `notes_*`: create, append, list, read, or search Apple Notes entries.
@@ -19,7 +19,7 @@ The `terminal` tool keeps a per-query working directory so subsequent calls shar
 
 ## Python REPL tool
 
-`python_repl` feeds `TOOL_QUERY` to `python -i` after installing a startup hook that changes into a temporary sandbox directory and wraps `open` so write modes only succeed inside that sandbox. On success it returns the interpreter output; uncaught exceptions exit non-zero and surface the traceback. Prefer short, single-purpose statements; long-running interpreters will be torn down once the session exits.
+`python_repl` feeds `TOOL_QUERY` to quiet `python -i` after installing a startup hook that changes into a temporary sandbox directory and wraps `open` so write modes only succeed inside that sandbox. On success it returns the interpreter output; uncaught exceptions exit non-zero and surface the traceback. Prefer short, single-purpose statements; long-running interpreters will be torn down once the session exits.
 
 ## macOS helpers
 

--- a/src/tools/python_repl.sh
+++ b/src/tools/python_repl.sh
@@ -110,13 +110,13 @@ tool_python_repl() {
 	repl_input=$(python_repl_wrap_query "${query}")
 	repl_input+=$'\n\nexit()\n'
 
-	PYTHONSTARTUP="${startup_file}" \
-		PYTHON_REPL_SANDBOX="${sandbox_dir}" \
-		PYTHONNOUSERSITE=1 \
-		python3 -i <<<"${repl_input}"
-	status=$?
-	rm -rf "${sandbox_dir}"
-	return "${status}"
+        PYTHONSTARTUP="${startup_file}" \
+                PYTHON_REPL_SANDBOX="${sandbox_dir}" \
+                PYTHONNOUSERSITE=1 \
+                python3 -iq <<<"${repl_input}"
+        status=$?
+        rm -rf "${sandbox_dir}"
+        return "${status}"
 }
 
 register_python_repl() {

--- a/tests/tools_python_repl.bats
+++ b/tests/tools_python_repl.bats
@@ -14,7 +14,7 @@
 #   Inherits Bats semantics; assertions verify interpreter behavior.
 
 @test "executes code inside sandbox directory" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 source ./src/tools/python_repl.sh
                 VERBOSITY=0
@@ -24,11 +24,23 @@
 	[ "$status" -eq 0 ]
 	sandbox_path=$(printf '%s\n' "${output}" | grep "Python REPL sandbox:" | head -n1 | awk '{print $4}')
 	[[ -n "${sandbox_path}" ]]
-	printf '%s\n' "${output}" | grep -F "${sandbox_path}" >/dev/null
+        printf '%s\n' "${output}" | grep -F "${sandbox_path}" >/dev/null
+}
+
+@test "starts quietly without Python banner" {
+        run bash -lc '
+                source ./src/tools/python_repl.sh
+                VERBOSITY=0
+                TOOL_QUERY=$'"'"'print("ok")'"'"'
+                tool_python_repl
+        '
+        [ "$status" -eq 0 ]
+        [[ "${output}" != *"Type \"help\""* ]]
+        [[ ! "${output}" =~ ^Python\ [0-9] ]]
 }
 
 @test "returns non-zero on Python errors" {
-	run bash -lc '
+        run bash -lc '
                 source ./src/tools/python_repl.sh
                 VERBOSITY=0
                 TOOL_QUERY=$'"'"'raise RuntimeError("boom")'"'"'


### PR DESCRIPTION
## Summary
- run the Python REPL tool with quiet startup to suppress the interpreter banner while keeping sandbox safeguards
- document that the REPL starts quietly and remains sandboxed
- add regression coverage to ensure the quiet startup behavior

## Testing
- bats tests/tools_python_repl.bats

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ca6959f248325a6a9ae8155cfebdc)