### PR TITLE
Align bats fixtures with planner prompt format

### DIFF
--- a/tests/cli/test_main.sh
+++ b/tests/cli/test_main.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bats
 
 setup() {
-	TEST_ROOT="${BATS_TMPDIR}/okso-main"
-	export HOME="${TEST_ROOT}/home"
-	export CONFIG_FILE="${TEST_ROOT}/config.env"
-	export LLAMA_BIN="${BATS_TEST_DIRNAME}/../fixtures/mock_llama_relevance.sh"
-	mkdir -p "${HOME}"
+        TEST_ROOT="${BATS_TMPDIR}/okso-main"
+        export HOME="${TEST_ROOT}/home"
+        export CONFIG_FILE="${TEST_ROOT}/config.env"
+        export LLAMA_BIN="${BATS_TEST_DIRNAME}/../fixtures/mock_llama_relevance.sh"
+        export USE_REACT_LLAMA=false
+        mkdir -p "${HOME}"
 
 	cat >"${CONFIG_FILE}" <<EOF
 MODEL_SPEC="example/repo:demo.gguf"


### PR DESCRIPTION
## Summary
- adjust the mock llama fixture to parse the current planner prompt structure and emit JSON plan arrays
- disable react llama usage in CLI bats setup for deterministic tool execution during tests

## Testing
- bats tests/cli/test_main.sh
- bats tests/tools_python_repl.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb0d679108325a134844f68549a10)