### PR TITLE
Add planner and react model configuration flags

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -56,7 +56,7 @@ Use `--dry-run` to stop after plan generation and approvals if you want to inspe
 ## llama.cpp dependency and fallbacks
 
 - `LLAMA_BIN` controls the llama.cpp binary path. If it is unset or unavailable, okso switches to deterministic planning and tool replay so execution continues without the model.
-- `MODEL_SPEC` selects the model weights used by llama.cpp; defaults are provided in [`configuration`](../reference/configuration.md).
+- `PLANNER_MODEL_SPEC` and `REACT_MODEL_SPEC` select the model weights used by llama.cpp for planning and tool selection respectively; defaults are provided in [`configuration`](../reference/configuration.md).
 - `TESTING_PASSTHROUGH=true` disables llama.cpp entirely for offline or CI runs while keeping deterministic behavior.
 - Planner and ReAct prompts both use the schemas in [`src/schemas/`](../reference/schemas.md) so that outputs stay parseable even when models vary.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -3,7 +3,9 @@
 Defaults live in `${XDG_CONFIG_HOME:-~/.config}/okso/config.env`. Create or update that file without running a query:
 
 ```bash
-./src/bin/okso init --model your-org/your-model:custom.gguf --model-branch main
+./src/bin/okso init --planner-model bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf \
+  --react-model bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf \
+  --model-branch main
 ```
 
 The config file is `KEY=value` style, with values shell-escaped so the file can
@@ -14,13 +16,21 @@ Supported keys:
 ```
 MODEL_SPEC=custom/model:demo\ quantized.gguf
 MODEL_BRANCH=release-candidate
+PLANNER_MODEL_SPEC=bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf
+PLANNER_MODEL_BRANCH=main
+REACT_MODEL_SPEC=bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf
+REACT_MODEL_BRANCH=main
 VERBOSITY=1
 APPROVE_ALL=false
 FORCE_CONFIRM=false
 ```
 
-- `MODEL_SPEC`: Hugging Face `repo[:file]` identifier for the llama.cpp model (default: `bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf`).
-- `MODEL_BRANCH`: Optional branch or tag for the model download (default: `main`).
+- `PLANNER_MODEL_SPEC`: Hugging Face `repo[:file]` identifier for the planning llama.cpp model (default: `bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf`).
+- `PLANNER_MODEL_BRANCH`: Optional branch or tag for the planner download (default: `main`).
+- `REACT_MODEL_SPEC`: Hugging Face `repo[:file]` identifier for the ReAct llama.cpp model (default: `bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf`).
+- `REACT_MODEL_BRANCH`: Optional branch or tag for the ReAct download (default: `main`).
+- `MODEL_SPEC`: Legacy shared model identifier; still accepted and used when planner/React flags are omitted.
+- `MODEL_BRANCH`: Legacy shared branch or tag (default: `main`).
 - `LLAMA_BIN`: Path to the llama.cpp binary used for scoring (default: `llama-cli`).
 - `TESTING_PASSTHROUGH`: `true` to bypass llama.cpp for offline or deterministic runs.
 - `APPROVE_ALL`: `true` to skip prompts by default.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -36,7 +36,9 @@ source ./.env
 set +a
 
 # Run okso with web_search enabled; variables from .env override config values.
-./src/bin/okso plan --config "${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env" --model bartowski/Qwen_Qwen3-4B-GGUF
+./src/bin/okso plan --config "${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env" \
+  --planner-model bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf \
+  --react-model bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf
 ```
 
 The exported variables are preferred over values in `config.env`, letting you keep API keys local while still allowing `okso init` to write non-secret defaults.

--- a/docs/user-guides/usage.md
+++ b/docs/user-guides/usage.md
@@ -31,18 +31,19 @@ Use `./src/bin/okso --help` to see all flags. The CLI walks through planning and
 
 ### Initialize config for a custom model
 
-1. Generate a config file without executing any plan using the `init` subcommand. Supply your preferred model and optional branch:
+1. Generate a config file without executing any plan using the `init` subcommand. Supply your preferred models and optional branch. The defaults split responsibilities so the planner uses Qwen3-8B while the ReAct loop uses Qwen3-1.7B:
 
    ```bash
    ./src/bin/okso init --config "${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env" \
-     --model your-org/your-model:custom.gguf \
+     --planner-model bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf \
+     --react-model bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf \
      --model-branch main
    ```
 
 2. At runtime, override config values with environment variables prefixed by `OKSO_`:
 
    ```bash
