### PR TITLE
Improve logging separation and verbosity coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ See [docs/user-guides/usage.md](docs/user-guides/usage.md) for task-based walkth
 - [Execution model](docs/reference/execution-model.md): how planning and ReAct loops interact with tool calls.
 - [Prompt assets](docs/reference/prompts.md): where prompts live and how they load.
 - [Architecture overview](docs/reference/architecture.md): deeper look at the planner pass, ReAct loop, llama.cpp fallbacks, and tool ranking.
+
+## Logging and output channels
+
+- Diagnostics emit structured JSON logs to `stderr`; control verbosity with
+  `--quiet`/`--verbose` or the `VERBOSITY` environment variable.
+- User-facing answers stay on `stdout` so they can be piped or captured without
+  mixing with diagnostic output.

--- a/src/lib/output.sh
+++ b/src/lib/output.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# User output helpers that keep stdout reserved for user-facing responses and
+# diagnostics routed through logging helpers on stderr.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/output.sh}/output.sh"
+#
+# Environment variables:
+#   None.
+#
+# Dependencies:
+#   - bash 5+
+#
+# Exit codes:
+#   Functions return 0 on success.
+
+# Emits a message to stdout without an automatic trailing newline.
+# Arguments:
+#   $1 - message (string)
+user_output() {
+        local message
+        message="$1"
+        printf '%s' "${message}"
+}
+
+# Emits a message followed by a newline to stdout.
+# Arguments:
+#   $1 - message (string)
+user_output_line() {
+        local message
+        message="$1"
+        printf '%s\n' "${message}"
+}
+
+# Emits each provided argument as a separate line to stdout.
+# Arguments:
+#   $@ - messages (string array)
+user_output_lines() {
+        local line
+        for line in "$@"; do
+                user_output_line "${line}"
+        done
+}

--- a/src/lib/prompts.sh
+++ b/src/lib/prompts.sh
@@ -18,6 +18,9 @@
 LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROMPTS_DIR="${LIB_DIR%/lib}/prompts"
 
+# shellcheck source=./logging.sh disable=SC1091
+source "${LIB_DIR}/logging.sh"
+
 # shellcheck source=./schema.sh disable=SC1091
 source "${LIB_DIR}/schema.sh"
 
@@ -26,12 +29,12 @@ load_prompt_template() {
 	#   $1 - prompt name (string)
 	local prompt_name prompt_path
 	prompt_name="$1"
-	prompt_path="${PROMPTS_DIR}/${prompt_name}.txt"
+        prompt_path="${PROMPTS_DIR}/${prompt_name}.txt"
 
-	if [[ ! -f "${prompt_path}" ]]; then
-		printf 'prompt template missing: %s\n' "${prompt_path}" >&2
-		return 1
-	fi
+        if [[ ! -f "${prompt_path}" ]]; then
+                log "ERROR" "prompt template missing" "${prompt_path}" || true
+                return 1
+        fi
 
 	cat "${prompt_path}"
 }
