### PR TITLE
Improve parse_json_logs compatibility with boxed summaries

### DIFF
--- a/tests/helpers/log_parsing.bats
+++ b/tests/helpers/log_parsing.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Regression tests for extracting structured JSON logs from mixed output.
+
+load log_parsing.sh
+
+@test "parse_json_logs ignores boxed summaries appended to structured logs" {
+        # Arrange: mix compact JSON entries, stray text, and a boxed summary block.
+        mixed_output=$'{"message":"Planner identified tools","detail":"tool-a"}\n'\
+'noise line\n'\
+$'{"message":"Final answer","detail":"Done"}\n'\
+$'┌─────────────\n'\
+$'│ Final answer\n'\
+$'└─────────────'
+
+        # Act
+        parsed_logs=$(parse_json_logs <<<"${mixed_output}")
+
+        # Assert
+        [ "$(jq length <<<"${parsed_logs}")" -eq 2 ]
+        [[ "$(jq -r '.[0].message' <<<"${parsed_logs}")" == "Planner identified tools" ]]
+        [[ "$(jq -r '.[1].detail' <<<"${parsed_logs}")" == "Done" ]]
+}
+
+@test "parse_json_logs handles pretty-printed JSON blocks" {
+        # Arrange: pretty JSON followed by a boxed recap.
+        pretty_json=$'{\n  "message": "Final answer",\n  "detail": "Great success"\n}\n'\
+$'┌───────\n'\
+$'│ Final\n'\
+$'└───────'
+
+        # Act
+        parsed_logs=$(parse_json_logs <<<"${pretty_json}")
+
+        # Assert
+        [ "$(jq length <<<"${parsed_logs}")" -eq 1 ]
+        [[ "$(jq -r '.[0].detail' <<<"${parsed_logs}")" == "Great success" ]]
+}

--- a/tests/helpers/log_parsing.sh
+++ b/tests/helpers/log_parsing.sh
@@ -5,24 +5,28 @@
 #   load helpers/log_parsing
 #   logs_json="$(printf '%s' "$output" | parse_json_logs)"
 parse_json_logs() {
-	python -c 'import json,sys
+        python -c 'import json, sys
 
 data = sys.stdin.read()
 decoder = json.JSONDecoder()
 logs = []
-pos = 0
+search_start = 0
 
-while pos < len(data):
+while True:
+    brace_index = data.find("{", search_start)
+    if brace_index == -1:
+        break
+
     try:
-        entry, idx = decoder.raw_decode(data, pos)
+        entry, end_index = decoder.raw_decode(data, brace_index)
     except json.JSONDecodeError:
-        pos += 1
+        search_start = brace_index + 1
         continue
 
     if isinstance(entry, dict):
         logs.append(entry)
 
-    pos = idx
+    search_start = end_index
 
 print(json.dumps(logs))
 '


### PR DESCRIPTION
## Summary
- update `parse_json_logs` to scan efficiently for JSON objects within mixed log output
- add regression tests covering boxed summary text and pretty-printed JSON logs

## Testing
- bats tests/helpers/log_parsing.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69420b0ec3288325a166f1074b24c7ba)