### PR TITLE
Remove legacy DO_* installer environment support

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,9 +15,6 @@
 #       URL when using this flag.
 #   OKSO_INSTALLER_BASE_URL (string): Source bundle location when installing
 #       without a local checkout.
-#   Legacy aliases are honored for compatibility: DO_LINK_DIR,
-#       DO_INSTALLER_SKIP_SELF_TEST, DO_INSTALLER_ASSUME_OFFLINE,
-#       DO_INSTALLER_BASE_URL.
 #
 # Exit codes:
 #   0: Success
@@ -39,7 +36,7 @@ set -euo pipefail
 
 APP_NAME="okso"
 DEFAULT_PREFIX="/usr/local/${APP_NAME}"
-DEFAULT_LINK_DIR="${OKSO_LINK_DIR:-${DO_LINK_DIR:-/usr/local/bin}}"
+DEFAULT_LINK_DIR="${OKSO_LINK_DIR:-/usr/local/bin}"
 DEFAULT_LINK_PATH="${DEFAULT_LINK_DIR}/${APP_NAME}"
 DEFAULT_BASE_URL="https://cmccomb.github.io/okso"
 SCRIPT_SOURCE="${BASH_SOURCE[0]-${0-}}"
@@ -94,7 +91,7 @@ download_source_bundle() {
 	local destination base_url tarball_url tarball_path extracted_root
 
 	destination="$(mktemp -d)"
-	base_url="${OKSO_INSTALLER_BASE_URL:-${DO_INSTALLER_BASE_URL:-${DEFAULT_BASE_URL}}}"
+        base_url="${OKSO_INSTALLER_BASE_URL:-${DEFAULT_BASE_URL}}"
 	tarball_url="${base_url%/}/okso.tar.gz"
 	tarball_path="${destination}/okso.tar.gz"
 
@@ -130,10 +127,10 @@ resolve_source_root() {
 		return 0
 	fi
 
-	if [ "${OKSO_INSTALLER_ASSUME_OFFLINE:-${DO_INSTALLER_ASSUME_OFFLINE:-false}}" = "true" ] && [ -z "${OKSO_INSTALLER_BASE_URL:-${DO_INSTALLER_BASE_URL:-}}" ]; then
-		log "ERROR" "No source tree present and OKSO_INSTALLER_BASE_URL not set for offline install"
-		exit 2
-	fi
+        if [ "${OKSO_INSTALLER_ASSUME_OFFLINE:-false}" = "true" ] && [ -z "${OKSO_INSTALLER_BASE_URL:-}" ]; then
+                log "ERROR" "No source tree present and OKSO_INSTALLER_BASE_URL not set for offline install"
+                exit 2
+        fi
 
 	download_source_bundle
 }
@@ -417,10 +414,10 @@ main() {
 	copy_payload "${source_root}" "${INSTALL_PREFIX}"
 	link_binary "${INSTALL_PREFIX}"
 
-	if [ "${OKSO_INSTALLER_SKIP_SELF_TEST:-${DO_INSTALLER_SKIP_SELF_TEST:-false}}" != "true" ]; then
-		self_test_install "${INSTALL_PREFIX}"
-	else
-		log "WARN" "Skipping installer self-test due to OKSO_INSTALLER_SKIP_SELF_TEST"
+        if [ "${OKSO_INSTALLER_SKIP_SELF_TEST:-false}" != "true" ]; then
+                self_test_install "${INSTALL_PREFIX}"
+        else
+                log "WARN" "Skipping installer self-test due to OKSO_INSTALLER_SKIP_SELF_TEST"
 	fi
 
 	log "INFO" "${APP_NAME} installer completed (${MODE})."

--- a/tests/cli/test_install.sh
+++ b/tests/cli/test_install.sh
@@ -6,7 +6,6 @@
 # Environment variables:
 #   OKSO_INSTALLER_ASSUME_OFFLINE (bool): force offline mode to skip network calls.
 #   OKSO_LINK_DIR (string): directory for the generated CLI symlink.
-#   Legacy DO_* aliases remain supported and are covered by compatibility tests.
 #
 # Dependencies:
 #   - bats
@@ -90,13 +89,13 @@ EOM_UNAME
 	[ -L "${OKSO_LINK_DIR}/okso" ]
 }
 
-@test "legacy DO_* environment variables remain supported" {
-	unset OKSO_LINK_DIR OKSO_INSTALLER_ASSUME_OFFLINE OKSO_INSTALLER_SKIP_SELF_TEST
-	export DO_LINK_DIR="${TEST_ROOT}/legacy-bin"
-	mkdir -p "${DO_LINK_DIR}"
-	run env DO_INSTALLER_ASSUME_OFFLINE=true DO_INSTALLER_SKIP_SELF_TEST=true ./scripts/install.sh --prefix "${TEST_ROOT}/legacy-prefix"
+@test "ignores legacy DO_* environment variables" {
+        export DO_LINK_DIR="${TEST_ROOT}/legacy-bin"
+        mkdir -p "${DO_LINK_DIR}" "${OKSO_LINK_DIR}"
 
-	[ "$status" -eq 0 ]
-	[ -L "${DO_LINK_DIR}/okso" ]
-	[ "$(readlink "${DO_LINK_DIR}/okso")" = "${TEST_ROOT}/legacy-prefix/bin/okso" ]
+        run env DO_INSTALLER_ASSUME_OFFLINE=true DO_INSTALLER_SKIP_SELF_TEST=true ./scripts/install.sh --prefix "${TEST_ROOT}/prefix"
+
+        [ "$status" -eq 0 ]
+        [ -L "${OKSO_LINK_DIR}/okso" ]
+        [ ! -e "${DO_LINK_DIR}/okso" ]
 }

--- a/tests/install/test_install_features.sh
+++ b/tests/install/test_install_features.sh
@@ -5,7 +5,6 @@
 # Environment variables:
 #   OKSO_INSTALLER_SKIP_SELF_TEST (bool): skip installer self-test to speed tests.
 #   OKSO_LINK_DIR (string): directory for the generated CLI symlink.
-#   Legacy DO_* aliases remain supported.
 #
 # Dependencies:
 #   - bats


### PR DESCRIPTION
## Summary
- drop DO_* environment variable fallbacks from the installer help and default resolution
- rely solely on OKSO_* configuration for installer paths and offline/self-test controls
- update installer bats coverage to reflect ignoring DO_* variables

## Testing
- shellcheck scripts/install.sh
- bats tests/cli/test_install.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da060b5f883259dc1bf665fb99e91)