-   OKSO_MODEL_SPEC=bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf \
+   OKSO_MODEL_SPEC=bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf \
    OKSO_MODEL_BRANCH=main \
    OKSO_LLAMA_BIN=llama-cli \
    ./src/bin/okso --yes -- "classify support tickets"

--- a/src/lib/cli/cli.sh
+++ b/src/lib/cli/cli.sh
@@ -23,12 +23,16 @@ CLI_LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${CLI_LIB_DIR}/../core/logging.sh"
 
 build_usage_text() {
-	local default_model_spec default_model_branch entrypoint_display
-	default_model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf}"
-	default_model_branch="${DEFAULT_MODEL_BRANCH_BASE:-main}"
-	entrypoint_display="${OKSO_ENTRYPOINT:-./src/bin/okso}"
+        local default_model_spec default_model_branch entrypoint_display default_planner_spec default_planner_branch default_react_spec default_react_branch
+        default_model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf}"
+        default_model_branch="${DEFAULT_MODEL_BRANCH_BASE:-main}"
+        default_planner_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf}"
+        default_planner_branch="${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}"
+        default_react_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-${default_model_spec}}"
+        default_react_branch="${DEFAULT_REACT_MODEL_BRANCH_BASE:-${default_model_branch}}"
+        entrypoint_display="${OKSO_ENTRYPOINT:-./src/bin/okso}"
 
-	cat <<USAGE
+        cat <<USAGE
 Usage: ${entrypoint_display} [OPTIONS] -- "user query"
 
 Options:
@@ -39,9 +43,17 @@ Options:
       --confirm         Always prompt before running tools.
       --dry-run         Print the planned tool calls without running them.
       --plan-only       Emit the planned calls as JSON and exit (implies --dry-run).
-  -m, --model VALUE     HF repo[:file] for llama.cpp (default: ${default_model_spec}).
+  -m, --model VALUE     HF repo[:file] used for both planner and ReAct models when specific flags are not set (default: ${default_model_spec}).
       --model-branch BRANCH
