### PR TITLE
Remove legacy DO overrides from config handling

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,4 +16,4 @@ The config file is `KEY="value"` style. Supported keys:
 - `FORCE_CONFIRM`: `true` to always prompt, even when approvals are automatic.
 - `VERBOSITY`: `0` (quiet), `1` (info), `2` (debug).
 
-Environment variables prefixed with `OKSO_` mirror the config keys and take precedence. Legacy `DO_*` aliases remain available for compatibility but prefer the `OKSO_*` names.
+Environment variables prefixed with `OKSO_` mirror the config keys and take precedence over file values.

--- a/tests/core/test_config.sh
+++ b/tests/core/test_config.sh
@@ -63,26 +63,16 @@ setup() {
 	[[ "${VERBOSITY}" == "2" ]]
 }
 
-@test "load_config retains DO_* compatibility when OKSO_* unset" {
-	cd "${REPO_ROOT}" || exit 1
-	source ./src/lib/config.sh
-	CONFIG_FILE="${BATS_TEST_TMPDIR}/config-legacy.env"
-	printf "MODEL_SPEC=base/model\nMODEL_BRANCH=dev\n" >"${CONFIG_FILE}"
-	DO_MODEL="legacy/model" DO_MODEL_BRANCH="legacy-branch" DO_VERBOSITY=0 DO_SUPERVISED=false load_config
-	[[ "${MODEL_SPEC}" == "legacy/model" ]]
-	[[ "${MODEL_BRANCH}" == "legacy-branch" ]]
-	[[ "${VERBOSITY}" == "0" ]]
-	[[ "${APPROVE_ALL}" == "true" ]]
-}
-
-@test "OKSO_* variables take precedence over DO_* equivalents" {
-	cd "${REPO_ROOT}" || exit 1
-	source ./src/lib/config.sh
-	CONFIG_FILE="${BATS_TEST_TMPDIR}/config-mixed.env"
-	printf "MODEL_SPEC=base/model\nMODEL_BRANCH=dev\n" >"${CONFIG_FILE}"
-	OKSO_MODEL="primary/model" DO_MODEL="legacy/model" OKSO_VERBOSITY=1 DO_VERBOSITY=2 load_config
-	[[ "${MODEL_SPEC}" == "primary/model" ]]
-	[[ "${VERBOSITY}" == "1" ]]
+@test "load_config ignores legacy DO_* variables" {
+        cd "${REPO_ROOT}" || exit 1
+        source ./src/lib/config.sh
+        CONFIG_FILE="${BATS_TEST_TMPDIR}/config-legacy.env"
+        printf "MODEL_SPEC=base/model\nMODEL_BRANCH=dev\n" >"${CONFIG_FILE}"
+        DO_MODEL="legacy/model" DO_MODEL_BRANCH="legacy-branch" DO_VERBOSITY=0 DO_SUPERVISED=false load_config
+        [[ "${MODEL_SPEC}" == "base/model" ]]
+        [[ "${MODEL_BRANCH}" == "dev" ]]
+        [[ "${VERBOSITY}" == "1" ]]
+        [[ "${APPROVE_ALL}" == "false" ]]
 }
 
 @test "load_config wires default MCP settings" {

--- a/tests/fixtures/sample.env
+++ b/tests/fixtures/sample.env
@@ -10,4 +10,3 @@ OKSO_VERBOSITY=2
 # LLAMA_BIN (string): llama.cpp binary to use for scoring; can be a stub during testing.
 LLAMA_BIN=./bin/llama-cli-mock
 
-# Legacy DO_* variables are still honored when present for backward compatibility.


### PR DESCRIPTION
## Summary
- rely solely on OKSO_* environment variables for config overrides and drop DO_* alias handling
- update configuration docs and sample env to reflect OKSO-only overrides
- adjust config tests to verify legacy DO_* inputs are ignored

## Testing
- bats tests/core/test_config.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da10797ac8325b618f709596dddde)