### PR TITLE
Handle MCP allowlist merge inside register_mcp_endpoints

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -60,3 +60,8 @@ server's `/tools` route to build a planner-friendly summary of the available
 tools. This keeps configuration terse while still giving the model concrete
 capabilities to select. Set `MCP_SKIP_USAGE_DISCOVERY=true` to fall back to
 `<tool> <query>` usage strings without hitting remote endpoints.
+
+MCP endpoints are merged into the tool allowlist automatically when
+`register_mcp_endpoints` runs. Operators no longer need to call
+`merge_tool_allowlist_with_mcp` explicitly; MCP tools become eligible for
+registration as soon as their definitions are present.


### PR DESCRIPTION
## Summary
- ensure register_mcp_endpoints merges MCP tool names into the allowlist before registration
- add a regression test covering MCP registration without prior allowlist merging
- document the implicit allowlist merge for MCP endpoint configuration

## Testing
- bats tests/tools/test_mcp.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed381c30c83259b2f52ce571af31c)