-                        HF branch or tag for the model download (default: ${default_model_branch}).
+                        HF branch or tag for the shared model download (default: ${default_model_branch}).
+      --planner-model VALUE
+                        HF repo[:file] for planning llama.cpp calls (default: ${default_planner_spec}).
+      --planner-model-branch BRANCH
+                        HF branch or tag for the planning model download (default: ${default_planner_branch}).
+      --react-model VALUE
+                        HF repo[:file] for ReAct llama.cpp calls (default: ${default_react_spec}).
+      --react-model-branch BRANCH
+                        HF branch or tag for the ReAct model download (default: ${default_react_branch}).
       --config FILE     Config file to load or create (default: ${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env).
   -v, --verbose         Increase log verbosity (JSON logs are always structured).
   -q, --quiet           Silence informational logs.
@@ -80,8 +92,13 @@ show_version() {
 
 # shellcheck disable=SC2034
 parse_args() {
-	local positional
-	positional=()
+        local positional
+        positional=()
+        local planner_model_spec_set react_model_spec_set planner_model_branch_set react_model_branch_set
+        planner_model_spec_set=false
+        react_model_spec_set=false
+        planner_model_branch_set=false
+        react_model_branch_set=false
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -118,25 +135,69 @@ parse_args() {
 			DRY_RUN=true
 			shift
 			;;
-		-m | --model)
-			if [[ $# -lt 2 ]]; then
-				die "cli" "usage" "--model requires an HF repo[:file] value"
-			fi
-			MODEL_SPEC="$2"
-			shift 2
-			;;
-		--model-branch)
-			if [[ $# -lt 2 ]]; then
-				die "cli" "usage" "--model-branch requires a branch or tag"
-			fi
-			MODEL_BRANCH="$2"
-			shift 2
-			;;
-		--config)
-			if [[ $# -lt 2 ]]; then
-				die "cli" "usage" "--config requires a path"
-			fi
-			CONFIG_FILE="$2"
+                -m | --model)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--model requires an HF repo[:file] value"
+                        fi
+                        MODEL_SPEC="$2"
+                        if [[ "${planner_model_spec_set}" != true ]]; then
+                                PLANNER_MODEL_SPEC="$2"
+                        fi
+                        if [[ "${react_model_spec_set}" != true ]]; then
+                                REACT_MODEL_SPEC="$2"
+                        fi
+                        shift 2
+                        ;;
+                --model-branch)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--model-branch requires a branch or tag"
+                        fi
+                        MODEL_BRANCH="$2"
+                        if [[ "${planner_model_branch_set}" != true ]]; then
+                                PLANNER_MODEL_BRANCH="$2"
+                        fi
+                        if [[ "${react_model_branch_set}" != true ]]; then
+                                REACT_MODEL_BRANCH="$2"
+                        fi
+                        shift 2
+                        ;;
+                --planner-model)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--planner-model requires an HF repo[:file] value"
+                        fi
+                        PLANNER_MODEL_SPEC="$2"
+                        planner_model_spec_set=true
+                        shift 2
+                        ;;
+                --planner-model-branch)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--planner-model-branch requires a branch or tag"
+                        fi
+                        PLANNER_MODEL_BRANCH="$2"
+                        planner_model_branch_set=true
+                        shift 2
+                        ;;
+                --react-model)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--react-model requires an HF repo[:file] value"
+                        fi
+                        REACT_MODEL_SPEC="$2"
+                        react_model_spec_set=true
+                        shift 2
+                        ;;
+                --react-model-branch)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--react-model-branch requires a branch or tag"
+                        fi
+                        REACT_MODEL_BRANCH="$2"
+                        react_model_branch_set=true
+                        shift 2
+                        ;;
+                --config)
+                        if [[ $# -lt 2 ]]; then
+                                die "cli" "usage" "--config requires a path"
+                        fi
+                        CONFIG_FILE="$2"
 			shift 2
 			;;
 		-v | --verbose)

--- a/src/lib/planning/llama_client.sh
+++ b/src/lib/planning/llama_client.sh
@@ -65,17 +65,21 @@ llama_with_timeout() {
 }
 
 llama_infer() {
-	# Runs llama.cpp with HF caching enabled for the configured model.
-	# Arguments:
-	#   $1 - prompt string
-	#   $2 - stop string (optional)
-	#   $3 - max tokens (optional)
-	#   $4 - schema file path (optional)
-	local prompt stop_string number_of_tokens schema_file_path schema_content
-	prompt="$1"
-	stop_string="${2:-}"
-	number_of_tokens="${3:-256}"
-	schema_file_path="${4:-}"
+        # Runs llama.cpp with HF caching enabled for the configured model.
+        # Arguments:
+        #   $1 - prompt string
+        #   $2 - stop string (optional)
+        #   $3 - max tokens (optional)
+        #   $4 - schema file path (optional)
+        #   $5 - model repo override (optional)
+        #   $6 - model file override (optional)
+        local prompt stop_string number_of_tokens schema_file_path schema_content repo_override file_override
+        prompt="$1"
+        stop_string="${2:-}"
+        number_of_tokens="${3:-256}"
+        schema_file_path="${4:-}"
+        repo_override="${5:-${MODEL_REPO}}"
+        file_override="${6:-${MODEL_FILE}}"
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "WARN" "llama unavailable; skipping inference" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
@@ -98,10 +102,10 @@ llama_infer() {
 	fi
 
 	local llama_args llama_arg_string stderr_file exit_code llama_stderr start_time_ns end_time_ns elapsed_ms llama_output
-	llama_args=(
-		"${LLAMA_BIN}"
-		--hf-repo "${MODEL_REPO}"
-		--hf-file "${MODEL_FILE}"
+        llama_args=(
+                "${LLAMA_BIN}"
+                --hf-repo "${repo_override}"
+                --hf-file "${file_override}"
 		-no-cnv --no-display-prompt --simple-io --verbose
 		-n "${number_of_tokens}"
 	)

--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -192,9 +192,9 @@ generate_plan_json() {
 
 	prompt="$(build_planner_prompt "${user_query}" "${tool_lines}")"
 	log "DEBUG" "Generated planner prompt" "${prompt}" >&2
-	raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_path}")" || raw_plan="[]"
-	plan_json="$(append_final_answer_step "${raw_plan}")" || plan_json="${raw_plan}"
-	printf '%s' "${plan_json}"
+        raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_path}" "${PLANNER_MODEL_REPO}" "${PLANNER_MODEL_FILE}")" || raw_plan="[]"
+        plan_json="$(append_final_answer_step "${raw_plan}")" || plan_json="${raw_plan}"
+        printf '%s' "${plan_json}"
 }
 
 generate_plan_outline() {
@@ -882,13 +882,13 @@ select_next_action() {
 		)"
 		validation_error_file="$(mktemp)"
 
-		raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_path}")"
-		if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
-			corrective_prompt="${react_prompt}"$'\n'"The previous response was invalid: $(cat "${validation_error_file}"). Respond with a valid JSON action that follows the schema."
-			raw_action="$(llama_infer "${corrective_prompt}" "" 256 "${react_schema_path}")"
+                raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_path}" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}")"
+                if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
+                        corrective_prompt="${react_prompt}"$'\n'"The previous response was invalid: $(cat "${validation_error_file}"). Respond with a valid JSON action that follows the schema."
+                        raw_action="$(llama_infer "${corrective_prompt}" "" 256 "${react_schema_path}" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}")"
 
