### PR TITLE
Add dynamic MCP endpoint registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,42 @@ More scenarios and reference material live in the [docs/](docs/index.md).
 
 ### MCP endpoints
 
-okso can forward queries to MCP-style endpoints alongside its built-in tools. Two
-registrations ship with the CLI:
+okso can forward queries to MCP-style endpoints alongside its built-in tools.
+Registrations are configuration-driven so planners automatically see any user
+definitions without code changes. Provide an environment variable or config file
+entry for `MCP_ENDPOINTS_JSON` containing a JSON array of endpoint definitions.
 
-- `mcp_huggingface` forwards the current tool query to a remote Hugging Face
-  endpoint. Configure the target URL and token variable through `MCP_HUGGINGFACE_URL`
-  and `MCP_HUGGINGFACE_TOKEN_ENV` (defaults to `HUGGINGFACEHUB_API_TOKEN`).
-- `mcp_local_server` targets a bundled local server over a unix socket set in
-  `MCP_LOCAL_SOCKET` (default: `${TMPDIR:-/tmp}/okso-mcp.sock`).
+Example:
 
-Configure these values in your config file or export them before running
-`okso`; the handlers emit JSON connection descriptors without printing token
-values.
+```json
+[
+  {
+    "name": "mcp_huggingface",
+    "provider": "huggingface",
+    "description": "Connect to the configured Hugging Face MCP endpoint with the provided query.",
+    "usage": "mcp_huggingface <query>",
+    "safety": "Requires a valid Hugging Face token; do not print secrets in tool calls.",
+    "transport": "http",
+    "endpoint": "https://example.test/mcp",
+    "token_env": "MCP_TOKEN"
+  },
+  {
+    "name": "mcp_local_server",
+    "provider": "local_demo",
+    "description": "Connect to the bundled local MCP server over a unix socket.",
+    "usage": "mcp_local_server <query>",
+    "safety": "Uses a local socket; ensure the path is trusted before writing.",
+    "transport": "unix",
+    "socket": "/tmp/okso-mcp.sock"
+  }
+]
+```
+
+If no custom value is supplied, okso synthesizes the above defaults using
+`MCP_HUGGINGFACE_URL`, `MCP_HUGGINGFACE_TOKEN_ENV` (default:
+`HUGGINGFACEHUB_API_TOKEN`), and `MCP_LOCAL_SOCKET` (default:
+`${TMPDIR:-/tmp}/okso-mcp.sock`). Handlers emit JSON connection descriptors
+without printing token values.
 
 ## Execution model
 

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -18,6 +18,7 @@
 #   MCP_HUGGINGFACE_URL (string): remote MCP endpoint for Hugging Face tools.
 #   MCP_HUGGINGFACE_TOKEN_ENV (string): env var holding the Hugging Face token.
 #   MCP_LOCAL_SOCKET (string): path or socket for a local MCP server.
+#   MCP_ENDPOINTS_JSON (string): JSON array describing MCP endpoints to register.
 #
 #   The following okso-branded variables take precedence over legacy aliases:
 #     OKSO_MODEL, OKSO_MODEL_BRANCH, OKSO_SUPERVISED, OKSO_VERBOSITY

--- a/src/tools/mcp.sh
+++ b/src/tools/mcp.sh
@@ -11,6 +11,7 @@
 #   MCP_HUGGINGFACE_URL (string): remote Hugging Face MCP endpoint URL.
 #   MCP_HUGGINGFACE_TOKEN_ENV (string): env var that stores the Hugging Face token.
 #   MCP_LOCAL_SOCKET (string): unix socket or filesystem path for a local MCP server.
+#   MCP_ENDPOINTS_JSON (string): JSON array of MCP endpoint definitions.
 #
 # Dependencies:
 #   - bash 5+
