### PR TITLE
Refactor tool argument handling to structured JSON

### DIFF
--- a/src/prompts/planner.txt
+++ b/src/prompts/planner.txt
@@ -12,6 +12,7 @@ Do NOT include fully executable shell commands; keep the guidance conceptual.
 Select only from the provided list of available tools.
 Each action must clearly indicate which tool will be used.
 If a query involves any kind of calculation, recommend a calculation tool.
+When describing tool usage, reference the structured argument fields each tool expects (for example terminal => {command, args}, notes_create => {title, body}, reminders_create => {title, time, notes}).
 
 # Output Format
 Respond ONLY with a JSON array of strings.

--- a/src/prompts/react.txt
+++ b/src/prompts/react.txt
@@ -12,6 +12,8 @@ We all believe in you!
 Action schema (JSON Schema enforced):
 ${react_grammar}
 
+Tool arguments must be well-formed JSON objects that match each tool's fields (e.g., terminal {command:string, args:[]}, notes_create {title:string, body:string}, reminders_create {title:string, time:string, notes:string}). Do not collapse fields into a single string.
+
 High-level plan:
 ${plan_outline}
 

--- a/src/tools/notes/append.sh
+++ b/src/tools/notes/append.sh
@@ -7,7 +7,7 @@
 #   source "${BASH_SOURCE[0]%/notes/append.sh}/notes/append.sh"
 #
 # Environment variables:
-#   TOOL_QUERY (string): first line is the note title; remaining lines are appended.
+#   TOOL_ARGS (json): {"title": string, "body": string}
 #   NOTES_FOLDER (string): target folder within Apple Notes.
 #   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
 #