-			if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
-				log "ERROR" "Invalid action output from llama" "$(cat "${validation_error_file}")"
+                        if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
+                                log "ERROR" "Invalid action output from llama" "$(cat "${validation_error_file}")"
 				rm -f "${validation_error_file}"
 				return 1
 			fi

--- a/src/lib/planning/respond.sh
+++ b/src/lib/planning/respond.sh
@@ -58,8 +58,8 @@ respond_text() {
 	prompt="$(build_concise_response_prompt "${user_query}" "${context}")"
 	log "INFO" "Invoking llama inference" "$(printf 'tokens=%s schema=%s' "${number_of_tokens}" "${concise_schema_path}")" >&2
 	local response_text
-	response_text="$(llama_infer "${prompt}" "" "${number_of_tokens}" "${concise_schema_path}")"
-	user_output "${response_text}"
-	log "INFO" "Direct response generation finished" "${user_query}" >&2
-	return 0
+        response_text="$(llama_infer "${prompt}" "" "${number_of_tokens}" "${concise_schema_path}" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}")"
+        user_output "${response_text}"
+        log "INFO" "Direct response generation finished" "${user_query}" >&2
+        return 0
 }

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -15,13 +15,22 @@
 # Expected types (namespaced JSON scoped by a settings prefix):
 #   ${settings_prefix}_json.version (string): application version.
 #   ${settings_prefix}_json.llama_bin (string): llama.cpp binary path.
-#   ${settings_prefix}_json.default_model_file (string): default GGUF filename.
+#   ${settings_prefix}_json.default_model_file (string): default GGUF filename for ReAct.
+#   ${settings_prefix}_json.default_planner_model_file (string): default GGUF filename for the planner.
 #   ${settings_prefix}_json.config_dir (string): directory for config file.
 #   ${settings_prefix}_json.config_file (string): path to the config file.
-#   ${settings_prefix}_json.model_spec (string): HF repo[:file] spec for downloads.
-#   ${settings_prefix}_json.model_branch (string): branch or tag for downloads.
-#   ${settings_prefix}_json.model_repo (string): parsed HF repo.
-#   ${settings_prefix}_json.model_file (string): parsed HF file.
+#   ${settings_prefix}_json.model_spec (string): legacy HF repo[:file] spec used as default.
+#   ${settings_prefix}_json.model_branch (string): legacy branch or tag for downloads.
+#   ${settings_prefix}_json.planner_model_spec (string): HF repo[:file] spec for planner llama.cpp.
+#   ${settings_prefix}_json.planner_model_branch (string): branch or tag for planner downloads.
+#   ${settings_prefix}_json.planner_model_repo (string): parsed planner HF repo.
+#   ${settings_prefix}_json.planner_model_file (string): parsed planner HF file.
+#   ${settings_prefix}_json.react_model_spec (string): HF repo[:file] spec for ReAct llama.cpp.
+#   ${settings_prefix}_json.react_model_branch (string): branch or tag for ReAct downloads.
+#   ${settings_prefix}_json.react_model_repo (string): parsed ReAct HF repo.
+#   ${settings_prefix}_json.react_model_file (string): parsed ReAct HF file.
+#   ${settings_prefix}_json.model_repo (string): parsed HF repo (legacy mirror of react model).
+#   ${settings_prefix}_json.model_file (string): parsed HF file (legacy mirror of react model).
 #   ${settings_prefix}_json.approve_all (bool string): true to bypass prompts.
 #   ${settings_prefix}_json.force_confirm (bool string): true to force prompts.
 #   ${settings_prefix}_json.dry_run (bool string): true to avoid execution.