@@ -64,66 +65,225 @@ PY
 }
 
 mcp_validate_remote_config() {
-	local url token_env
-	url="$1"
-	token_env="$2"
+        local url token_env
+        url="$1"
+        token_env="$2"
 
-	if [[ -z "${url}" ]]; then
-		log "ERROR" "MCP remote endpoint not configured" ""
-		return 1
-	fi
+        if [[ -z "${url}" ]]; then
+                log "ERROR" "MCP remote endpoint not configured" ""
+                return 1
+        fi
 
-	if [[ -z "${token_env}" ]]; then
-		log "ERROR" "MCP token env var name missing" ""
-		return 1
-	fi
+        if [[ -z "${token_env}" ]]; then
+                log "ERROR" "MCP token env var name missing" ""
+                return 1
+        fi
 
-	if [[ -z "${!token_env:-}" ]]; then
-		log "ERROR" "MCP token not exported" "${token_env}"
-		return 1
-	fi
+        if [[ -z "${!token_env:-}" ]]; then
+                log "ERROR" "MCP token not exported" "${token_env}"
+                return 1
+        fi
 
-	return 0
+        return 0
 }
 
-tool_mcp_huggingface() {
-	# Connect to the configured remote MCP server hosted on Hugging Face.
-	local url token_env
-	url="${MCP_HUGGINGFACE_URL:-}"             # string remote endpoint
-	token_env="${MCP_HUGGINGFACE_TOKEN_ENV:-}" # string token env var name
+mcp_validate_unix_config() {
+        local socket_path
+        socket_path="$1"
 
-	if ! mcp_validate_remote_config "${url}" "${token_env}"; then
-		return 1
-	fi
+        if [[ -z "${socket_path}" ]]; then
+                log "ERROR" "Local MCP socket missing" ""
+                return 1
+        fi
 
-	mcp_print_connection_json "huggingface" "http" "${url}" "" "${token_env}"
+        return 0
 }
 
-tool_mcp_local_server() {
-	# Connect to a bundled local MCP server via socket or filesystem path.
-	local socket_path
-	socket_path="${MCP_LOCAL_SOCKET:-}" # string local socket path
+mcp_dispatch_endpoint() {
+        # Arguments:
+        #   $1 - provider label (string)
+        #   $2 - transport type (string)
+        #   $3 - HTTP endpoint URL (string)
+        #   $4 - unix socket path (string)
+        #   $5 - token environment variable name (string)
+        local provider transport endpoint socket_path token_env
+        provider="$1"
+        transport="$2"
+        endpoint="$3"
+        socket_path="$4"
+        token_env="$5"
 
-	if [[ -z "${socket_path}" ]]; then
-		log "ERROR" "Local MCP socket missing" ""
-		return 1
-	fi
+        case "${transport}" in
+        http)
+                if ! mcp_validate_remote_config "${endpoint}" "${token_env}"; then
+                        return 1
+                fi
+                mcp_print_connection_json "${provider}" "${transport}" "${endpoint}" "" "${token_env}"
+                ;;
+        unix)
+                if ! mcp_validate_unix_config "${socket_path}"; then
+                        return 1
+                fi
+                mcp_print_connection_json "${provider}" "${transport}" "" "${socket_path}" ""
+                ;;
+        *)
+                log "ERROR" "Unsupported MCP transport" "${transport}"
+                return 1
+                ;;
+        esac
+}
 
