### PR TITLE
Improve tool error reporting and validation

### DIFF
--- a/src/grammars/react_action.schema.json
+++ b/src/grammars/react_action.schema.json
@@ -6,6 +6,7 @@
   "required": ["thought", "tool", "args"],
   "additionalProperties": false,
   "properties": {
+    "type": { "type": "string", "enum": ["tool"] },
     "thought": { "type": "string", "minLength": 1 },
     "tool": { "type": "string", "minLength": 1 },
     "args": { "type": "object" }

--- a/src/tools/terminal.sh
+++ b/src/tools/terminal.sh
@@ -182,10 +182,11 @@ tool_terminal() {
 	command="${TERMINAL_CMD}"
 	args=("${TERMINAL_CMD_ARGS[@]}")
 
-	if ! terminal_allowed "${command}"; then
-		log "WARN" "Unknown terminal command; showing status" "${command}"
-		command="status"
-	fi
+        if ! terminal_allowed "${command}"; then
+                log "WARN" "Unknown terminal command; rejecting" "${command}"
+                printf 'Command "%s" is not allowed. Allowed commands: %s\n' "${command}" "${TERMINAL_ALLOWED_COMMANDS[*]}"
+                return 1
+        fi
 
 	case "${command}" in
 	status)
@@ -223,13 +224,14 @@ tool_terminal() {
 	grep)
 		terminal_run_in_workdir grep "${args[@]}"
 		;;
-	open)
-		if [[ "${IS_MACOS}" != true ]]; then
-			log "WARN" "'open' is macOS-only; skipping" "${args[*]:-""}"
-			return 0
-		fi
-		terminal_run_in_workdir open "${args[@]}"
-		;;
+        open)
+                if [[ "${IS_MACOS}" != true ]]; then
+                        log "WARN" "'open' is macOS-only; skipping" "${args[*]:-""}"
+                        printf "'open' is only available on macOS.\n"
+                        return 1
+                fi
+                terminal_run_in_workdir open "${args[@]}"
+                ;;
 	mkdir)
 		if [[ ${#args[@]} -eq 0 ]]; then
 			log "ERROR" "mkdir requires a target directory" ""


### PR DESCRIPTION
## Summary
- append stderr and exit-code summaries to tool observations while preserving logs
- provide explicit messaging for unsupported terminal commands and allow action validation with type metadata
- expand coverage for failing tools and disallowed commands, including updated grammar and history expectations

## Testing
- bats tests/core/test_modules.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f0a0d1fcc83258113f4dda0b8f29f)