@@ -118,38 +127,55 @@ set_by_name() {
 }
 
 create_default_settings() {
-	# Arguments:
-	#   $1 - settings namespace prefix
-	local settings_prefix config_dir default_model_file config_file model_spec new_settings_json
-	settings_prefix="$1"
+        # Arguments:
+        #   $1 - settings namespace prefix
+        local settings_prefix config_dir default_model_file config_file model_spec new_settings_json default_planner_model_file planner_model_spec react_model_spec
+        settings_prefix="$1"
 
-	settings_clear_namespace "${settings_prefix}"
+        settings_clear_namespace "${settings_prefix}"
 
-	config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-	default_model_file="${DEFAULT_MODEL_FILE_BASE:-Qwen_Qwen3-4B-Q4_K_M.gguf}"
-	config_file="${config_dir}/config.env"
-	model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:${default_model_file}}"
+        config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+        default_model_file="${DEFAULT_MODEL_FILE_BASE:-Qwen_Qwen3-1.7B-Q4_K_M.gguf}"
+        default_planner_model_file="${DEFAULT_PLANNER_MODEL_FILE_BASE:-Qwen_Qwen3-8B-Q4_K_M.gguf}"
+        config_file="${config_dir}/config.env"
+        model_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-1.7B-GGUF:${default_model_file}}"
+        planner_model_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:${default_planner_model_file}}"
+        react_model_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-${model_spec}}"
 
