### PR TITLE
Add web tool suite with fetch helper

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -64,6 +64,6 @@ Use `--dry-run` to stop after plan generation and approvals if you want to inspe
 
 - Tool metadata (name, description, command, safety notes) is bundled into the planner prompt so llama.cpp can rank them for the outline and initial suggestions.
 - Without llama.cpp, a keyword heuristic orders tools; this ordering is reused during deterministic execution.
-- Each tool wrapper lives under `src/tools/` and enforces its own guards (sandboxed directories, platform checks, interactive deletes).
+- Each tool wrapper lives under `src/tools/` (with suites like `src/tools/web/` grouping related helpers) and enforces its own guards (sandboxed directories, platform checks, interactive deletes).
 - The `terminal` tool keeps a persistent working directory per request, while helpers such as `python_repl`, `file_search`, and macOS-specific tools run in isolated contexts.
 - Traces and logs for each invocation help you audit decisions and replay failures.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1,13 +1,14 @@
 # Tools
 
-The planner registers these tools (each implemented under `src/tools/<name>.sh`). Handlers expect structured arguments in `TOOL_ARGS`
-that follow the registered JSON schema. Free-form, single-string payloads always use the canonical `input` property so prompts and
-schemas can reference `args.input` consistently across tools:
+The planner registers these tools (implemented under `src/tools/`, with suites such as `src/tools/web/` grouping related helpers).
+Handlers expect structured arguments in `TOOL_ARGS` that follow the registered JSON schema. Free-form, single-string payloads always
+use the canonical `input` property so prompts and schemas can reference `args.input` consistently across tools:
 
 - `terminal`: persistent working directory with `pwd`, `ls`, `cd`, `find`, `grep`, `stat`, `wc`, `du`, `base64 encode|decode`, and guarded mutations (`rm -i`, `mkdir`, `mv`, `cp`, `touch`). Uses `open` on macOS.
 - `python_repl`: run Python snippets in an ephemeral sandbox using quiet `python -i` startup guards that confine writes.
 - `file_search`: search for files and contents using `mdfind` on macOS with `fd`/`rg` fallbacks elsewhere. Accepts an `input` string.
 - `web_search`: query the Google Custom Search API with a structured payload (`query` and optional `num`) and return JSON results.
+- `web_fetch`: retrieve HTTP response bodies with a configurable size cap, returning JSON metadata.
 - `*_search`: Notes, Calendar, and Mail searches reuse the same `input` field for the search term.
 - `clipboard_copy` / `clipboard_paste`: macOS clipboard helpers.
 - `notes_*`: create, append, list, read, or search Apple Notes entries.

--- a/src/lib/tools.sh
+++ b/src/lib/tools.sh
@@ -54,8 +54,8 @@ source "${TOOLS_DIR}/mail/index.sh"
 source "${TOOLS_DIR}/applescript.sh"
 # shellcheck source=./tools/final_answer.sh disable=SC1091
 source "${TOOLS_DIR}/final_answer.sh"
-# shellcheck source=./tools/web_search.sh disable=SC1091
-source "${TOOLS_DIR}/web_search.sh"
+# shellcheck source=./tools/web/index.sh disable=SC1091
+source "${TOOLS_DIR}/web/index.sh"
 
 tools_normalize_path() {
 	# Returns a normalized absolute path for allowlist checks.
@@ -121,6 +121,6 @@ initialize_tools() {
 	register_calendar_suite
 	register_mail_suite
 	register_applescript
-	register_final_answer
-	register_web_search
+        register_final_answer
+        register_web_suite
 }

--- a/src/tools/web/index.sh
+++ b/src/tools/web/index.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Web tool suite aggregator, providing registration for web_search and web_fetch.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/tools/web/index.sh}/tools/web/index.sh"
+#
+# Dependencies:
+#   - bash 5+
+#   - logging helpers from logging.sh
+#   - register_tool utilities from tools/registry.sh
+
+WEB_TOOLS_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SRC_ROOT=$(cd -- "${WEB_TOOLS_DIR}/../.." && pwd)
+
+# shellcheck source=../../lib/logging.sh disable=SC1091
+source "${SRC_ROOT}/lib/logging.sh"
+# shellcheck source=../registry.sh disable=SC1091
+source "${SRC_ROOT}/tools/registry.sh"
+
+# shellcheck source=./web_search.sh disable=SC1091
+source "${WEB_TOOLS_DIR}/web_search.sh"
+# shellcheck source=./web_fetch.sh disable=SC1091
+source "${WEB_TOOLS_DIR}/web_fetch.sh"
+
+register_web_suite() {
+        register_web_search
+        register_web_fetch
+}

