### PR TITLE
Refactor docs and split advanced README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,36 +46,8 @@ Initialize a config file with your preferred model settings:
 ./src/bin/okso init --model your-org/your-model:custom.gguf --model-branch main
 ```
 
-More scenarios and reference material live in the [docs/](docs/index.md).
+More scenarios and reference material live in the [docs/](docs/index.md), including:
 
-## Execution model
-
-okso separates high-level planning from step-by-step execution:
-
-- **Planner pass:** drafts a numbered outline that mentions the tools to use.
-- **ReAct loop:** by default, llama.cpp is queried before each step to pick the next tool
-  and craft an appropriate call based on prior observations.
-
-If llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso falls back to a
-deterministic sequence that feeds the original user query to each planned tool.
-
-## Capturing feedback
-
-The bundled `feedback` tool records a 1-5 rating and optional comments for the
-current plan item. Provide a JSON context payload describing the step and
-observation summary:
-
-```bash
-TOOL_QUERY='{"plan_item":"Summarize notes","observations":"Draft complete"}' \
-  FEEDBACK_NONINTERACTIVE_INPUT="5|Clear summary" \
-  bash -lc 'source ./src/tools/feedback.sh; tool_feedback'
-```
-
-Interactive prompts are enabled by default. Set `FEEDBACK_ENABLED=false` to
-skip prompting entirely or `FEEDBACK_OUTPUT_PATH=${HOME}/.okso/feedback.json` to
-persist the captured payload within the writable allowlist.
-
-## Prompt assets
-
-Prompt templates live alongside grammar definitions to keep the assistant behaviour easy to review.
-Each prompt has a dedicated file in `src/prompts/` (for example, `concise_response.txt`, `planner.txt`, and `react.txt`) and is loaded by the helpers in `src/lib/prompts.sh` before being sent to llama.cpp.
+- [Execution model](docs/reference/execution-model.md): how planning and ReAct loops interact with tool calls.
+- [Capturing feedback](docs/reference/feedback.md): recording plan ratings and configuring prompts.
+- [Prompt assets](docs/reference/prompts.md): where prompts live and how they load.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@ Use this map to find the right guide:
   - [Installation](user-guides/installation.md): install, upgrade, or uninstall the CLI.
   - [Usage](user-guides/usage.md): command-line flags and common execution patterns.
 - **Reference** (`docs/reference/`)
+  - [Execution model](reference/execution-model.md): planning steps, ReAct loops, and tracing hooks.
+  - [Feedback](reference/feedback.md): rating plan items interactively or non-interactively.
+  - [Prompts](reference/prompts.md): template layout and grammar links.
   - [Configuration](reference/configuration.md): environment variables and config file keys.
   - [Tools](reference/tools.md): available tool handlers and platform notes.
   - [Grammars](reference/grammars.md): JSON schemas that keep planner output predictable.

--- a/docs/reference/execution-model.md
+++ b/docs/reference/execution-model.md
@@ -1,0 +1,26 @@
+# Execution model
+
+okso separates high-level planning from step-by-step execution so that tool calls stay predictable and reviewable.
+
+## Planner pass
+
+1. The planner drafts a numbered outline that mentions the tools to use for each step.
+2. The outline is emitted as structured JSON for logging and optional downstream automation.
+3. Approval prompts give you a chance to refine or abort the plan before any commands run.
+
+## ReAct loop
+
+After the plan is approved, the runtime iterates through each item:
+
+- **Default behaviour:** llama.cpp is queried before each step to pick the next tool and craft an appropriate call based on the running transcript.
+- **Fallback behaviour:** if llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso runs a deterministic sequence that feeds the original user query to each planned tool.
+
+The active plan item and observations are streamed to the terminal to make model decisions auditable. Use `--dry-run` when you want to inspect the generated plan and tool calls without executing anything.
+
+## Configuration hooks
+
+- `USE_REACT_LLAMA`: toggles the ReAct pass (defaults to enabled).
+- `OKSO_PLAN_OUTPUT`: file path for writing the approved plan JSON.
+- `OKSO_TRACE_DIR`: directory for trace artifacts from each tool run.
+
+See [usage](../user-guides/usage.md) for CLI flags that control approvals and dry runs.

--- a/docs/reference/feedback.md
+++ b/docs/reference/feedback.md
@@ -1,0 +1,34 @@
+# Capturing feedback
+
+Use the bundled `feedback` tool to record ratings for each plan item. Feedback events help tune prompts and surface regressions without storing raw transcripts.
+
+## Quick start
+
+Provide a JSON context payload describing the current plan item and any prior observations, then supply the score and optional notes:
+
+```bash
+TOOL_QUERY='{"plan_item":"Summarize notes","observations":"Draft complete"}' \
+  FEEDBACK_NONINTERACTIVE_INPUT="5|Clear summary" \
+  bash -lc 'source ./src/tools/feedback.sh; tool_feedback'
+```
+
+Interactive prompts are enabled by default. Set `FEEDBACK_ENABLED=false` to skip prompting entirely. To persist the captured payload within the writable allowlist, set `FEEDBACK_OUTPUT_PATH=${HOME}/.okso/feedback.json`.
+
+## Runtime prompts
+
+When interactive mode is enabled, the tool will:
+
+1. Print the plan item and recent observations.
+2. Request a 1-5 numeric rating.
+3. Optionally collect a short free-form note.
+
+Use `FEEDBACK_NONINTERACTIVE_INPUT` to pre-fill both fields when running in CI or other unattended environments (`rating|note`).
+
+## Additional controls
+
+- `FEEDBACK_ENABLED`: globally toggles feedback collection.
+- `FEEDBACK_OUTPUT_PATH`: path for the JSONL log of captured events.
+- `FEEDBACK_MIN_INTERVAL`: minimum seconds between prompts to avoid chatter during rapid tool loops.
+- `FEEDBACK_MAX_ENTRIES`: cap the number of stored events before rotation.
+
+The feedback handler is loaded via `src/tools/feedback.sh`; see [tools](tools.md) for broader tool lifecycle details.

--- a/docs/reference/prompts.md
+++ b/docs/reference/prompts.md
@@ -1,0 +1,21 @@
+# Prompt assets
+
+Prompt templates live alongside grammar definitions so the assistant behaviour stays easy to review and update.
+
+## Layout
+
+- `src/prompts/`: text templates used by the planner, ReAct loop, and response helpers (for example, `concise_response.txt`, `planner.txt`, and `react.txt`).
+- `src/lib/prompts.sh`: helper functions that load prompt files, substitute runtime variables, and pass the final strings to llama.cpp.
+- `src/grammars/`: JSON grammars that constrain planner output and tool arguments.
+
+## Working with prompts
+
+- Edit templates directly to adjust tone or required fields. Keep grammar changes in sync to avoid model errors.
+- Store reusable snippets (such as safety disclaimers) in dedicated files and compose them within the main prompt templates.
+- Keep prompts minimal and version-controlled; avoid inlining large instructions in code so they remain discoverable for audits.
+
+## Related resources
+
+- [Grammars](grammars.md): schema details for planner and tool outputs.
+- [Execution model](execution-model.md): how prompts feed into planning and the ReAct loop.
+- [Tools](tools.md): available handlers that consume prompt output.


### PR DESCRIPTION
## Summary
- Trim README to focus on installation and common usage, linking to detailed docs
- Move execution model, feedback, and prompt details into dedicated reference pages
- Surface new reference topics from the docs index for easier navigation

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694369a227648325bcd1b2fb4ec51e73)