-	mcp_print_connection_json "local_demo" "unix" "" "${socket_path}" ""
+mcp_default_endpoints_json() {
+        cat <<JSON
+[
+  {
+    "name": "mcp_huggingface",
+    "provider": "huggingface",
+    "description": "Connect to the configured Hugging Face MCP endpoint with the provided query.",
+    "usage": "mcp_huggingface <query>",
+    "safety": "Requires a valid Hugging Face token; do not print secrets in tool calls.",
+    "transport": "http",
+    "endpoint": "${MCP_HUGGINGFACE_URL:-}",
+    "token_env": "${MCP_HUGGINGFACE_TOKEN_ENV:-HUGGINGFACEHUB_API_TOKEN}"
+  },
+  {
+    "name": "mcp_local_server",
+    "provider": "local_demo",
+    "description": "Connect to the bundled local MCP server over a unix socket.",
+    "usage": "mcp_local_server <query>",
+    "safety": "Uses a local socket; ensure the path is trusted before writing.",
+    "transport": "unix",
+    "socket": "${MCP_LOCAL_SOCKET:-${TMPDIR:-/tmp}/okso-mcp.sock}"
+  }
+]
+JSON
+}
+
+mcp_resolved_endpoint_definitions() {
+        local raw_json
+        raw_json="${MCP_ENDPOINTS_JSON:-}" # string JSON array
+        local allow_partial_default
+        allow_partial_default=false
+
+        if [[ -z "${raw_json// }" ]]; then
+                raw_json="$(mcp_default_endpoints_json)"
+                allow_partial_default=true
+        fi
+
+        MCP_ENDPOINTS_PAYLOAD="${raw_json}" MCP_ENDPOINTS_ALLOW_PARTIAL_DEFAULT="${allow_partial_default}" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+raw = os.environ.get("MCP_ENDPOINTS_PAYLOAD", "").strip()
+if not raw:
+    sys.stderr.write("Empty MCP endpoint configuration\n")
+    sys.exit(1)
+
+try:
+    definitions = json.loads(raw)
+except json.JSONDecodeError as exc:  # pragma: no cover - handled in tests
+    sys.stderr.write(f"Failed to parse MCP_ENDPOINTS_JSON: {exc}\n")
+    sys.exit(1)
+
+if not isinstance(definitions, list):
+    sys.stderr.write("MCP endpoint configuration must be a JSON array\n")
+    sys.exit(1)
+
+name_pattern = re.compile(r"^[a-z0-9_]+$")
+normalized = []
+allow_partial = os.environ.get("MCP_ENDPOINTS_ALLOW_PARTIAL_DEFAULT", "").lower() == "true"
+
+for index, entry in enumerate(definitions):
+    if not isinstance(entry, dict):
+        sys.stderr.write(f"Entry {index} is not an object\n")
+        sys.exit(1)
+
+    required = ["name", "provider", "description", "usage", "safety", "transport"]
+    missing = [field for field in required if not entry.get(field)]
+    if missing:
+        sys.stderr.write(f"Entry {index} missing fields: {', '.join(missing)}\n")
+        sys.exit(1)
+
+    if not name_pattern.match(entry["name"]):
+        sys.stderr.write(f"Invalid MCP tool name: {entry['name']}\n")
+        sys.exit(1)
+
+    transport = entry.get("transport")
+    if transport not in {"http", "unix"}:
+        sys.stderr.write(f"Unsupported transport for {entry['name']}: {transport}\n")
+        sys.exit(1)
+
+    if transport == "http":
+        if not entry.get("endpoint") and not allow_partial:
+            sys.stderr.write(f"HTTP endpoint missing for {entry['name']}\n")
+            sys.exit(1)
+        if not entry.get("token_env"):
+            sys.stderr.write(f"token_env missing for {entry['name']}\n")
+            sys.exit(1)
+    elif transport == "unix":
+        if not entry.get("socket") and not allow_partial:
+            sys.stderr.write(f"socket missing for {entry['name']}\n")
+            sys.exit(1)
+
+    normalized.append(
+        {
+            "name": entry["name"],
+            "provider": entry["provider"],
+            "description": entry["description"],
+            "usage": entry["usage"],
+            "safety": entry["safety"],
+            "transport": transport,
+            "endpoint": entry.get("endpoint", ""),
+            "socket": entry.get("socket", ""),
+            "token_env": entry.get("token_env", ""),
+        }
+    )
+
+json.dump(normalized, sys.stdout)
+PY
+}
+
+mcp_register_endpoint_from_definition() {
+        # Arguments:
+        #   $1 - JSON for a single endpoint definition
+        local definition_json name handler_name provider description usage safety transport endpoint socket_path token_env
+        definition_json="$1"
+
+        name="$(jq -r '.name' <<<"${definition_json}")"
+        provider="$(jq -r '.provider' <<<"${definition_json}")"
+        description="$(jq -r '.description' <<<"${definition_json}")"
+        usage="$(jq -r '.usage' <<<"${definition_json}")"
+        safety="$(jq -r '.safety' <<<"${definition_json}")"
+        transport="$(jq -r '.transport' <<<"${definition_json}")"
+        endpoint="$(jq -r '.endpoint' <<<"${definition_json}")"
+        socket_path="$(jq -r '.socket' <<<"${definition_json}")"
+        token_env="$(jq -r '.token_env' <<<"${definition_json}")"
+
+        handler_name="tool_${name}"
+
+        local handler_body
+        printf -v handler_body "%s" "$(printf 'mcp_dispatch_endpoint %q %q %q %q %q' "${provider}" "${transport}" "${endpoint}" "${socket_path}" "${token_env}")"
+
+        eval "${handler_name}() { ${handler_body}; }"
+
+        register_tool "${name}" "${description}" "${usage}" "${safety}" "${handler_name}"
 }
 
 register_mcp_endpoints() {
-	register_tool \
-		"mcp_huggingface" \
-		"Connect to the configured Hugging Face MCP endpoint with the provided query." \
-		"mcp_huggingface <query>" \
-		"Requires a valid Hugging Face token; do not print secrets in tool calls." \
-		tool_mcp_huggingface
+        local definitions_json definitions_count
+        if ! definitions_json="$(mcp_resolved_endpoint_definitions)"; then
+                log "ERROR" "Failed to parse MCP endpoint definitions" ""
+                return 1
+        fi
 
-	register_tool \
-		"mcp_local_server" \
-		"Connect to the bundled local MCP server over a unix socket." \
-		"mcp_local_server <query>" \
-		"Uses a local socket; ensure the path is trusted before writing." \
-		tool_mcp_local_server
+        definitions_count="$(jq 'length' <<<"${definitions_json}")"
+
+        local index
+        for index in $(seq 0 $((definitions_count - 1))); do
+                if ! mcp_register_endpoint_from_definition "$(jq -c --argjson i "${index}" '.[$i]' <<<"${definitions_json}")"; then
+                        return 1
+                fi
+        done
 }