-	new_settings_json=$(jq -c -n \
-		--arg version "0.1.0" \
-		--arg llama_bin "${LLAMA_BIN:-llama-cli}" \
-		--arg default_model_file "${default_model_file}" \
-		--arg config_dir "${config_dir}" \
-		--arg config_file "${config_file}" \
-		--arg model_spec "${model_spec}" \
-		--arg model_branch "${DEFAULT_MODEL_BRANCH_BASE:-main}" \
-		--arg notes_dir "${HOME}/.okso" \
-		--arg use_react_llama "${USE_REACT_LLAMA:-true}" \
-		'{
+        new_settings_json=$(jq -c -n \
+                --arg version "0.1.0" \
+                --arg llama_bin "${LLAMA_BIN:-llama-cli}" \
+                --arg default_model_file "${default_model_file}" \
+                --arg default_planner_model_file "${default_planner_model_file}" \
+                --arg config_dir "${config_dir}" \
+                --arg config_file "${config_file}" \
+                --arg model_spec "${model_spec}" \
+                --arg planner_model_spec "${planner_model_spec}" \
+                --arg react_model_spec "${react_model_spec}" \
+                --arg model_branch "${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}" \
+                --arg planner_model_branch "${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}" \
+                --arg react_model_branch "${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}" \
+                --arg notes_dir "${HOME}/.okso" \
+                --arg use_react_llama "${USE_REACT_LLAMA:-true}" \
+                '{
                         version: $version,
                         llama_bin: $llama_bin,
                         default_model_file: $default_model_file,
+                        default_planner_model_file: $default_planner_model_file,
                         config_dir: $config_dir,
                         config_file: $config_file,
                         model_spec: $model_spec,
                         model_branch: $model_branch,
+                        planner_model_spec: $planner_model_spec,
+                        planner_model_branch: $planner_model_branch,
+                        react_model_spec: $react_model_spec,
+                        react_model_branch: $react_model_branch,
                         model_repo: "",
                         model_file: "",
+                        planner_model_repo: "",
+                        planner_model_file: "",
+                        react_model_repo: "",
+                        react_model_file: "",
                         approve_all: "false",
                         force_confirm: "false",
                         dry_run: "false",
@@ -163,20 +189,29 @@ create_default_settings() {
                         user_query: ""
                 }')
 
-	settings_set_json_document "${settings_prefix}" "${new_settings_json}"
+        settings_set_json_document "${settings_prefix}" "${new_settings_json}"
 }
 
 settings_field_mappings() {
-	cat <<'EOF'
+        cat <<'EOF'
 version VERSION
 llama_bin LLAMA_BIN
 default_model_file DEFAULT_MODEL_FILE
+default_planner_model_file DEFAULT_PLANNER_MODEL_FILE
 config_dir CONFIG_DIR
 config_file CONFIG_FILE
 model_spec MODEL_SPEC
 model_branch MODEL_BRANCH
+planner_model_spec PLANNER_MODEL_SPEC
+planner_model_branch PLANNER_MODEL_BRANCH
+react_model_spec REACT_MODEL_SPEC
+react_model_branch REACT_MODEL_BRANCH
 model_repo MODEL_REPO
 model_file MODEL_FILE
+planner_model_repo PLANNER_MODEL_REPO
+planner_model_file PLANNER_MODEL_FILE
+react_model_repo REACT_MODEL_REPO
+react_model_file REACT_MODEL_FILE
 approve_all APPROVE_ALL
 force_confirm FORCE_CONFIRM
 dry_run DRY_RUN
@@ -234,11 +269,11 @@ load_runtime_settings() {
 
 	# Ordering matters: config file may update globals before CLI args take
 	# precedence, matching typical UNIX expectations.
-	detect_config_file "$@"
-	load_config
-	parse_args "$@"
-	normalize_approval_flags
-	hydrate_model_spec
+        detect_config_file "$@"
+        load_config
+        parse_args "$@"
+        normalize_approval_flags
+        hydrate_model_specs
 
 	capture_globals_into_settings "${settings_prefix}"
 }

--- a/tests/core/config.sh
+++ b/tests/core/config.sh
@@ -102,11 +102,15 @@ SCRIPT
 }
 
 @test "write_config_file emits shell-parsable assignments" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 config_file="$(mktemp)"
 MODEL_SPEC="demo/model with space:demo file.gguf"
 MODEL_BRANCH="feature branch"
+PLANNER_MODEL_SPEC="planner/model:planner.gguf"
+PLANNER_MODEL_BRANCH="planner-branch"
+REACT_MODEL_SPEC="react/model:react.gguf"
+REACT_MODEL_BRANCH="react-branch"
 VERBOSITY=2
 APPROVE_ALL=true
 FORCE_CONFIRM=false
@@ -116,24 +120,38 @@ write_config_file >/dev/null
 bash -n "${config_file}"
 MODEL_SPEC="placeholder"
 MODEL_BRANCH="placeholder"
+PLANNER_MODEL_SPEC="placeholder"
+PLANNER_MODEL_BRANCH="placeholder"
+REACT_MODEL_SPEC="placeholder"
+REACT_MODEL_BRANCH="placeholder"
 VERBOSITY=0
 APPROVE_ALL=false
 FORCE_CONFIRM=true
 source "${config_file}"
-printf '%s\n' "${MODEL_SPEC}" "${MODEL_BRANCH}" "${VERBOSITY}" "${APPROVE_ALL}" "${FORCE_CONFIRM}"
+printf '%s\n' \
+        "${MODEL_SPEC}" "${MODEL_BRANCH}" \
+        "${PLANNER_MODEL_SPEC}" "${PLANNER_MODEL_BRANCH}" \
+        "${REACT_MODEL_SPEC}" "${REACT_MODEL_BRANCH}" \
+        "${VERBOSITY}" "${APPROVE_ALL}" "${FORCE_CONFIRM}" \
+        "$(wc -l < "${config_file}" | tr -d ' ')"
 rm -f "${config_file}"
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	[ "${lines[0]}" = "demo/model with space:demo file.gguf" ]
-	[ "${lines[1]}" = "feature branch" ]
-	[ "${lines[2]}" = "2" ]
-	[ "${lines[3]}" = "true" ]
-	[ "${lines[4]}" = "false" ]
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "demo/model with space:demo file.gguf" ]
+        [ "${lines[1]}" = "feature branch" ]
+        [ "${lines[2]}" = "planner/model:planner.gguf" ]
+        [ "${lines[3]}" = "planner-branch" ]
+        [ "${lines[4]}" = "react/model:react.gguf" ]
+        [ "${lines[5]}" = "react-branch" ]
+        [ "${lines[6]}" = "2" ]
+        [ "${lines[7]}" = "true" ]
+        [ "${lines[8]}" = "false" ]
+        [ "${lines[9]}" = "9" ]
 }
 
 @test "okso init writes clean config without stray characters" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 config_dir="$(mktemp -d)"
@@ -143,20 +161,112 @@ model_branch="stable/2024-08"
 cd "${repo_root}"
 ./src/bin/okso init --config "${config_file}" --model "${model_spec}" --model-branch "${model_branch}" --yes >/dev/null
 bash -n "${config_file}"
