### PR TITLE
Clarify notes tool invocation patterns

### DIFF
--- a/src/tools/notes/append.sh
+++ b/src/tools/notes/append.sh
@@ -67,10 +67,10 @@ APPLESCRIPT
 }
 
 register_notes_append() {
-	register_tool \
-		"notes_append" \
-		"Append text to an existing Apple Note matched by title." \
-		"osascript -e 'set body of note \"<title>\" to body & \"<text>\"'" \
-		"Requires macOS Apple Notes access; updates existing note content." \
-		tool_notes_append
+        register_tool \
+                "notes_append" \
+                "Append text to an existing Apple Note matched by title." \
+                "notes_append 'Title\nAdditional text' (first line is title, following lines are appended)" \
+                "Requires macOS Apple Notes access; updates existing note content." \
+                tool_notes_append
 }

--- a/src/tools/notes/create.sh
+++ b/src/tools/notes/create.sh
@@ -83,10 +83,10 @@ APPLESCRIPT
 }
 
 register_notes_create() {
-	register_tool \
-		"notes_create" \
-		"Create a new Apple Note using the first line as the title." \
-		"osascript -e 'make new note with {name:<title>, body:<body>}'" \
-		"Requires macOS Apple Notes access; content is sent to Notes." \
-		tool_notes_create
+        register_tool \
+                "notes_create" \
+                "Create a new Apple Note using the first line as the title." \
+                "notes_create 'Title\nBody' (first line is title, remaining lines are note body)" \
+                "Requires macOS Apple Notes access; content is sent to Notes." \
+                tool_notes_create
 }

--- a/src/tools/notes/list.sh
+++ b/src/tools/notes/list.sh
@@ -58,10 +58,10 @@ APPLESCRIPT
 }
 
 register_notes_list() {
-	register_tool \
-		"notes_list" \
-		"List note titles from the configured Apple Notes folder." \
-		"osascript -e 'get name of every note'" \
-		"Requires macOS Apple Notes access; read-only." \
-		tool_notes_list
+        register_tool \
+                "notes_list" \
+                "List note titles from the configured Apple Notes folder." \
+                "notes_list (no arguments; returns one title per line)" \
+                "Requires macOS Apple Notes access; read-only." \
+                tool_notes_list
 }

--- a/src/tools/notes/read.sh
+++ b/src/tools/notes/read.sh
@@ -68,10 +68,10 @@ APPLESCRIPT
 }
 
 register_notes_read() {
-	register_tool \
-		"notes_read" \
-		"Read an Apple Note's content by title." \
-		"osascript -e 'get body of note \"<title>\"'" \
-		"Requires macOS Apple Notes access; read-only." \
-		tool_notes_read
+        register_tool \
+                "notes_read" \
+                "Read an Apple Note's content by title." \
+                "notes_read 'Title' (returns the title and body separated by a newline)" \
+                "Requires macOS Apple Notes access; read-only." \
+                tool_notes_read
 }

--- a/src/tools/notes/search.sh
+++ b/src/tools/notes/search.sh
@@ -69,10 +69,10 @@ APPLESCRIPT
 }
 
 register_notes_search() {
-	register_tool \
-		"notes_search" \
-		"Search Apple Notes titles and bodies for a phrase." \
-		"osascript -e 'notes whose body contains \"<term>\"'" \
-		"Requires macOS Apple Notes access; read-only." \
-		tool_notes_search
+        register_tool \
+                "notes_search" \
+                "Search Apple Notes titles and bodies for a phrase." \
+                "notes_search 'search term' (matches titles or bodies containing the phrase)" \
+                "Requires macOS Apple Notes access; read-only." \
+                tool_notes_search
 }


### PR DESCRIPTION
## Summary
- update notes tool registration examples to show user-facing invocation patterns
- clarify expected input structure for creating and appending notes
- describe required arguments for list, search, and read operations

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb38ba5408325af208af81fb8ba7d)