### PR TITLE
Use mdfind for macOS file searches

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -4,7 +4,7 @@ The planner registers these tools (each implemented under `src/tools/<name>.sh`)
 
 - `terminal`: persistent working directory with `pwd`, `ls`, `cd`, `find`, `grep`, `stat`, `wc`, `du`, `base64 encode|decode`, and guarded mutations (`rm -i`, `mkdir`, `mv`, `cp`, `touch`). Uses `open` on macOS.
 - `python_repl`: run Python snippets in an ephemeral sandbox using quiet `python -i` startup guards that confine writes.
-- `file_search`: search for files and contents using `fd`/`rg` fallbacks.
+- `file_search`: search for files and contents using `mdfind` on macOS with `fd`/`rg` fallbacks elsewhere.
 - `clipboard_copy` / `clipboard_paste`: macOS clipboard helpers.
 - `notes_*`: create, append, list, read, or search Apple Notes entries.
 - `reminders_*`: create, list, or complete Apple Reminders.

--- a/docs/user-guides/installation.md
+++ b/docs/user-guides/installation.md
@@ -27,7 +27,7 @@ The hosted script re-executes under `bash` and mirrors the local installer behav
 ## What the installer configures
 
 1. Checks for Homebrew and installs it if missing (without running `brew upgrade`).
-2. Ensures pinned dependencies such as `llama.cpp`, `llama-tokenize`, `tesseract`, `pandoc`, `poppler` (`pdftotext`), `yq`, `bash`, `coreutils`, and `jq`.
+2. Ensures pinned dependencies such as `llama.cpp`, `llama-tokenize`, `tesseract`, `pandoc`, `poppler` (`pdftotext`), `yq`, `bash`, `coreutils`, `jq`, `ripgrep`, and `fd`.
 3. Copies the `src/` contents into the install prefix and symlinks `okso` into your `PATH` (default: `/usr/local/bin`).
 4. Uses llama.cpp's Hugging Face cache for models; download happens on demand through `--model`/`--model-branch` flags rather than manual cache setup.
 5. Refuses to run on non-macOS hosts so platform assumptions stay consistent.
@@ -36,7 +36,7 @@ The hosted script re-executes under `bash` and mirrors the local installer behav
 
 If you prefer to manage dependencies yourself:
 
-1. Ensure `bash`, `jq`, `rg`, `fd`, and a `llama.cpp` binary are on your `PATH`.
+1. Ensure `bash`, `jq`, `rg`, `fd`, and a `llama.cpp` binary are on your `PATH` (macOS includes `mdfind` for Spotlight-backed searches).
 2. Clone the repository and run the CLI directly:
    ```bash
    ./src/bin/okso --help

--- a/scripts/okso.rb
+++ b/scripts/okso.rb
@@ -15,6 +15,8 @@ class Okso < Formula
   depends_on "coreutils"
   depends_on "jq"
   depends_on "gum"
+  depends_on "ripgrep"
+  depends_on "fd"
 
   def install
     prefix.install Dir["*"]

--- a/src/tools/file_search.sh
+++ b/src/tools/file_search.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 #
-# File and content search tool using fd/rg fallbacks.
+# File and content search tool using macOS Spotlight or fd/rg fallbacks.
 #
 # Usage:
 #   source "${BASH_SOURCE[0]%/tools/file_search.sh}/tools/file_search.sh"
@@ -11,6 +11,7 @@
 #
 # Dependencies:
 #   - bash 5+
+#   - mdfind (macOS, preferred when available)
 #   - fd (optional)
 #   - ripgrep (optional)
 #   - logging helpers from logging.sh
@@ -29,11 +30,17 @@ tool_file_search() {
 	query=${TOOL_QUERY:-""}
 	log "INFO" "Searching files" "${query}"
 
-	if command -v fd >/dev/null 2>&1; then
-		fd --hidden --color=never --max-depth 5 "${query:-.}" . || true
-	else
-		find . -maxdepth 5 -iname "*${query}*" || true
-	fi
+        if [[ "${IS_MACOS:-false}" == true ]] && command -v mdfind >/dev/null 2>&1; then
+                if [[ -n "${query}" ]]; then
+                        mdfind -onlyin "${PWD}" "${query}" || true
+                else
+                        mdfind -onlyin "${PWD}" "*" || true
+                fi
+        elif command -v fd >/dev/null 2>&1; then
+                fd --hidden --color=never --max-depth 5 "${query:-.}" . || true
+        else
+                find . -maxdepth 5 -iname "*${query}*" || true
+        fi
 
 	if command -v rg >/dev/null 2>&1 && [[ -n "${query}" ]]; then
 		rg --line-number --hidden --color=never "${query}" || true

--- a/tests/tools/test_file_search.sh
+++ b/tests/tools/test_file_search.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+#
+# Focused tests for the file_search tool and its platform fallbacks.
+#
+# Usage: bats tests/tools/test_file_search.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "uses mdfind on macOS when available" {
+        run bash -lc '
+                set -e
+                stub_dir="$(mktemp -d)"
+                cat >"${stub_dir}/mdfind" <<"STUB"
+#!/usr/bin/env bash
+printf "mdfind:%s\n" "$*"
+STUB
+                chmod +x "${stub_dir}/mdfind"
+
+                PATH="${stub_dir}:${PATH}"
+                VERBOSITY=0
+                IS_MACOS=true
+                TOOL_QUERY="needle"
+                source ./src/tools/file_search.sh
+                tool_file_search
+        '
+
+        [ "$status" -eq 0 ]
+        [[ "${lines[0]}" == mdfind:*"-onlyin"*"needle" ]]
+}
+
+@test "falls back to fd when Spotlight is unavailable" {
+        run bash -lc '
+                set -e
+                stub_dir="$(mktemp -d)"
+                cat >"${stub_dir}/fd" <<"STUB"
+#!/usr/bin/env bash
+printf "fd:%s\n" "$*"
+STUB
+                chmod +x "${stub_dir}/fd"
+
+                PATH="${stub_dir}:${PATH}"
+                VERBOSITY=0
+                IS_MACOS=false
+                TOOL_QUERY="query"
+                source ./src/tools/file_search.sh
+                tool_file_search
+        '
+
+        [ "$status" -eq 0 ]
+        [[ "${lines[0]}" == fd:*"--max-depth"*"query"*"." ]]
+}


### PR DESCRIPTION
## Summary
- prefer macOS Spotlight (mdfind) for file search while keeping fd/find and ripgrep fallbacks
- document the new search behavior and include ripgrep/fd in macOS install dependencies
- add Homebrew dependencies and regression tests for the file search tool

## Testing
- bats tests/tools/test_file_search.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d9df558508325a81bd0e5a5db6762)