--- a/tests/tools/test_mcp.sh
+++ b/tests/tools/test_mcp.sh
@@ -16,9 +16,9 @@ setup() {
 	REPO_ROOT="$(git rev-parse --show-toplevel)"
 }
 
-@test "register_mcp_endpoints registers both endpoints" {
-	cd "${REPO_ROOT}" || exit 1
-	run bash -lc '
+@test "register_mcp_endpoints registers default endpoints" {
+        cd "${REPO_ROOT}" || exit 1
+        run bash -lc '
                 source ./src/tools/registry.sh
                 source ./src/tools/mcp.sh
                 TOOL_NAME_ALLOWLIST=(mcp_huggingface mcp_local_server)
@@ -26,45 +26,111 @@ setup() {
                 register_mcp_endpoints
                 [[ -n "$(tool_description mcp_huggingface)" ]] && [[ -n "$(tool_description mcp_local_server)" ]]
         '
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
 }
 
 @test "tool_mcp_huggingface fails when token missing" {
-	cd "${REPO_ROOT}" || exit 1
-	run bash -lc '
+        cd "${REPO_ROOT}" || exit 1
+        run bash -lc '
+                source ./src/tools/registry.sh
                 source ./src/tools/mcp.sh
+                TOOL_NAME_ALLOWLIST=(mcp_huggingface mcp_local_server)
+                init_tool_registry
                 MCP_HUGGINGFACE_URL="https://example.test/mcp"
                 MCP_HUGGINGFACE_TOKEN_ENV="MCP_TOKEN"
+                register_mcp_endpoints
                 TOOL_QUERY="ping"
                 tool_mcp_huggingface
         '
-	[ "$status" -eq 1 ]
+        [ "$status" -eq 1 ]
 }
 
 @test "tool_mcp_huggingface emits connection descriptor" {
-	cd "${REPO_ROOT}" || exit 1
-	run bash -lc '
+        cd "${REPO_ROOT}" || exit 1
+        run bash -lc '
+                source ./src/tools/registry.sh
                 source ./src/tools/mcp.sh
+                TOOL_NAME_ALLOWLIST=(mcp_huggingface mcp_local_server)
+                init_tool_registry
                 MCP_HUGGINGFACE_URL="https://example.test/mcp"
                 MCP_HUGGINGFACE_TOKEN_ENV="MCP_TOKEN"
                 MCP_TOKEN="secret"
+                register_mcp_endpoints
                 TOOL_QUERY="list tools"
                 tool_mcp_huggingface
         '
-	[ "$status" -eq 0 ]
-	[[ "${output}" == *'"provider":"huggingface"'* ]]
-	[[ "${output}" == *'"token_env":"MCP_TOKEN"'* ]]
+        [ "$status" -eq 0 ]
+        [[ "${output}" == *'"provider":"huggingface"'* ]]
+        [[ "${output}" == *'"token_env":"MCP_TOKEN"'* ]]
 }
 
 @test "tool_mcp_local_server emits connection descriptor" {
-	cd "${REPO_ROOT}" || exit 1
-	expected_socket="${TMPDIR:-/tmp}/okso-mcp.sock"
-	run bash -lc '
+        cd "${REPO_ROOT}" || exit 1
+        expected_socket="${TMPDIR:-/tmp}/okso-mcp.sock"
+        run bash -lc '
+                source ./src/tools/registry.sh
                 source ./src/tools/mcp.sh
+                TOOL_NAME_ALLOWLIST=(mcp_huggingface mcp_local_server)
+                init_tool_registry
                 MCP_LOCAL_SOCKET="${TMPDIR:-/tmp}/okso-mcp.sock"
+                register_mcp_endpoints
                 TOOL_QUERY="status"
                 tool_mcp_local_server
         '
-	[ "$status" -eq 0 ]
-	[[ "${output}" == *"\"socket\":\"${expected_socket}\""* ]]
+        [ "$status" -eq 0 ]
+        [[ "${output}" == *"\"socket\":\"${expected_socket}\""* ]]
+}
+
+@test "register_mcp_endpoints honors MCP_ENDPOINTS_JSON" {
+        cd "${REPO_ROOT}" || exit 1
+        run bash -lc '
+                source ./src/tools/registry.sh
+                source ./src/tools/mcp.sh
+                TOOL_NAME_ALLOWLIST=(custom_http custom_unix)
+                MCP_ENDPOINTS_JSON='"'"'[
+                        {
+                                "name": "custom_http",
+                                "provider": "alpha",
+                                "description": "Custom HTTP endpoint",
+                                "usage": "custom_http <query>",
+                                "safety": "Do not log secrets",
+                                "transport": "http",
+                                "endpoint": "https://example.test/http",
+                                "token_env": "CUSTOM_TOKEN"
+                        },
+                        {
+                                "name": "custom_unix",
+                                "provider": "beta",
+                                "description": "Custom unix endpoint",
+                                "usage": "custom_unix <query>",
+                                "safety": "Local socket only",
+                                "transport": "unix",
+                                "socket": "/tmp/custom.sock"
+                        }
+                ]'"'"'
+
+                init_tool_registry
+                register_mcp_endpoints
+                CUSTOM_TOKEN="token"
+                TOOL_QUERY="hello"
+                tool_custom_http
+                tool_custom_unix
+                [[ "$(tool_description custom_http)" == "Custom HTTP endpoint" ]]
+                [[ "$(tool_description custom_unix)" == "Custom unix endpoint" ]]
+        '
+        [ "$status" -eq 0 ]
+}
+
+@test "register_mcp_endpoints fails for invalid configuration" {
+        cd "${REPO_ROOT}" || exit 1
+        run bash -lc '
+                source ./src/tools/registry.sh
+                source ./src/tools/mcp.sh
+                TOOL_NAME_ALLOWLIST=(broken_entry)
+                MCP_ENDPOINTS_JSON='"'"'[{"name": "broken_entry", "provider": "bad", "description": "Bad", "usage": "bad <q>", "safety": "", "transport": "http"}]'"'"'
+                init_tool_registry
+                register_mcp_endpoints
+        '
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"missing fields"* ]]
 }


### PR DESCRIPTION
## Summary
- add a config-driven MCP endpoint loader that parses MCP_ENDPOINTS_JSON with validation and defaults
- dynamically register MCP tool handlers with sanitized parameters instead of hardcoded entries
- document configurable MCP endpoints and cover new registration paths with tests

## Testing
- bats tests/tools/test_mcp.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d9fe57a8883258e6bb380cb2db111)