### PR TITLE
Update mail tool invocation examples

### DIFF
--- a/src/tools/mail/draft.sh
+++ b/src/tools/mail/draft.sh
@@ -74,10 +74,10 @@ APPLESCRIPT
 }
 
 register_mail_draft() {
-	register_tool \
-		"mail_draft" \
-		"Create an Apple Mail draft using the first line for recipients and second for the subject." \
-		"osascript -e 'make new outgoing message with {subject:<subject>, content:<body>}'" \
-		"Requires macOS Apple Mail access; content and recipients are sent to Mail." \
-		tool_mail_draft
+        register_tool \
+                "mail_draft" \
+                "Create an Apple Mail draft using the first line for recipients and second for the subject." \
+                "mail_draft 'to@example.com\\nSubject\\nBody'" \
+                "Requires macOS Apple Mail access; content and recipients are sent to Mail." \
+                tool_mail_draft
 }

--- a/src/tools/mail/list_inbox.sh
+++ b/src/tools/mail/list_inbox.sh
@@ -59,10 +59,10 @@ APPLESCRIPT
 }
 
 register_mail_list_inbox() {
-	register_tool \
-		"mail_list_inbox" \
-		"List recent Apple Mail inbox messages." \
-		"osascript -e 'get messages of inbox'" \
-		"Requires macOS Apple Mail access; returns metadata only." \
-		tool_mail_list_inbox
+        register_tool \
+                "mail_list_inbox" \
+                "List recent Apple Mail inbox messages." \
+                "mail_list_inbox" \
+                "Requires macOS Apple Mail access; returns metadata only." \
+                tool_mail_list_inbox
 }

--- a/src/tools/mail/list_unread.sh
+++ b/src/tools/mail/list_unread.sh
@@ -59,10 +59,10 @@ APPLESCRIPT
 }
 
 register_mail_list_unread() {
-	register_tool \
-		"mail_list_unread" \
-		"List unread Apple Mail inbox messages." \
-		"osascript -e 'get messages of inbox whose unread is true'" \
-		"Requires macOS Apple Mail access; returns metadata only." \
-		tool_mail_list_unread
+        register_tool \
+                "mail_list_unread" \
+                "List unread Apple Mail inbox messages." \
+                "mail_list_unread" \
+                "Requires macOS Apple Mail access; returns metadata only." \
+                tool_mail_list_unread
 }

--- a/src/tools/mail/search.sh
+++ b/src/tools/mail/search.sh
@@ -67,10 +67,10 @@ APPLESCRIPT
 }
 
 register_mail_search() {
-	register_tool \
-		"mail_search" \
-		"Search Apple Mail inbox messages by subject, sender, or content." \
-		"osascript -e 'messages of inbox whose subject contains <term>'" \
-		"Requires macOS Apple Mail access; returns metadata only." \
-		tool_mail_search
+        register_tool \
+                "mail_search" \
+                "Search Apple Mail inbox messages by subject, sender, or content." \
+                "mail_search 'term'" \
+                "Requires macOS Apple Mail access; returns metadata only." \
+                tool_mail_search
 }

--- a/src/tools/mail/send.sh
+++ b/src/tools/mail/send.sh
@@ -70,10 +70,10 @@ APPLESCRIPT
 }
 
 register_mail_send() {
-	register_tool \
-		"mail_send" \
-		"Send an email via Apple Mail; recipients on line one, subject on line two." \
-		"osascript -e 'make new outgoing message with {subject:<subject>, content:<body>}' -e 'send result'" \
-		"Requires macOS Apple Mail access; sends immediately to listed recipients." \
-		tool_mail_send
+        register_tool \
+                "mail_send" \
+                "Send an email via Apple Mail; recipients on line one, subject on line two." \
+                "mail_send 'to@example.com\\nSubject\\nBody'" \
+                "Requires macOS Apple Mail access; sends immediately to listed recipients." \
+                tool_mail_send
 }


### PR DESCRIPTION
## Summary
- update mail tool registrations to show direct invocation examples instead of internal osascript commands
- clarify usage strings for search, inbox listing, unread listing, draft creation, and sending tools

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb439f8f08325b31b78e50272d41e)