--- a/src/tools/web/web_fetch.sh
+++ b/src/tools/web/web_fetch.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Web fetch tool that retrieves HTTP response bodies with size safeguards.
+#
+# Usage:
+#   source "${BASH_SOURCE[0]%/tools/web/web_fetch.sh}/tools/web/web_fetch.sh"
+#
+# Environment variables:
+#   TOOL_ARGS (JSON object): structured args with required `url` and optional `max_bytes`.
+#
+# Dependencies:
+#   - bash 5+
+#   - curl
+#   - jq
+#   - logging helpers from logging.sh
+#   - register_tool from tools/registry.sh
+#
+# Exit codes:
+#   Non-zero on validation errors, network failures, or oversized payload handling.
+
+WEB_TOOLS_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SRC_ROOT=$(cd -- "${WEB_TOOLS_DIR}/../.." && pwd)
+
+# shellcheck source=../../lib/logging.sh disable=SC1091
+source "${SRC_ROOT}/lib/logging.sh"
+# shellcheck source=../registry.sh disable=SC1091
+source "${SRC_ROOT}/tools/registry.sh"
+
+web_fetch_parse_args() {
+        # Parses TOOL_ARGS JSON for the web_fetch tool.
+        # Returns a JSON object with `url` and `max_bytes`.
+        local args_json
+        args_json="${TOOL_ARGS:-}" || true
+
+        jq -cer '
+                if (type != "object") then error("args must be object") end
+                | if (.url? == null) then error("missing url") end
+                | if (.url | type) != "string" or (.url | length) == 0 then error("url must be non-empty string") end
+                | if (.max_bytes? != null) then
+                        if (.max_bytes | type) != "number" or (.max_bytes | floor) != .max_bytes then error("max_bytes must be integer") end
+                        | if (.max_bytes < 1 or .max_bytes > 5242880) then error("max_bytes must be between 1 and 5242880") end
+                else
+                        .max_bytes = 1048576
+                end
+                | if ((del(.url, .max_bytes) | length) != 0) then error("unexpected properties") end
+                | {url: .url, max_bytes: (.max_bytes // 1)}
+        ' <<<"${args_json}" 2>/dev/null
+}
+
+tool_web_fetch() {
+        # Downloads the response body for a URL, enforcing size limits and returning JSON metadata.
+        local parsed_args url max_bytes body_file stderr_file http_code status body_size truncated response_body truncated_json
+        body_file="$(mktemp)"
+        stderr_file="$(mktemp)"
+
+        parsed_args=$(web_fetch_parse_args)
+        if [[ -z "${parsed_args}" ]]; then
+                log "ERROR" "Invalid TOOL_ARGS for web_fetch" "${TOOL_ARGS:-}" >&2
+                rm -f "${body_file}" "${stderr_file}"
+                return 1
+        fi
+
+        url=$(jq -r '.url' <<<"${parsed_args}")
+        max_bytes=$(jq -r '.max_bytes' <<<"${parsed_args}")
+
+        log "INFO" "Fetching URL" "${url}" >&2
+
+        http_code=$(curl \
+                --silent \
+                --show-error \
+                --fail \
+                --location \
+                --max-time 20 \
+                --connect-timeout 5 \
+                --retry 1 \
+                --retry-delay 1 \
+                --output "${body_file}" \
+                --write-out '%{http_code}' \
+                --header 'Accept: */*' \
+                "${url}" \
+                2>"${stderr_file}")
+        status=$?
+
+        if ((status != 0)); then
+                log "ERROR" "curl request failed" "$(cat "${stderr_file}")" >&2
+                rm -f "${body_file}" "${stderr_file}"
+                return 1
+        fi
+
+        body_size=$(wc -c <"${body_file}")
+        truncated=false
+        if ((body_size > max_bytes)); then
+                head -c "${max_bytes}" "${body_file}" >"${body_file}.trimmed"
+                mv "${body_file}.trimmed" "${body_file}"
+                truncated=true
+        fi
+
+        response_body="$(cat "${body_file}")"
+        rm -f "${body_file}" "${stderr_file}"
+
+        if [[ "${truncated}" == "true" ]]; then
+                truncated_json=true
+        else
+                truncated_json=false
+        fi
+
+        jq -nc --arg url "${url}" --arg body "${response_body}" --argjson status "${http_code:-0}" --argjson truncated "${truncated_json}" '{url: $url, status: $status, body: $body, truncated: $truncated}'
+}
+
+register_web_fetch() {
+        local args_schema
+
+        args_schema=$(jq -nc '{
+                type: "object",
+                required: ["url"],
+                additionalProperties: false,
+                properties: {
+                        url: {type: "string", format: "uri", minLength: 1},
+                        max_bytes: {type: "integer", minimum: 1, maximum: 5242880}
+                }
+        }')
+
+        register_tool \
+                "web_fetch" \
+                "Retrieve the raw HTTP response body for a URL." \
+                "web_fetch <url>" \
+                "Performs external HTTP requests; avoid sharing sensitive data." \
+                tool_web_fetch \
+                "${args_schema}"
+}

--- a/src/tools/web/web_search.sh
+++ b/src/tools/web/web_search.sh
@@ -4,7 +4,7 @@
 # Web search tool backed by Google Custom Search API.
 #
 # Usage:
-#   source "${BASH_SOURCE[0]%/tools/web_search.sh}/tools/web_search.sh"
+#   source "${BASH_SOURCE[0]%/tools/web/web_search.sh}/tools/web/web_search.sh"
 #
 # Environment variables:
 #   TOOL_ARGS (JSON object): structured args with required `query` and optional `num`.
@@ -21,10 +21,13 @@
 # Exit codes:
 #   Non-zero on validation errors, missing configuration, or API failures.
 
-# shellcheck source=../lib/logging.sh disable=SC1091
-source "${BASH_SOURCE[0]%/tools/web_search.sh}/lib/logging.sh"
-# shellcheck source=./registry.sh disable=SC1091
-source "${BASH_SOURCE[0]%/web_search.sh}/registry.sh"
+WEB_TOOLS_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SRC_ROOT=$(cd -- "${WEB_TOOLS_DIR}/../.." && pwd)
+
+# shellcheck source=../../lib/logging.sh disable=SC1091
+source "${SRC_ROOT}/lib/logging.sh"
+# shellcheck source=../registry.sh disable=SC1091
+source "${SRC_ROOT}/tools/registry.sh"
 
 web_search_parse_args() {
 	# Parses TOOL_ARGS JSON for the web_search tool.

--- a/tests/tools/test_web_fetch.sh
+++ b/tests/tools/test_web_fetch.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+#
+# Tests for the web_fetch tool, including argument validation and registration.
+#
+# Usage:
+#   bats tests/tools/test_web_fetch.sh
+
+setup() {
+        export TOOL_ARGS=''
+}
+
+@test "web_fetch rejects missing url" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/tools/web/web_fetch.sh
+TOOL_ARGS='{}' tool_web_fetch
+SCRIPT
+
+        [ "$status" -ne 0 ]
+}
+
+@test "web_fetch surfaces curl failures" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+mock_bin="$(mktemp -d)"
+cat >"${mock_bin}/curl" <<'MOCK'
+#!/usr/bin/env bash
+exit 22
+MOCK
+chmod +x "${mock_bin}/curl"
+export PATH="${mock_bin}:$PATH"
+source ./src/tools/web/web_fetch.sh
+TOOL_ARGS='{"url":"https://example.com"}'
+tool_web_fetch
+SCRIPT
+
+        [ "$status" -ne 0 ]
+}
+
+@test "web_fetch trims oversized bodies" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+mock_bin="$(mktemp -d)"
+cat >"${mock_bin}/curl" <<'MOCK'
+#!/usr/bin/env bash
+output_file=""
+write_out=""
+while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --output)
+                output_file="$2"
+                shift 2
+                ;;
+        --write-out)
+                write_out="$2"
+                shift 2
+                ;;
+        *)
+                shift
+                ;;
+        esac
+done
+printf 'ABCDEFGHIJ' >"${output_file}"
+printf '200'
+MOCK
+chmod +x "${mock_bin}/curl"
+export PATH="${mock_bin}:$PATH"
+source ./src/tools/web/web_fetch.sh
+TOOL_ARGS='{"url":"https://example.com","max_bytes":5}'
+output="$(tool_web_fetch 2>/dev/null)"
+rm -rf "${mock_bin}"
+printf '%s' "${output}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        expected='{"url":"https://example.com","status":200,"body":"ABCDE","truncated":true}'
+        [ "${output}" = "${expected}" ]
+}
+
+@test "web tools register through the aggregator" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+source ./src/lib/tools.sh
+init_tool_registry
+initialize_tools
+mapfile -t names < <(tool_names)
+for name in "${names[@]}"; do
+        printf '%s\n' "${name}"
+done
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [[ " ${lines[*]} " == *" web_search "* ]]
+        [[ " ${lines[*]} " == *" web_fetch "* ]]
+}

