### PR TITLE
Update calendar tool invocation examples

### DIFF
--- a/src/tools/calendar/create.sh
+++ b/src/tools/calendar/create.sh
@@ -75,10 +75,10 @@ APPLESCRIPT
 }
 
 register_calendar_create() {
-	register_tool \
-		"calendar_create" \
-		"Create a new Apple Calendar event (line 1: title; line 2: start time)." \
-		"osascript -e 'make new event with {summary:<title>, start date:date \"<time>\"}'" \
-		"Requires macOS Calendar access; event details are sent to Calendar." \
-		tool_calendar_create
+        register_tool \
+                "calendar_create" \
+                "Create a new Apple Calendar event (line 1: title; line 2: start time)." \
+                "calendar_create 'Title\\nStart time'" \
+                "Requires macOS Calendar access; event details are sent to Calendar." \
+                tool_calendar_create
 }

--- a/src/tools/calendar/list.sh
+++ b/src/tools/calendar/list.sh
@@ -73,10 +73,10 @@ APPLESCRIPT
 }
 
 register_calendar_list() {
-	register_tool \
-		"calendar_list" \
-		"List upcoming Apple Calendar events from the configured calendar." \
-		"osascript -e 'events of calendar <name> starting today'" \
-		"Requires macOS Calendar access; read-only." \
-		tool_calendar_list
+        register_tool \
+                "calendar_list" \
+                "List upcoming Apple Calendar events from the configured calendar." \
+                "calendar_list" \
+                "Requires macOS Calendar access; read-only." \
+                tool_calendar_list
 }

--- a/src/tools/calendar/search.sh
+++ b/src/tools/calendar/search.sh
@@ -77,10 +77,10 @@ APPLESCRIPT
 }
 
 register_calendar_search() {
-	register_tool \
-		"calendar_search" \
-		"Search Apple Calendar events by title or location." \
-		"osascript -e 'events whose summary contains \"<term>\"'" \
-		"Requires macOS Calendar access; read-only." \
-		tool_calendar_search
+        register_tool \
+                "calendar_search" \
+                "Search Apple Calendar events by title or location." \
+                "calendar_search '<query>'" \
+                "Requires macOS Calendar access; read-only." \
+                tool_calendar_search
 }


### PR DESCRIPTION
## Summary
- update calendar tool registration examples to show LLM invocation patterns instead of AppleScript snippets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb43b8db48325a98dcee55ed916b7)