-unset MODEL_SPEC MODEL_BRANCH VERBOSITY APPROVE_ALL FORCE_CONFIRM
+unset MODEL_SPEC MODEL_BRANCH PLANNER_MODEL_SPEC PLANNER_MODEL_BRANCH REACT_MODEL_SPEC REACT_MODEL_BRANCH VERBOSITY APPROVE_ALL FORCE_CONFIRM
 source "${config_file}"
-printf '%s\n' "${MODEL_SPEC}" "${MODEL_BRANCH}" "${VERBOSITY}" "${APPROVE_ALL}" "${FORCE_CONFIRM}"
-printf '%s\n' "$(grep -E '^[A-Z_]+=.*' "${config_file}" | wc -l | tr -d ' ')"
-printf '%s\n' "$(wc -l < "${config_file}" | tr -d ' ')"
+printf '%s\n' \
+        "${MODEL_SPEC}" "${MODEL_BRANCH}" \
+        "${PLANNER_MODEL_SPEC}" "${PLANNER_MODEL_BRANCH}" \
+        "${REACT_MODEL_SPEC}" "${REACT_MODEL_BRANCH}" \
+        "${VERBOSITY}" "${APPROVE_ALL}" "${FORCE_CONFIRM}" \
+        "$(grep -E '^[A-Z_]+=.*' "${config_file}" | wc -l | tr -d ' ')" \
+        "$(wc -l < "${config_file}" | tr -d ' ')"
 rm -rf "${config_dir}"
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	[ "${lines[0]}" = "custom/model:quant demo.gguf" ]
-	[ "${lines[1]}" = "stable/2024-08" ]
-	[ "${lines[2]}" = "1" ]
-	[ "${lines[3]}" = "true" ]
-	[ "${lines[4]}" = "false" ]
-	[ "${lines[5]}" = "5" ]
-	[ "${lines[6]}" = "5" ]
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "custom/model:quant demo.gguf" ]
+        [ "${lines[1]}" = "stable/2024-08" ]
+        [ "${lines[2]}" = "custom/model:quant demo.gguf" ]
+        [ "${lines[3]}" = "stable/2024-08" ]
+        [ "${lines[4]}" = "custom/model:quant demo.gguf" ]
+        [ "${lines[5]}" = "stable/2024-08" ]
+        [ "${lines[6]}" = "1" ]
+        [ "${lines[7]}" = "true" ]
+        [ "${lines[8]}" = "false" ]
+        [ "${lines[9]}" = "9" ]
+        [ "${lines[10]}" = "9" ]
+}
+
+@test "planner and react specs hydrate defaults and shared overrides" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+CONFIG_FILE="$(mktemp)"
+NOTES_DIR="$(mktemp -d)"
+source ./src/lib/config.sh
+load_config
+hydrate_model_specs
+printf '%s\n' \
+        "${PLANNER_MODEL_REPO}" "${PLANNER_MODEL_FILE}" \
+        "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}" \
+        "${PLANNER_MODEL_SPEC}" "${REACT_MODEL_SPEC}"
+MODEL_SPEC="override/repo:react.gguf"
+MODEL_BRANCH="dev"
+PLANNER_MODEL_SPEC=""
+REACT_MODEL_SPEC=""
+PLANNER_MODEL_BRANCH=""
+REACT_MODEL_BRANCH=""
+hydrate_model_specs
+printf '%s\n' "${PLANNER_MODEL_SPEC}" "${REACT_MODEL_SPEC}" "${PLANNER_MODEL_BRANCH}" "${REACT_MODEL_BRANCH}"
+rm -f "${CONFIG_FILE}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "bartowski/Qwen_Qwen3-8B-GGUF" ]
+        [ "${lines[1]}" = "Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[2]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF" ]
+        [ "${lines[3]}" = "Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[4]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[5]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[6]}" = "override/repo:react.gguf" ]
+        [ "${lines[7]}" = "override/repo:react.gguf" ]
+        [ "${lines[8]}" = "dev" ]
+        [ "${lines[9]}" = "dev" ]
+}
+
+@test "cli shared model flags populate planner and react when unset" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/cli/cli.sh
+COMMAND="run"
+DEFAULT_MODEL_BRANCH_BASE=${DEFAULT_MODEL_BRANCH_BASE:-main}
+DEFAULT_PLANNER_MODEL_BRANCH_BASE=${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}
+DEFAULT_REACT_MODEL_BRANCH_BASE=${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}
+MODEL_BRANCH="${DEFAULT_MODEL_BRANCH_BASE}"
+PLANNER_MODEL_BRANCH="${DEFAULT_PLANNER_MODEL_BRANCH_BASE}"
+REACT_MODEL_BRANCH="${DEFAULT_REACT_MODEL_BRANCH_BASE}"
+parse_args --model shared/repo:shared.gguf --model-branch release -- "demo query"
+printf '%s\n' "${MODEL_SPEC}" "${PLANNER_MODEL_SPEC}" "${REACT_MODEL_SPEC}" "${MODEL_BRANCH}" "${PLANNER_MODEL_BRANCH}" "${REACT_MODEL_BRANCH}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "shared/repo:shared.gguf" ]
+        [ "${lines[1]}" = "shared/repo:shared.gguf" ]
+        [ "${lines[2]}" = "shared/repo:shared.gguf" ]
+        [ "${lines[3]}" = "release" ]
+        [ "${lines[4]}" = "release" ]
+        [ "${lines[5]}" = "release" ]
+}
+
+@test "cli planner flags override shared selections" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/cli/cli.sh
+COMMAND="run"
+DEFAULT_MODEL_BRANCH_BASE=${DEFAULT_MODEL_BRANCH_BASE:-main}
+DEFAULT_PLANNER_MODEL_BRANCH_BASE=${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}
+DEFAULT_REACT_MODEL_BRANCH_BASE=${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}
+MODEL_BRANCH="${DEFAULT_MODEL_BRANCH_BASE}"
+PLANNER_MODEL_BRANCH="${DEFAULT_PLANNER_MODEL_BRANCH_BASE}"
+REACT_MODEL_BRANCH="${DEFAULT_REACT_MODEL_BRANCH_BASE}"
+parse_args --model shared/repo:shared.gguf --planner-model dedicated/planner:plan.gguf --planner-model-branch nightly -- "demo query"
+printf '%s\n' "${MODEL_SPEC}" "${PLANNER_MODEL_SPEC}" "${REACT_MODEL_SPEC}" "${MODEL_BRANCH}" "${PLANNER_MODEL_BRANCH}" "${REACT_MODEL_BRANCH}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "shared/repo:shared.gguf" ]
+        [ "${lines[1]}" = "dedicated/planner:plan.gguf" ]
+        [ "${lines[2]}" = "shared/repo:shared.gguf" ]
+        [ "${lines[3]}" = "main" ]
+        [ "${lines[4]}" = "nightly" ]
+        [ "${lines[5]}" = "main" ]
 }