@@ -37,13 +37,13 @@ derive_notes_append_query() {
 tool_notes_append() {
 	local title body folder_script
 
-	if ! notes_require_platform; then
-		return 0
-	fi
+        if ! notes_require_platform; then
+                return 0
+        fi
 
-	if ! { IFS= read -r -d '' title && IFS= read -r -d '' body; } < <(notes_extract_title_and_body); then
-		return 0
-	fi
+        if ! { IFS= read -r -d '' title && IFS= read -r -d '' body; } < <(notes_extract_title_and_body); then
+                return 1
+        fi
 
 	folder_script="$(notes_resolve_folder_script)"
 
@@ -69,15 +69,14 @@ APPLESCRIPT
 register_notes_append() {
 	local args_schema
 
-	args_schema=$(
-		cat <<'JSON'
-{"type":"object","required":["content"],"properties":{"content":{"type":"string","minLength":1}},"additionalProperties":false}
+        args_schema=$(cat <<'JSON'
+{"type":"object","required":["title"],"properties":{"title":{"type":"string","minLength":1},"body":{"type":"string"}},"additionalProperties":false}
 JSON
-	)
-	register_tool \
-		"notes_append" \
-		"Append text to an existing Apple Note matched by title." \
-		"notes_append 'Title\nAdditional text' (first line is title, following lines are appended)" \
+        )
+        register_tool \
+                "notes_append" \
+                "Append text to an existing Apple Note matched by title." \
+                "notes_append {\"title\":\"Title\",\"body\":\"Additional text\"}" \
 		"Requires macOS Apple Notes access; updates existing note content." \
 		tool_notes_append \
 		"${args_schema}"

--- a/src/tools/notes/common.sh
+++ b/src/tools/notes/common.sh
@@ -33,38 +33,36 @@ notes_folder_name() {
 }
 
 notes_require_platform() {
-	# Ensures Apple Notes tools only run on macOS with osascript available.
-	if ! assert_osascript_available \
-		"Apple Notes is only available on macOS" \
-		"osascript missing; cannot reach Apple Notes" \
-		"${NOTES_OSASCRIPT_BIN:-osascript}" \
-		"${TOOL_QUERY:-}"; then
-		return 1
-	fi
+        # Ensures Apple Notes tools only run on macOS with osascript available.
+        if ! assert_osascript_available \
+                "Apple Notes is only available on macOS" \
+                "osascript missing; cannot reach Apple Notes" \
+                "${NOTES_OSASCRIPT_BIN:-osascript}" \
+                "${TOOL_ARGS:-}"; then
+                return 1
+        fi
 
-	return 0
+        return 0
 }
 
 notes_extract_title_and_body() {
-	# Splits TOOL_QUERY into a title (first line) and body (remaining lines).
-	# Emits two lines to stdout: title then body.
-	local query title body
-	query=${TOOL_QUERY:-""}
+        # Splits TOOL_ARGS into a title (first line) and body (remaining lines).
+        # Emits two lines to stdout: title then body.
+        local title body
 
-	if [[ -z "${query//[[:space:]]/}" ]]; then
-		log "ERROR" "Note content is required" "" || true
-		return 1
-	fi
+        title=$(jq -er '.title // empty' <<<"${TOOL_ARGS:-{}}" 2>/dev/null || true)
+        body=$(jq -er '.body // ""' <<<"${TOOL_ARGS:-{}}" 2>/dev/null || true)
 
-	title=${query%%$'\n'*}
-	body=${query#"${title}"}
-	body=${body#$'\n'}
+        if [[ -z "${title//[[:space:]]/}" && -z "${body//[[:space:]]/}" ]]; then
+                log "ERROR" "Note content is required" "" || true
+                return 1
+        fi
 
-	if [[ -z "${title//[[:space:]]/}" ]]; then
-		title="Untitled note $(date -Iseconds)"
-	fi
+        if [[ -z "${title//[[:space:]]/}" ]]; then
+                title="Untitled note $(date -Iseconds)"
+        fi
 
-	printf '%s\0%s\0' "${title}" "${body}"
+        printf '%s\0%s\0' "${title}" "${body}"
 }
 
 notes_run_script() {

--- a/src/tools/notes/read.sh
+++ b/src/tools/notes/read.sh
@@ -7,7 +7,7 @@
 #   source "${BASH_SOURCE[0]%/notes/read.sh}/notes/read.sh"
 #
 # Environment variables:
-#   TOOL_QUERY (string): title of the note to read.
+#   TOOL_ARGS (json): {"title": string}
 #   NOTES_FOLDER (string): target folder within Apple Notes.
 #   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
 #
@@ -35,17 +35,17 @@ derive_notes_read_query() {
 }
 
 tool_notes_read() {
-	local title folder_script
-	title=${TOOL_QUERY:-""}
+        local title folder_script
+        title=$(jq -er '.title // empty' <<<"${TOOL_ARGS:-{}}" 2>/dev/null || true)
 
 	if ! notes_require_platform; then
 		return 0
 	fi
 
-	if [[ -z "${title//[[:space:]]/}" ]]; then
-		log "ERROR" "Note title is required to read a note" "" || true
-		return 0
-	fi
+        if [[ -z "${title//[[:space:]]/}" ]]; then
+                log "ERROR" "Note title is required to read a note" "" || true
+                return 1
+        fi
 
 	folder_script="$(notes_resolve_folder_script)"
 

--- a/src/tools/reminders/complete.sh
+++ b/src/tools/reminders/complete.sh
@@ -7,7 +7,7 @@
 #   source "${BASH_SOURCE[0]%/reminders/complete.sh}/reminders/complete.sh"
 #
 # Environment variables:
-#   TOOL_QUERY (string): reminder title (first line is used).
+#   TOOL_ARGS (json): {"title": string}
 #   REMINDERS_LIST (string): target list within Apple Reminders.
 #   IS_MACOS (bool): indicates whether macOS-specific tooling should run.
 #
@@ -31,13 +31,13 @@ source "${BASH_SOURCE[0]%/complete.sh}/common.sh"
 tool_reminders_complete() {
 	local title list_script
 
-	if ! reminders_require_platform; then
-		return 0
-	fi
+        if ! reminders_require_platform; then
+                return 0
+        fi
 
-	if ! IFS= read -r -d '' title < <(reminders_extract_title_and_body); then
-		return 0
-	fi
+        if ! IFS= read -r -d '' title < <(reminders_extract_title_and_body); then
+                return 1
+        fi
 
 	list_script="$(reminders_resolve_list_script)"
 

--- a/tests/tools/test_notes.sh
+++ b/tests/tools/test_notes.sh
@@ -12,8 +12,7 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "notes tools warn when run off macOS" {
-	run bash -lc 'source ./src/tools/notes/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_QUERY=$'"'"'Title
-Body'"'"'; tool_notes_create'
+        run bash -lc 'source ./src/tools/notes/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_ARGS="{\"title\":\"Title\",\"body\":\"Body\"}"; tool_notes_create'
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Apple Notes is only available on macOS"* ]]
 }
@@ -24,9 +23,7 @@ Body'"'"'; tool_notes_create'
                 export NOTES_STUB_LOG="$(mktemp)"
                 export IS_MACOS=true
                 export VERBOSITY=0
-                TOOL_QUERY=$'"'"'Quick title
-First line
-Second line'"'"'
+                TOOL_ARGS='"'"'{"title":"Quick title","body":"First line\nSecond line"}'"'"'
                 source ./src/tools/notes/index.sh
                 tool_notes_create
                 cat "${NOTES_STUB_LOG}"
@@ -34,4 +31,16 @@ Second line'"'"'
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"ARGS: - Quick\\ title $'First line\\nSecond line'"* ]]
 	[[ "$output" == *"Second line"* ]]
+}
+
+@test "notes tools validate missing title" {
+        run bash -lc '
+                export NOTES_OSASCRIPT_BIN="/bin/echo"
+                export IS_MACOS=true
+                export VERBOSITY=0
+                TOOL_ARGS="{}"
+                source ./src/tools/notes/index.sh
+                tool_notes_create
+        '
+        [ "$status" -eq 1 ]
 }

--- a/tests/tools/test_reminders.sh
+++ b/tests/tools/test_reminders.sh
@@ -12,7 +12,7 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "reminders tools warn when run off macOS" {
-	run bash -lc 'source ./src/tools/reminders/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_QUERY=$'"'"'Title\nBody'"'"'; tool_reminders_create'
+        run bash -lc 'source ./src/tools/reminders/index.sh; IS_MACOS=false; VERBOSITY=1; TOOL_ARGS="{\"title\":\"Title\",\"notes\":\"Body\"}"; tool_reminders_create'
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"Apple Reminders is only available on macOS"* ]]
 }
@@ -23,7 +23,7 @@
                 export REMINDERS_STUB_LOG="$(mktemp)"
                 export IS_MACOS=true
                 export VERBOSITY=0
-                TOOL_QUERY=$'"'"'Quick reminder\nBody text'"'"'
+                TOOL_ARGS='"'"'{"title":"Quick reminder","notes":"Body text","time":""}'"'"'
                 source ./src/tools/reminders/index.sh
                 tool_reminders_create
                 cat "${REMINDERS_STUB_LOG}"
@@ -39,7 +39,7 @@
                 export REMINDERS_STUB_LOG="$(mktemp)"
                 export IS_MACOS=true
                 export VERBOSITY=0
-                TOOL_QUERY=$'"'"'Finish errands'"'"'
+                TOOL_ARGS='"'"'{"title":"Finish errands"}'"'"'
                 source ./src/tools/reminders/index.sh
                 tool_reminders_complete
                 cat "${REMINDERS_STUB_LOG}"
@@ -47,4 +47,16 @@
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"ARGS: - Finish\ errands"* ]]
 	[[ "$output" == *"set completed of r to true"* ]]
+}
+
+@test "reminders tools validate missing title" {
+        run bash -lc '
+                export REMINDERS_OSASCRIPT_BIN="/bin/echo"
+                export IS_MACOS=true
+                export VERBOSITY=0
+                TOOL_ARGS="{}"
+                source ./src/tools/reminders/index.sh
+                tool_reminders_create
+        '
+        [ "$status" -eq 1 ]
 }

