### PR TITLE
Disallow extraneous ReAct tool args by default

### DIFF
--- a/src/lib/planner.sh
+++ b/src/lib/planner.sh
@@ -596,12 +596,16 @@ tool_enum = []
 for name in allowed:
     info = registry_map.get(name, {})
     schema = info.get("args_schema") if isinstance(info, dict) else None
-    if not isinstance(schema, dict):
+    has_defined_schema = isinstance(schema, dict)
+    if not has_defined_schema:
         schema = fallback_schema
 
     normalized = {"type": "object"}
     normalized.update(schema)
-    normalized.setdefault("additionalProperties", {"type": "string"})
+    if has_defined_schema:
+        normalized.setdefault("additionalProperties", False)
+    else:
+        normalized.setdefault("additionalProperties", {"type": "string"})
 
     args_by_tool[name] = normalized
     tool_enum.append(name)
@@ -708,7 +712,9 @@ properties = tool_schema.get("properties", {})
 if not isinstance(properties, dict):
     properties = {}
 required_args = tool_schema.get("required", [])
-additional_properties = tool_schema.get("additionalProperties", False)
+additional_properties = tool_schema.get("additionalProperties")
+if additional_properties is None:
+    additional_properties = False
 
 for key in required_args:
     if key not in args:

--- a/tests/planner/test_react_action.sh
+++ b/tests/planner/test_react_action.sh
@@ -10,8 +10,8 @@
 #   - bash 5+
 
 @test "validate_react_action accepts actions without type" {
-	script=$(
-		cat <<'INNERSCRIPT'
+        script=$(
+                cat <<'INNERSCRIPT'
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
@@ -30,10 +30,75 @@ rm -f "${schema_path}"
 
 jq -e 'has("thought") and has("tool") and has("args") and (.thought=="go") and (.tool=="alpha") and (.args.message=="hi") and (has("type")|not)' <<<"${validated}"
 INNERSCRIPT
-	)
+        )
 
-	run bash -lc "${script}"
-	[ "$status" -eq 0 ]
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
+}
+
+@test "build_react_action_grammar disallows extra args unless opted in" {
+        script=$(
+                cat <<'INNERSCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+source ./src/lib/planner.sh
+
+tool_registry_json() {
+        printf "%s" '{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","required":["message"],"properties":
+{"message":{"type":"string","minLength":1}}}}}}'
+}
+
+tool_names() { printf "%s\n" "alpha"; }
+
+schema_path="$(build_react_action_grammar "alpha")"
+
+jq -e '."$defs".args_by_tool.alpha.additionalProperties == false' "${schema_path}"
+
+rm -f "${schema_path}"
+INNERSCRIPT
+        )
+
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
+}
+
+@test "validate_react_action rejects extraneous arguments" {
+        script=$(
+                cat <<'INNERSCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+source ./src/lib/planner.sh
+
+tool_registry_json() {
+        printf "%s" '{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","required":["message"],"properties":
+{"message":{"type":"string","minLength":1}}}}}}'
+}
+
+tool_names() { printf "%s\n" "alpha"; }
+
+schema_path="$(build_react_action_grammar "alpha")"
+
+invalid_action='{"thought":"go","tool":"alpha","args":{"message":"hi","noise":"boom"}}'
+
+set +e
+validate_react_action "${invalid_action}" "${schema_path}" 2>err.log
+status=$?
+set -e
+
+if [[ ${status} -eq 0 ]]; then
+        echo "validation unexpectedly succeeded"
+        exit 1
+fi
+
+grep -F "Unexpected arg: noise" err.log
+rm -f "${schema_path}" err.log
+INNERSCRIPT
+        )
+
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
 }
 
 @test "select_next_action emits simplified payload when llama is unavailable" {


### PR DESCRIPTION
## Summary
- default ReAct tool schemas to disallow extra arguments unless explicitly opted in
- mirror the stricter additionalProperties handling in validation logic
- add planner Bats tests covering schema defaults and extraneous argument rejection

## Testing
- bats tests/planner/test_react_action.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f09a2e64883259fc84eea8675c0a1)