--- a/tests/runtime/test_settings.sh
+++ b/tests/runtime/test_settings.sh
@@ -19,22 +19,26 @@
 }
 
 @test "create_default_settings wires derived defaults and react toggle" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 unset USE_REACT_LLAMA
                 source ./src/lib/runtime.sh
                 create_default_settings compat
                 doc="$(settings_get_json_document compat)"
-                printf "%s\n%s\n%s" \
+                printf "%s\n%s\n%s\n%s\n%s" \
                         "$(jq -r ".config_dir" <<<"${doc}")" \
                         "$(jq -r ".config_file" <<<"${doc}")" \
-                        "$(jq -r ".use_react_llama" <<<"${doc}")"
+                        "$(jq -r ".use_react_llama" <<<"${doc}")" \
+                        "$(jq -r ".planner_model_spec" <<<"${doc}")" \
+                        "$(jq -r ".react_model_spec" <<<"${doc}")"
         '
-	[ "$status" -eq 0 ]
-	config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-	[ "${lines[0]}" = "${config_dir_expected}" ]
-	[ "${lines[1]}" = "${config_dir_expected}/config.env" ]
-	[ "${lines[2]}" = "true" ]
+        [ "$status" -eq 0 ]
+        config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+        [ "${lines[0]}" = "${config_dir_expected}" ]
+        [ "${lines[1]}" = "${config_dir_expected}/config.env" ]
+        [ "${lines[2]}" = "true" ]
+        [ "${lines[3]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[4]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
 }
 
 @test "settings json helpers round-trip through globals" {


### PR DESCRIPTION
## Summary
- add dedicated planner and ReAct model spec/branch flags with defaults for Qwen3-8B planning and Qwen3-1.7B tool execution
- persist the split model configuration in runtime settings and route llama calls through the appropriate model contexts
- update CLI help and documentation alongside new regression tests for overrides and legacy fallbacks

## Testing
- bats tests/core/config.sh tests/runtime/test_settings.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457b38d1fc8325b95f0a343f85659a)