--- a/tests/tools/test_terminal.sh
+++ b/tests/tools/test_terminal.sh
@@ -12,43 +12,43 @@
 #   Inherits Bats semantics; individual tests assert script exit codes.
 
 @test "status default exposes allowed commands" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY=""; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{}"; tool_terminal'
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == Session:* ]]
 	[[ "${output}" == *"Allowed commands:"* ]]
 }
 
 @test "cd updates persistent working directory" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(pwd)"; TOOL_QUERY="cd tests"; tool_terminal; TOOL_QUERY="pwd"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(pwd)"; TOOL_ARGS="{\"command\":\"cd\",\"args\":[\"tests\"]}"; tool_terminal; TOOL_ARGS="{\"command\":\"pwd\",\"args\":[]}"; tool_terminal'
 	[ "$status" -eq 0 ]
 	last_index=$((${#lines[@]} - 1))
 	[[ "${lines[$last_index]}" == *"/tests" ]]
 }
 
 @test "unknown command falls back to status" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="launch rockets"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"launch\",\"args\":[\"rockets\"]}"; tool_terminal'
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"Allowed commands:"* ]]
 }
 
 @test "mkdir and rmdir operate within working directory" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(mktemp -d)"; TOOL_QUERY="mkdir sandbox"; tool_terminal; TOOL_QUERY="rmdir sandbox"; tool_terminal; ls "${TERMINAL_WORKDIR}"'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(mktemp -d)"; TOOL_ARGS="{\"command\":\"mkdir\",\"args\":[\"sandbox\"]}"; tool_terminal; TOOL_ARGS="{\"command\":\"rmdir\",\"args\":[\"sandbox\"]}"; tool_terminal; ls "${TERMINAL_WORKDIR}"'
 	[ "$status" -eq 0 ]
 	[[ -z "${output}" ]]
 }
 
 @test "mkdir errors without target" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="mkdir"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"mkdir\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"mkdir requires a target directory"* ]]
 }
 
 @test "mv and cp require source and destination" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="mv source-only"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"mv\",\"args\":[\"source-only\"]}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"mv requires a source and destination"* ]]
 
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="cp"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"cp\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"cp requires a source and destination"* ]]
 }
