### PR TITLE
Extract prompt templates to shared files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ okso separates high-level planning from step-by-step execution:
 
 If llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso falls back to a
 deterministic sequence that feeds the original user query to each planned tool.
+
+## Prompt assets
+
+Prompt templates live alongside grammar definitions to keep the assistant behaviour easy to review.
+Each prompt has a dedicated file in `src/prompts/` (for example, `concise_response.txt`, `planner.txt`, and `react.txt`) and is loaded by the helpers in `src/lib/prompts.sh` before being sent to llama.cpp.

--- a/src/lib/prompts.sh
+++ b/src/lib/prompts.sh
@@ -16,95 +16,105 @@
 #   Functions print prompts and return 0 on success.
 
 LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROMPTS_DIR="${LIB_DIR%/lib}/prompts"
 
 # shellcheck source=./grammar.sh disable=SC1091
 source "${LIB_DIR}/grammar.sh"
 
+load_prompt_template() {
+        # Arguments:
+        #   $1 - prompt name (string)
+        local prompt_name prompt_path
+        prompt_name="$1"
+        prompt_path="${PROMPTS_DIR}/${prompt_name}.txt"
+
+        if [[ ! -f "${prompt_path}" ]]; then
+                printf 'prompt template missing: %s\n' "${prompt_path}" >&2
+                return 1
+        fi
+
+        cat "${prompt_path}"
+}
+
+render_prompt_template() {
+        # Arguments:
+        #   $1 - prompt name (string)
+        #   $@ - key/value pairs for substitution (string)
+        # Types:
+        #   prompt name: string
+        #   key/value pairs: alternating strings representing variable names and values
+        local prompt_name prompt_text
+        local -a substitutions=()
+
+        prompt_name="$1"
+        shift
+        prompt_text="$(load_prompt_template "${prompt_name}")" || return 1
+
+        if (($# % 2 != 0)); then
+                printf 'render_prompt_template expects an even number of substitution arguments\n' >&2
+                return 1
+        fi
+
+        while (($# > 0)); do
+                local key value
+                key="$1"
+                value="$2"
+                substitutions+=("${key}=${value}")
+                shift 2
+        done
+
+        if ((${#substitutions[@]} == 0)); then
+                printf '%s' "${prompt_text}"
+                return 0
+        fi
+
+        env "${substitutions[@]}" envsubst <<<"${prompt_text}"
+}
+
 build_concise_response_prompt() {
-	# Arguments:
-	#   $1 - user query (string)
-	local user_query concise_grammar
-	user_query="$1"
-	concise_grammar="$(load_grammar_text concise_response)"
+        # Arguments:
+        #   $1 - user query (string)
+        local user_query concise_grammar
+        user_query="$1"
+        concise_grammar="$(load_grammar_text concise_response)"
 
-	cat <<PROMPT
-Provide a short, concise answer (two to three sentences) to the user.
-Follow this JSON schema:
-${concise_grammar}
-
-USER REQUEST:
-${user_query}
-
-CONCISE RESPONSE:
-
-PROMPT
+        render_prompt_template "concise_response" \
+                user_query "${user_query}" \
+                concise_grammar "${concise_grammar}"
 }
 
 build_planner_prompt() {
-	# Arguments:
-	#   $1 - user query (string)
-	#   $2 - formatted tool descriptions (string)
-	local user_query tool_lines planner_grammar
-	user_query="$1"
-	tool_lines="$2"
-	planner_grammar="$(load_grammar_text planner_plan)"
+        # Arguments:
+        #   $1 - user query (string)
+        #   $2 - formatted tool descriptions (string)
+        local user_query tool_lines planner_grammar
+        user_query="$1"
+        tool_lines="$2"
+        planner_grammar="$(load_grammar_text planner_plan)"
 
-	cat <<PROMPT
-# General Rules
-You are a planner for an autonomous agent.
-Given a user request and a list of available tools, draft an ordered list of high-level actions the agent should take.
-Format the output as a JSON array of strings.
-Each step must mention the tool name that will be used.
-Do NOT include fully executable shell commands; keep the guidance conceptual.
-
-Constrain your response using this JSON schema:
-${planner_grammar}
-
-# Available tools:
-${tool_lines}
-
-# User request:
-${user_query}
-
-# Plan:
-
-PROMPT
+        render_prompt_template "planner" \
+                user_query "${user_query}" \
+                tool_lines "${tool_lines}" \
+                planner_grammar "${planner_grammar}"
 }
 
 build_react_prompt() {
-	# Arguments:
-	#   $1 - user query (string)
-	#   $2 - formatted allowed tool descriptions (string)
-	#   $3 - high-level plan outline (string)
-	#   $4 - prior interaction history (string)
-	local user_query allowed_tools plan_outline history react_grammar
-	user_query="$1"
-	allowed_tools="$2"
-	plan_outline="$3"
-	history="$4"
-	react_grammar="$(load_grammar_text react_action)"
+        # Arguments:
+        #   $1 - user query (string)
+        #   $2 - formatted allowed tool descriptions (string)
+        #   $3 - high-level plan outline (string)
+        #   $4 - prior interaction history (string)
+        local user_query allowed_tools plan_outline history react_grammar
+        user_query="$1"
+        allowed_tools="$2"
+        plan_outline="$3"
+        history="$4"
+        react_grammar="$(load_grammar_text react_action)"
 
-	cat <<PROMPT
-You are an intelligent assistant charged with faithfully performing a complex task for the user.
-Use the high-level plan as guidance but adapt after each observation.
-Respond ONLY with a single JSON object per turn.
-
-Action schema (JSON Schema enforced):
-${react_grammar}
-
-High-level plan:
-${plan_outline}
-
-User request:
-${user_query}
-
-Allowed tools:
-${allowed_tools}
-
-Previous steps:
-${history}
-
-Next Action:
-
-PROMPT
+        render_prompt_template "react" \
+                user_query "${user_query}" \
+                allowed_tools "${allowed_tools}" \
+                plan_outline "${plan_outline}" \
+                history "${history}" \
+                react_grammar "${react_grammar}"
 }

--- a/src/prompts/concise_response.txt
+++ b/src/prompts/concise_response.txt
@@ -1,0 +1,9 @@
+Provide a short, concise answer (two to three sentences) to the user.
+Follow this JSON schema:
+${concise_grammar}
+
+USER REQUEST:
+${user_query}
+
+CONCISE RESPONSE:
+

--- a/src/prompts/planner.txt
+++ b/src/prompts/planner.txt
@@ -1,0 +1,18 @@
+# General Rules
+You are a planner for an autonomous agent.
+Given a user request and a list of available tools, draft an ordered list of high-level actions the agent should take.
+Format the output as a JSON array of strings.
+Each step must mention the tool name that will be used.
+Do NOT include fully executable shell commands; keep the guidance conceptual.
+
+Constrain your response using this JSON schema:
+${planner_grammar}
+
+# Available tools:
+${tool_lines}
+
+# User request:
+${user_query}
+
+# Plan:
+

--- a/src/prompts/react.txt
+++ b/src/prompts/react.txt
@@ -1,0 +1,21 @@
+You are an intelligent assistant charged with faithfully performing a complex task for the user.
+Use the high-level plan as guidance but adapt after each observation.
+Respond ONLY with a single JSON object per turn.
+
+Action schema (JSON Schema enforced):
+${react_grammar}
+
+High-level plan:
+${plan_outline}
+
+User request:
+${user_query}
+
+Allowed tools:
+${allowed_tools}
+
+Previous steps:
+${history}
+
+Next Action:
+

--- a/tests/core/test_prompts.sh
+++ b/tests/core/test_prompts.sh
@@ -23,6 +23,11 @@
 }
 
 @test "react prompt lists schema and previous steps" {
-	run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/prompts.sh; tools=$"Available tools:\n- gamma: sample (example query: try gamma)"; prompt=$(build_react_prompt "Assist" "$tools" "1. Start" "Observed"); [[ "$prompt" == *"Action schema:"* ]]; [[ "$prompt" == *"Available tools"* ]]; [[ "$prompt" == *"example query: try gamma"* ]]; [[ "$prompt" == *"Observed"* ]]'
-	[ "$status" -eq 0 ]
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/prompts.sh; tools=$"Available tools:\n- gamma: sample (example query: try gamma)"; prompt=$(build_react_prompt "Assist" "$tools" "1. Start" "Observed"); [[ "$prompt" == *"Action schema:"* ]]; [[ "$prompt" == *"Available tools"* ]]; [[ "$prompt" == *"example query: try gamma"* ]]; [[ "$prompt" == *"Observed"* ]]'
+        [ "$status" -eq 0 ]
+}
+
+@test "prompt templates are loaded from disk" {
+        run bash -lc 'cd "$(git rev-parse --show-toplevel)" && source ./src/lib/prompts.sh; template=$(load_prompt_template planner); [[ "$template" == *"# General Rules"* ]]; [[ "$template" == *"# Plan:"* ]]'
+        [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- move prompt bodies into dedicated files under src/prompts with envsubst-based loader
- refactor prompt builders to render templates from disk and keep planner/react helpers aligned
- document prompt asset layout and extend prompt tests to cover template loading

## Testing
- bats tests/core/test_prompts.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cb756a4548325a3ae5d09b81b6807)