--- a/tests/tools/test_web_search.sh
+++ b/tests/tools/test_web_search.sh
@@ -10,9 +10,9 @@ setup() {
 }
 
 @test "web_search rejects missing query" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
-source ./src/tools/web_search.sh
+source ./src/tools/web/web_search.sh
 TOOL_ARGS='{}' tool_web_search
 SCRIPT
 
@@ -20,9 +20,9 @@ SCRIPT
 }
 
 @test "web_search fails without configuration" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
-source ./src/tools/web_search.sh
+source ./src/tools/web/web_search.sh
 TOOL_ARGS='{"query":"test"}'
 tool_web_search
 SCRIPT
@@ -31,7 +31,7 @@ SCRIPT
 }
 
 @test "web_search parses responses into structured output" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 mock_bin="$(mktemp -d)"
 cat >"${mock_bin}/curl" <<'MOCK'
@@ -51,7 +51,7 @@ chmod +x "${mock_bin}/curl"
 export PATH="${mock_bin}:$PATH"
 export GOOGLE_SEARCH_API_KEY="key"
 export GOOGLE_SEARCH_CX="cx"
-source ./src/tools/web_search.sh
+source ./src/tools/web/web_search.sh
 TOOL_ARGS='{"query":"demo","num":2}'
 output="$(tool_web_search 2>/dev/null)"
 rm -rf "${mock_bin}"
@@ -64,7 +64,7 @@ SCRIPT
 }
 
 @test "web_search surfaces API errors" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 mock_bin="$(mktemp -d)"
 cat >"${mock_bin}/curl" <<'MOCK'
@@ -77,7 +77,7 @@ chmod +x "${mock_bin}/curl"
 export PATH="${mock_bin}:$PATH"
 export GOOGLE_SEARCH_API_KEY="key"
 export GOOGLE_SEARCH_CX="cx"
-source ./src/tools/web_search.sh
+source ./src/tools/web/web_search.sh
 TOOL_ARGS='{"query":"demo"}'
 tool_web_search
 SCRIPT


### PR DESCRIPTION
## Summary
- move web_search into a new src/tools/web suite and centralize registration through an index script
- add a web_fetch tool for capped HTTP body retrieval and register it with the web suite
- update docs and bats tests to reflect the new web tool layout and registrations

## Testing
- bats tests/tools/test_web_search.sh tests/tools/test_web_fetch.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ae5039388325a5294f1a9af8675e)