@@ -60,9 +60,9 @@
                 VERBOSITY=0
                 TERMINAL_WORKDIR="$(mktemp -d)"
                 echo "demo" >"${TERMINAL_WORKDIR}/original.txt"
-                TOOL_QUERY="cp original.txt copy.txt"; tool_terminal
-                TOOL_QUERY="mv copy.txt moved.txt"; tool_terminal
-                TOOL_QUERY="cat moved.txt"; tool_terminal
+                TOOL_ARGS='"'"'{"command":"cp","args":["original.txt","copy.txt"]}'"'"'; tool_terminal
+                TOOL_ARGS='"'"'{"command":"mv","args":["copy.txt","moved.txt"]}'"'"'; tool_terminal
+                TOOL_ARGS='"'"'{"command":"cat","args":["moved.txt"]}'"'"'; tool_terminal
         '
 	[ "$status" -eq 0 ]
 	last_index=$((${#lines[@]} - 1))
@@ -75,12 +75,12 @@
                 source ./src/tools/terminal.sh
                 VERBOSITY=0
                 TERMINAL_WORKDIR="$(mktemp -d)"
-                TOOL_QUERY="touch created.txt"; tool_terminal
+                TOOL_ARGS='"'"'{"command":"touch","args":["created.txt"]}'"'"'; tool_terminal
                 [ -f "${TERMINAL_WORKDIR}/created.txt" ]
         '
 	[ "$status" -eq 0 ]
 
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="touch"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"touch\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"touch requires at least one target"* ]]
 }
@@ -91,24 +91,24 @@
                 VERBOSITY=0
                 TERMINAL_WORKDIR="$(mktemp -d)"
                 echo "to delete" >"${TERMINAL_WORKDIR}/temp.txt"
-                printf "y\n" | TOOL_QUERY="rm temp.txt" tool_terminal
+                printf "y\n" | TOOL_ARGS='"'"'{"command":"rm","args":["temp.txt"]}'"'"' tool_terminal
                 [ ! -f "${TERMINAL_WORKDIR}/temp.txt" ]
         '
 	[ "$status" -eq 0 ]
 }
 
 @test "rm emits error when no target provided" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="rm"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"rm\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"rm requires a target"* ]]
 }
 
 @test "stat and wc validate targets" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="stat"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"stat\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"stat requires a target"* ]]
 
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="wc"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"wc\"}"; tool_terminal'
 	[ "$status" -eq 1 ]
 	[[ "${output}" == *"wc requires at least one target"* ]]
 }
