### PR TITLE
Simplify ReAct action schema

### DIFF
--- a/docs/reference/grammars.md
+++ b/docs/reference/grammars.md
@@ -5,7 +5,7 @@ Structured outputs keep planner interactions predictable. Grammar files live in 
 ## Available schemas
 
 - `planner_plan.schema.json`: numbered outline that proposes tools and ends with `final_answer`.
-- `react_action.schema.json`: single tool call per ReAct turn with tool name, arguments, and optional planner context.
+- `react_action.schema.json`: single tool call per ReAct turn with thought, tool name, and arguments.
 - `concise_response.schema.json`: short direct answers when no tools should run.
 
 Add new schemas alongside prompts in `src/lib/prompts.sh` when introducing new tool types or output formats.

--- a/src/grammars/react_action.schema.json
+++ b/src/grammars/react_action.schema.json
@@ -3,10 +3,9 @@
   "title": "ReactActionBase",
   "description": "Base ReAct action shape; runtime grammars are generated from the tool registry and allowed tool list.",
   "type": "object",
-  "required": ["type", "thought", "tool", "args"],
+  "required": ["thought", "tool", "args"],
   "additionalProperties": false,
   "properties": {
-    "type": { "const": "tool" },
     "thought": { "type": "string", "minLength": 1 },
     "tool": { "type": "string", "minLength": 1 },
     "args": { "type": "object" }

--- a/tests/planner/test_react_action.sh
+++ b/tests/planner/test_react_action.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+#
+# Regression tests for ReAct action validation and selection.
+#
+# Usage:
+#   bats tests/planner/test_react_action.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+
+@test "validate_react_action accepts actions without type" {
+        script=$(
+                cat <<'INNERSCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+source ./src/lib/planner.sh
+
+tool_registry_json() {
+        printf "%s" '{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","required":["message"],"properties":{"message":{"type":"string","minLength":1}},"additionalProperties":false}}}}'
+}
+
+tool_names() { printf "%s\n" "alpha"; }
+
+schema_path="$(build_react_action_grammar "alpha")"
+action='{"thought":"go","tool":"alpha","args":{"message":"hi"}}'
+validated="$(validate_react_action "${action}" "${schema_path}")"
+rm -f "${schema_path}"
+
+jq -e 'has("thought") and has("tool") and has("args") and (.thought=="go") and (.tool=="alpha") and (.args.message=="hi") and (has("type")|not)' <<<"${validated}"
+INNERSCRIPT
+        )
+
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
+}
+
+@test "select_next_action emits simplified payload when llama is unavailable" {
+        script=$(
+                cat <<'INNERSCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+USE_REACT_LLAMA=false
+LLAMA_AVAILABLE=false
+
+source ./src/lib/planner.sh
+
+state_prefix=react
+initialize_react_state "${state_prefix}" "demo request" $'terminal\nfinal_answer' $'terminal|echo hi|0' $'1. terminal -> run echo'
+
+next_action="$(select_next_action "${state_prefix}")"
+
+jq -e 'has("thought") and has("tool") and has("args") and (has("type")|not)' <<<"${next_action}"
+INNERSCRIPT
+        )
+
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- drop the legacy `type` field from the ReAct action schema and generated grammars while keeping the required thought/tool/args shape
- update validation and fallback action construction to emit the simplified payload
- add regression coverage for type-less actions and llama-unavailable selection flows

## Testing
- bats tests/planner/test_react_action.sh
- bats tests/core/test_prompts.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693efddd61a88325a53236aafc1247aa)