### PR TITLE
Handle non-JSON feedback context

### DIFF
--- a/tests/tools/test_feedback.sh
+++ b/tests/tools/test_feedback.sh
@@ -37,7 +37,7 @@
 }
 
 @test "feedback records rating and writes payload" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 cd "$(git rev-parse --show-toplevel)"
                 source ./src/lib/tools.sh
@@ -49,5 +49,17 @@
                 jq -e ".rating == 5 and .comment == \"ship it\" and .plan_item == \"draft summary\"" <<<"${payload}"
                 jq -e ".status == \"recorded\"" "${FEEDBACK_OUTPUT_PATH}"
         '
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
+}
+
+@test "feedback accepts raw string context" {
+        run bash -lc '
+                set -e
+                cd "$(git rev-parse --show-toplevel)"
+                source ./src/lib/tools.sh
+                TOOL_QUERY="that actually looks pretty good, please proceed"
+                FEEDBACK_NONINTERACTIVE_INPUT="4|sounds fine" payload=$(tool_feedback)
+                jq -e ".plan_item == \"that actually looks pretty good, please proceed\"" <<<"${payload}"
+        '
+        [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- relax feedback context parsing to fall back to raw strings or alternate fields when plan_item is missing
- retain observation capture while validating that a plan description is present
- add a regression test covering raw string context input

## Testing
- bats tests/tools/test_feedback.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693edc441a388325b2e7bf681f661bf4)