### PR TITLE
Refine boxed summary tool history formatting

### DIFF
--- a/tests/lib/test_summary.sh
+++ b/tests/lib/test_summary.sh
@@ -9,28 +9,30 @@
 #   - bats
 #   - bash 5+
 
-@test "render_boxed_summary builds boxed output with sections" {
-	mapfile -t lines < <(bash -lc '
+@test "render_boxed_summary builds boxed output with nested tool history" {
+        mapfile -t lines < <(bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 source ./src/lib/formatting.sh
-                tool_history=$'"'"'step1\nstep2'"'"'
+                tool_history=$'"'"'Step 1 action search query=weather\nObservation: sunny\nStep 2 action final_answer query=done\nObservation: finished'"'"'
                 render_boxed_summary "What is new?" "Outline details" "${tool_history}" "Final thoughts"
         ')
-	status=$?
-	output="${lines[*]}"
-	[[ "${output}" == *"Query:"* ]]
-	[[ "${output}" == *"Plan:"* ]]
-	[[ "${output}" == *"Tool runs:"* ]]
-	[[ "${output}" == *"Final answer:"* ]]
-	if ! [[ "${output}" == *"step1"* && "${output}" == *"step2"* ]]; then
-		echo "DEBUG output: ${output}" >&2
-	fi
-	[[ "${output}" == *"step1"* && "${output}" == *"step2"* ]]
-	[ "$status" -eq 0 ]
+        status=$?
+        output="${lines[*]}"
+        [[ "${output}" == *"Query:"* ]]
+        [[ "${output}" == *"Plan:"* ]]
+        [[ "${output}" == *"Tool runs:"* ]]
+        [[ "${output}" == *"Final answer:"* ]]
+        [[ "${output}" == *"- Step 1"* ]]
+        [[ "${output}" == *"action: search query=weather"* ]]
+        [[ "${output}" == *"observation: sunny"* ]]
+        [[ "${output}" == *"- Step 2"* ]]
+        [[ "${output}" == *"action: final_answer query=done"* ]]
+        [[ "${output}" == *"observation: finished"* ]]
+        [ "$status" -eq 0 ]
 }
 
 @test "render_boxed_summary handles empty tool history" {
-	run bash -lc '
+        run bash -lc '
                 cd "$(git rev-parse --show-toplevel)" || exit 1
                 source ./src/lib/formatting.sh
                 render_boxed_summary "Question" "" "" "Answer"


### PR DESCRIPTION
## Summary
- parse tool history into grouped step, action, and observation bullets for boxed summaries
- keep terminal folding while rendering nested tool history content
- update summary tests to cover nested tool history formatting

## Testing
- bats tests/lib/test_summary.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb339952c83259a729797ca4158a0)