@@ -46,14 +49,14 @@ render_prompt_template() {
 	local prompt_name prompt_text
 	local -a substitutions=()
 
-	prompt_name="$1"
-	shift
-	prompt_text="$(load_prompt_template "${prompt_name}")" || return 1
+        prompt_name="$1"
+        shift
+        prompt_text="$(load_prompt_template "${prompt_name}")" || return 1
 
-	if (($# % 2 != 0)); then
-		printf 'render_prompt_template expects an even number of substitution arguments\n' >&2
-		return 1
-	fi
+        if (($# % 2 != 0)); then
+                log "ERROR" "render_prompt_template expects substitution pairs" "args_count=$#" || true
+                return 1
+        fi
 
 	while (($# > 0)); do
 		local key value

--- a/src/lib/respond.sh
+++ b/src/lib/respond.sh
@@ -20,6 +20,8 @@ LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=./logging.sh disable=SC1091
 source "${LIB_DIR}/logging.sh"
+# shellcheck source=./output.sh disable=SC1091
+source "${LIB_DIR}/output.sh"
 # shellcheck source=./prompts.sh disable=SC1091
 source "${LIB_DIR}/prompts.sh"
 # shellcheck source=./schema.sh disable=SC1091
@@ -43,21 +45,21 @@ respond_text() {
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "INFO" "LLM unavailable; using deterministic response fallback" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}" >&2
 		log "ERROR" "Falling back to deterministic response" "${user_query}" >&2
-		printf 'LLM unavailable. Request received: %s\n' "${user_query}"
-		return 0
-	fi
+                user_output_line "LLM unavailable. Request received: ${user_query}"
+                return 0
+        fi
 
-	if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
-		log "INFO" "Mock llama direct response path" "${user_query}" >&2
-		printf 'Responding directly to: %s\n' "${user_query}"
-		return 0
-	fi
+        if [[ "${LLAMA_BIN}" == *"mock_llama_relevance.sh" ]]; then
+                log "INFO" "Mock llama direct response path" "${user_query}" >&2
+                user_output_line "Responding directly to: ${user_query}"
+                return 0
+        fi
 
 	prompt="$(build_concise_response_prompt "${user_query}" "${context}")"
 	log "INFO" "Invoking llama inference" "$(printf 'tokens=%s schema=%s' "${number_of_tokens}" "${concise_schema_path}")" >&2
 	local response_text
 	response_text="$(llama_infer "${prompt}" "" "${number_of_tokens}" "${concise_schema_path}")"
-	printf '%s' "${response_text}"
-	log "INFO" "Direct response generation finished" "${user_query}" >&2
-	return 0
+        user_output "${response_text}"
+        log "INFO" "Direct response generation finished" "${user_query}" >&2
+        return 0
 }

--- a/src/lib/schema.sh
+++ b/src/lib/schema.sh
@@ -17,6 +17,9 @@
 
 LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
+# shellcheck source=./logging.sh disable=SC1091
+source "${LIB_DIR}/logging.sh"
+
 # Returns the absolute path to the schema directory.
 schema_root_dir() {
 	cd "${LIB_DIR}/../schemas" && pwd
@@ -29,21 +32,21 @@ schema_path() {
 	local schema_name schema_file
 	schema_name="$1"
 
-	case "${schema_name}" in
-	react_action)
+        case "${schema_name}" in
+        react_action)
 		schema_file="react_action.schema.json"
 		;;
 	planner_plan)
 		schema_file="planner_plan.schema.json"
 		;;
-	concise_response)
-		schema_file="concise_response.schema.json"
-		;;
-	*)
-		printf 'Unknown schema requested: %s\n' "${schema_name}" >&2
-		return 1
-		;;
-	esac
+        concise_response)
+                schema_file="concise_response.schema.json"
+                ;;
+        *)
+                log "ERROR" "Unknown schema requested" "${schema_name}" || true
+                return 1
+                ;;
+        esac
 
 	printf '%s/%s' "$(schema_root_dir)" "${schema_file}"
 }

