### PR TITLE
Add task-based usage walkthroughs and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,7 @@ See [docs/user-guides/installation.md](docs/user-guides/installation.md) for add
 
 ## Basic usage
 
-Run a prompted plan and tool execution:
-
-```bash
-./src/bin/okso -- "inspect project layout and search notes"
-```
-
-Skip confirmations and pick a specific model:
-
-```bash
-./src/bin/okso --yes --model your-org/your-model:custom.gguf -- "save reminder"
-```
-
-Initialize a config file with your preferred model settings:
-
-```bash
-./src/bin/okso init --model your-org/your-model:custom.gguf --model-branch main
-```
-
-More scenarios and reference material live in the [docs/](docs/index.md), including:
+See [docs/user-guides/usage.md](docs/user-guides/usage.md) for task-based walkthroughs (approvals, offline feedback capture, and configuration setup). Reference material lives in the [docs/](docs/index.md), including:
 
 - [Execution model](docs/reference/execution-model.md): how planning and ReAct loops interact with tool calls.
 - [Capturing feedback](docs/reference/feedback.md): recording plan ratings and configuring prompts.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,3 +17,5 @@ The config file is `KEY="value"` style. Supported keys:
 - `VERBOSITY`: `0` (quiet), `1` (info), `2` (debug).
 
 Environment variables prefixed with `OKSO_` mirror the config keys and take precedence over file values.
+
+See the [Initialize config for a custom model](../user-guides/usage.md#initialize-config-for-a-custom-model) walkthrough for a step-by-step example that combines `okso init` with environment overrides.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -13,6 +13,8 @@ The planner registers these tools (each implemented under `src/tools/<name>.sh`)
 - `applescript`: execute AppleScript snippets on macOS (no-op elsewhere).
 - `final_answer`: emit the assistant's final reply.
 
+For end-to-end scenarios that show how tools fit into approvals and offline runs, see the [Run with approvals](../user-guides/usage.md#run-with-approvals) and [Offline or noninteractive feedback collection](../user-guides/usage.md#offline-or-noninteractive-feedback-collection) walkthroughs.
+
 ## Terminal tool
 
 The `terminal` tool keeps a per-query working directory so subsequent calls share context. The default `status` command shows the current directory and a listing. Mutation commands validate arguments and keep `rm` interactive by default.

--- a/docs/user-guides/usage.md
+++ b/docs/user-guides/usage.md
@@ -2,43 +2,80 @@
 
 Use `./src/bin/okso --help` to see all flags. The CLI walks through planning and tool execution with approvals by default.
 
-## Approval and preview modes
+## Task-based walkthroughs
 
-- **Prompted (default):** asks before executing each tool.
-- `--yes` / `--no-confirm`: skip prompts and run the ranked tools automatically.
-- `--confirm`: force prompts even when the config enables auto-approval.
-- `--dry-run`: print the planned tool calls without executing them.
-- `--plan-only`: emit the machine-readable plan JSON and exit.
+### Run with approvals
 
-## Model selection
+1. Start with a prompted run so each tool call requires confirmation (default):
 
-Model defaults live in `${XDG_CONFIG_HOME:-~/.config}/okso/config.env`. Override them per run:
+   ```bash
+   ./src/bin/okso -- "inspect project layout and search notes"
+   ```
 
-```bash
-./src/bin/okso --model your-org/your-model:custom.gguf --model-branch main -- "draft meeting notes"
-```
+2. To auto-approve tool calls, pass `--yes` (or `--no-confirm`) for a fully automated pass:
 
-## Common flows
+   ```bash
+   ./src/bin/okso --yes -- "save reminder"
+   ```
 
-Prompted run:
+3. If your config sets `APPROVE_ALL=true` but you need to restore prompts for a sensitive query, add `--confirm` to override the config.
 
-```bash
-./src/bin/okso -- "inspect project layout and search notes"
-```
+4. Preview the plan without running anything using `--dry-run`, or emit machine-readable JSON only via `--plan-only`:
 
-Auto-approval with a specific model:
+   ```bash
+   ./src/bin/okso --dry-run -- "draft meeting notes"
+   ./src/bin/okso --plan-only -- "catalog data sources"
+   ```
 
-```bash
-./src/bin/okso --yes --model your-org/your-model:custom.gguf -- "save reminder"
-```
+5. Increase logging with `--verbose` or silence informational logs with `--quiet` when running unattended scripts.
 
-Write a config file without executing a plan:
+### Offline or noninteractive feedback collection
 
-```bash
-./src/bin/okso init --config ~/.config/okso/config.env --model your-org/your-model:custom.gguf --model-branch beta
-```
+The `feedback` tool can run without prompts while still capturing ratings and notes.
 
-macOS clipboard helpers:
+1. Disable interactive prompts and pre-fill a rating and note using `FEEDBACK_NONINTERACTIVE_INPUT` (`rating|note`). To bypass llama.cpp entirely for deterministic scoring, set `TESTING_PASSTHROUGH=true`.
+
+   ```bash
+   FEEDBACK_NONINTERACTIVE_INPUT="5|Clear summary" \
+   TESTING_PASSTHROUGH=true \
+   ./src/bin/okso --yes -- "summarize research notes"
+   ```
+
+2. When you only need to collect feedback artifacts, call the tool directly with a context payload and an output file:
+
+   ```bash
+   TOOL_QUERY='{"plan_item":"Summarize notes","observations":"Draft complete"}' \
+     FEEDBACK_NONINTERACTIVE_INPUT="4|Mentioned gaps" \
+     FEEDBACK_OUTPUT_PATH="${HOME}/.okso/feedback.jsonl" \
+     bash -lc 'source ./src/tools/feedback.sh; tool_feedback'
+   ```
+
+3. Turn off prompts entirely for CI runs with `FEEDBACK_ENABLED=false`; set `FEEDBACK_MIN_INTERVAL` or `FEEDBACK_MAX_ENTRIES` to tune churn and storage rotation.
+
+### Initialize config for a custom model
+
+1. Generate a config file without executing any plan using the `init` subcommand. Supply your preferred model and optional branch:
+
+   ```bash
+   ./src/bin/okso init --config "${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env" \
+     --model your-org/your-model:custom.gguf \
+     --model-branch main
+   ```
+
+2. At runtime, override config values with environment variables prefixed by `OKSO_`:
+
+   ```bash
+   OKSO_MODEL_SPEC=bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf \
+   OKSO_MODEL_BRANCH=main \
+   OKSO_LLAMA_BIN=llama-cli \
+   ./src/bin/okso --yes -- "classify support tickets"
+   ```
+
+3. To keep the run noninteractive while still respecting a new model, pair the overrides with `--yes` or `--confirm` depending on whether you want automatic approvals.
+
+### macOS clipboard helpers
+
+Call built-in helpers when you need quick transfers without opening other tools:
 
 ```bash
 ./src/bin/okso -- tool clipboard_copy "temporary text"


### PR DESCRIPTION
## Summary
- expand the usage guide with task-based walkthroughs for approvals, offline feedback, and custom model setup
- trim duplicated quickstart commands from the README in favor of the walkthroughs
- link configuration and tools reference pages directly to the relevant walkthrough sections

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436ae28cd08325a358e1deebdf642d)