@@ -120,15 +120,15 @@
                 VERBOSITY=0
                 TERMINAL_WORKDIR="$(mktemp -d)"
                 printf "line one\nline two\n" >"${TERMINAL_WORKDIR}/data.txt"
-                TOOL_QUERY="stat data.txt"; tool_terminal
-                TOOL_QUERY="wc -l data.txt"; tool_terminal
+                TOOL_ARGS='"'"'{"command":"stat","args":["data.txt"]}'"'"'; tool_terminal
+                TOOL_ARGS='"'"'{"command":"wc","args":["-l","data.txt"]}'"'"'; tool_terminal
         '
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"2 data.txt"* ]]
 }
 
 @test "du defaults to human-readable summary" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(mktemp -d)"; TOOL_QUERY="du"; tool_terminal'
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TERMINAL_WORKDIR="$(mktemp -d)"; TOOL_ARGS="{\"command\":\"du\"}"; tool_terminal'
 	[ "$status" -eq 0 ]
 	[[ "${lines[0]}" == *"." ]]
 }
@@ -140,8 +140,8 @@
                 VERBOSITY=0
                 TERMINAL_WORKDIR="$(mktemp -d)"
                 printf "encode me" >"${TERMINAL_WORKDIR}/payload.txt"
-                TOOL_QUERY="base64 encode payload.txt"; tool_terminal >"${TERMINAL_WORKDIR}/encoded.txt"
-                TOOL_QUERY="base64 decode encoded.txt"; tool_terminal
+                TOOL_ARGS='"'"'{"command":"base64","args":["encode","payload.txt"]}'"'"'; tool_terminal >"${TERMINAL_WORKDIR}/encoded.txt"
+                TOOL_ARGS='"'"'{"command":"base64","args":["decode","encoded.txt"]}'"'"'; tool_terminal
         '
 	[ "$status" -eq 0 ]
 	last_index=$((${#lines[@]} - 1))
@@ -149,17 +149,23 @@
 }
 
 @test "base64 validates modes and arguments" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="base64"; tool_terminal'
-	[ "$status" -eq 1 ]
-	[[ "${output}" == *"base64 requires a mode"* ]]
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"base64\"}"; tool_terminal'
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"base64 requires a mode"* ]]
 
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_QUERY="base64 transform file"; tool_terminal'
-	[ "$status" -eq 1 ]
-	[[ "${output}" == *"base64 mode must be encode or decode"* ]]
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"base64\",\"args\":[\"transform\",\"file\"]}"; tool_terminal'
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"base64 mode must be encode or decode"* ]]
+}
+
+@test "terminal args require array input" {
+        run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":\"bad\"}"; tool_terminal'
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"terminal args must supply an array for args"* ]]
 }
 
 @test "open warns on non-macOS hosts" {
-	run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; IS_MACOS=false; TOOL_QUERY="open README.md"; tool_terminal'
+    run bash -lc 'source ./src/tools/terminal.sh; VERBOSITY=0; IS_MACOS=false; TOOL_ARGS="{\"command\":\"open\",\"args\":[\"README.md\"]}"; tool_terminal'
 	[ "$status" -eq 0 ]
 	[[ "${output}" == *"macOS-only"* ]]
 }


### PR DESCRIPTION
## Summary
- Convert planner tooling to emit structured JSON arguments for terminal, notes, reminders, and related tools and refresh prompts to describe the shapes
- Update tool handlers to consume TOOL_ARGS with validation for required fields and structured parsing
- Expand Bats coverage for terminal, notes, and reminders to verify structured inputs and error handling

## Testing
- bats tests/tools/test_terminal.sh
- bats tests/tools/test_notes.sh
- bats tests/tools/test_reminders.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ef94660dc832595bdf18618a8eeb7)