--- a/src/tools/feedback.sh
+++ b/src/tools/feedback.sh
@@ -108,13 +108,13 @@ feedback_capture_input() {
 			comment_input=""
 		fi
 	else
-		printf 'Current plan item:%s%s\n' $' ' "${plan_item}" >&2
-		if [[ -n "${observations}" ]]; then
-			printf 'Recent tool results:%s%s\n' $' ' "${observations}" >&2
-		fi
-		read -r -p "Please rate this step (1-5): " rating_input || true
-		read -r -p "Comments (optional): " comment_input || true
-	fi
+                log "INFO" "Current plan item" "${plan_item}" || true
+                if [[ -n "${observations}" ]]; then
+                        log_pretty "INFO" "Recent tool results" "${observations}" || true
+                fi
+                read -r -p "Please rate this step (1-5): " rating_input || true
+                read -r -p "Comments (optional): " comment_input || true
+        fi
 
 	if [[ -z "${rating_input}" || ! "${rating_input}" =~ ^[1-5]$ ]]; then
 		log "ERROR" "Invalid feedback rating" "${rating_input:-empty}" || true

--- a/src/tools/final_answer.sh
+++ b/src/tools/final_answer.sh
@@ -19,6 +19,8 @@
 
 # shellcheck source=../lib/logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/final_answer.sh}/lib/logging.sh"
+# shellcheck source=../lib/output.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/final_answer.sh}/lib/output.sh"
 # shellcheck source=./registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/final_answer.sh}/registry.sh"
 
@@ -46,7 +48,7 @@ tool_final_answer() {
 	fi
 
 	log "INFO" "final_answer tool invoked" "$(printf 'length=%s' "${#message}")" >&2
-	printf '%s' "${message}" || true
+        user_output "${message}" || true
 }
 
 register_final_answer() {

--- a/src/tools/terminal.sh
+++ b/src/tools/terminal.sh
@@ -24,6 +24,8 @@
 
 # shellcheck source=../lib/logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/terminal.sh}/lib/logging.sh"
+# shellcheck source=../lib/output.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/terminal.sh}/lib/output.sh"
 # shellcheck source=./registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/terminal.sh}/registry.sh"
 
@@ -57,30 +59,30 @@ derive_terminal_query() {
 	# Arguments:
 	#   $1 - user query (string)
 	local user_query lower_query
-	user_query="$1"
-	lower_query=$(printf '%s' "${user_query}" | tr '[:upper:]' '[:lower:]')
+        user_query="$1"
+        lower_query=$(printf '%s' "${user_query}" | tr '[:upper:]' '[:lower:]')
 
-	if [[ "${user_query}" =~ \`([^\`]+)\` ]]; then
-		printf '%s\n' "${BASH_REMATCH[1]}"
-		return
-	fi
+        if [[ "${user_query}" =~ \`([^\`]+)\` ]]; then
+                user_output_line "${BASH_REMATCH[1]}"
+                return
+        fi
 
-	if [[ "${lower_query}" == *"todo"* ]]; then
-		printf 'rg -n "TODO" .\n'
-		return
-	fi
+        if [[ "${lower_query}" == *"todo"* ]]; then
+                user_output_line 'rg -n "TODO" .'
+                return
+        fi
 
-	if [[ "${lower_query}" == *"list files"* || "${lower_query}" == *"show directory"* || "${lower_query}" == *"show folder"* ]]; then
-		printf 'ls -la\n'
-		return
-	fi
+        if [[ "${lower_query}" == *"list files"* || "${lower_query}" == *"show directory"* || "${lower_query}" == *"show folder"* ]]; then
+                user_output_line 'ls -la'
+                return
+        fi
 
-	if [[ "${user_query}" =~ (^|[[:space:]])(ls|cd|cat|grep|find|pwd|rg)([[:space:]]|$) ]]; then
-		printf '%s\n' "${BASH_REMATCH[2]}"
-		return
-	fi
+        if [[ "${user_query}" =~ (^|[[:space:]])(ls|cd|cat|grep|find|pwd|rg)([[:space:]]|$) ]]; then
+                user_output_line "${BASH_REMATCH[2]}"
+                return
+        fi
 
-	printf 'status\n'
+        user_output_line 'status'
 }
 
 terminal_args_from_json() {
@@ -164,13 +166,14 @@ terminal_change_dir() {
 	fi
 
 	TERMINAL_WORKDIR="${resolved}"
-	printf '%s\n' "${TERMINAL_WORKDIR}"
+        user_output_line "${TERMINAL_WORKDIR}"
 }
 
 terminal_print_status() {
-	printf 'Session: %s\n' "${TERMINAL_SESSION_ID}"
-	printf 'Working directory: %s\n' "${TERMINAL_WORKDIR}"
-	printf 'Allowed commands: %s\n' "${TERMINAL_ALLOWED_COMMANDS[*]}"
+        user_output_lines \
+                "Session: ${TERMINAL_SESSION_ID}" \
+                "Working directory: ${TERMINAL_WORKDIR}" \
+                "Allowed commands: ${TERMINAL_ALLOWED_COMMANDS[*]}"
 }
 
 tool_terminal() {

--- a/tests/lib/test_logging.sh
+++ b/tests/lib/test_logging.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+#
+# Tests for logging and user output helpers.
+#
+# Usage:
+#   bats tests/lib/test_logging.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 5+
+#   - jq
+#
+# Exit codes:
+#   Inherits Bats semantics.
+
+setup() {
+        cd "$(git rev-parse --show-toplevel)" || exit 1
+}
+
+@test "log suppresses info when quiet" {
+        run bash -lc '
+                source ./src/lib/logging.sh
+                VERBOSITY=0 log INFO "hidden" "detail"
+        '
+
+        [ "$status" -eq 0 ]
+        [[ -z "$output" ]]
+}
+
+@test "log emits compact JSON with message metadata" {
+        run bash -lc '
+                source ./src/lib/logging.sh
+                VERBOSITY=1 log INFO "visible" "more-detail"
+        '
+
+        [ "$status" -eq 0 ]
+        level=$(jq -r '.level' <<<"${output}")
+        message=$(jq -r '.message' <<<"${output}")
+        detail=$(jq -r '.detail' <<<"${output}")
+
+        [[ "${level}" == "INFO" ]]
+        [[ "${message}" == "visible" ]]
+        [[ "${detail}" == "more-detail" ]]
+}
+
+@test "log_pretty emits parseable formatted JSON" {
+        run bash -lc '
+                source ./src/lib/logging.sh
+                VERBOSITY=2 log_pretty DEBUG "pretty" "{\"a\":1}"
+        '
+
+        [ "$status" -eq 0 ]
+        compact=$(printf '%s' "${output}" | jq -c '.')
+        detail_value=$(jq -r '.detail' <<<"${compact}")
+
+        [[ "${compact}" == *'"level":"DEBUG"'* ]]
+        [[ "${compact}" == *'"message":"pretty"'* ]]
+        [[ "${detail_value}" == '{"a":1}' ]]
+}
+
+@test "log debug messages honor verbosity" {
+        run bash -lc '
+                source ./src/lib/logging.sh
+                VERBOSITY=1 log DEBUG "silenced" "detail"
+        '
+
+        [ "$status" -eq 0 ]
+        [[ -z "$output" ]]
+}
+
+@test "user output stays on stdout while logs remain on stderr" {
+        run bash -lc '
+                source ./src/lib/output.sh
+                source ./src/lib/logging.sh
+
+                stdout_file=$(mktemp)
+                stderr_file=$(mktemp)
+
+                {
+                        user_output_line "user-facing"
+                        VERBOSITY=1 log WARN "diagnostic" "detail"
+                } 1>"${stdout_file}" 2>"${stderr_file}"
+
+                printf "STDOUT:%s\nSTDERR:%s\n" "$(cat "${stdout_file}")" "$(cat "${stderr_file}")"
+        '
+
+        [ "$status" -eq 0 ]
+        stdout_line=$(printf '%s' "${output}" | awk -F':' '/^STDOUT:/ {print $2}')
+        stderr_payload=$(printf '%s' "${output}" | awk -F':' '/^STDERR:/ {sub(/^STDERR:/, ""); print $0}' | tail -n1)
+
+        [[ "${stdout_line}" == "user-facing" ]]
+        [[ -n "${stderr_payload}" ]]
+        [[ "${stderr_payload}" == *'"level":"WARN"'* ]]
+}


### PR DESCRIPTION
## Summary
- add shared output helpers to separate user-facing stdout content from diagnostic logs
- route shell diagnostics through structured log/log_pretty helpers in runtime and tool scripts
- document logging controls and add bats coverage for verbosity and JSON/pretty log formats

## Testing
- bats tests/lib/test_logging.sh
- shellcheck src/lib/logging.sh src/lib/output.sh src/lib/json_state.sh src/lib/schema.sh src/lib/prompts.sh src/lib/respond.sh src/tools/terminal.sh src/tools/final_answer.sh src/tools/feedback.sh tests/lib/test_logging.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944a42220a883258444cd2ba49cee24)