### PR TITLE
Update default model defaults to Qwen3 split

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ FORCE_CONFIRM=false
 - `PLANNER_MODEL_BRANCH`: Optional branch or tag for the planner download (default: `main`).
 - `REACT_MODEL_SPEC`: Hugging Face `repo[:file]` identifier for the ReAct llama.cpp model (default: `bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf`).
 - `REACT_MODEL_BRANCH`: Optional branch or tag for the ReAct download (default: `main`).
-- `MODEL_SPEC`: Legacy shared model identifier; still accepted and used when planner/React flags are omitted.
+- `MODEL_SPEC`: Legacy shared model identifier used when planner/React flags are omitted (default: `bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf`).
 - `MODEL_BRANCH`: Legacy shared branch or tag (default: `main`).
 - `LLAMA_BIN`: Path to the llama.cpp binary used for scoring (default: `llama-cli`).
 - `TESTING_PASSTHROUGH`: `true` to bypass llama.cpp for offline or deterministic runs.

--- a/src/bin/okso
+++ b/src/bin/okso
@@ -14,7 +14,7 @@
 #       --confirm         Always prompt before running tools.
 #       --dry-run         Print the planned tool calls without running them.
 #       --plan-only       Emit the planned calls as JSON and exit.
-#   -m, --model VALUE     HF repo[:file] for llama.cpp download (default: bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf).
+#   -m, --model VALUE     HF repo[:file] for llama.cpp download (default: bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf).
 #       --model-branch BRANCH  HF branch or tag for the model download (default: main).
 #       --config FILE     Config file to load (default: ${XDG_CONFIG_HOME:-$HOME/.config}/okso/config.env).
 #   -v, --verbose         Increase log verbosity (JSON logs are always structured).

--- a/src/lib/cli/cli.sh
+++ b/src/lib/cli/cli.sh
@@ -23,14 +23,14 @@ CLI_LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${CLI_LIB_DIR}/../core/logging.sh"
 
 build_usage_text() {
-	local default_model_spec default_model_branch entrypoint_display default_planner_spec default_planner_branch default_react_spec default_react_branch
-	default_model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf}"
-	default_model_branch="${DEFAULT_MODEL_BRANCH_BASE:-main}"
-	default_planner_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf}"
-	default_planner_branch="${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}"
-	default_react_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-${default_model_spec}}"
-	default_react_branch="${DEFAULT_REACT_MODEL_BRANCH_BASE:-${default_model_branch}}"
-	entrypoint_display="${OKSO_ENTRYPOINT:-./src/bin/okso}"
+        local default_model_spec default_model_branch entrypoint_display default_planner_spec default_planner_branch default_react_spec default_react_branch
+        default_model_spec="${DEFAULT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf}"
+        default_model_branch="${DEFAULT_MODEL_BRANCH_BASE:-main}"
+        default_planner_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf}"
+        default_planner_branch="${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}"
+        default_react_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-${default_model_spec}}"
+        default_react_branch="${DEFAULT_REACT_MODEL_BRANCH_BASE:-${default_model_branch}}"
+        entrypoint_display="${OKSO_ENTRYPOINT:-./src/bin/okso}"
 
 	cat <<USAGE
 Usage: ${entrypoint_display} [OPTIONS] -- "user query"

--- a/tests/lib/test_cli_help.sh
+++ b/tests/lib/test_cli_help.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+@test "CLI help advertises Qwen3 planner/react defaults" {
+        run bash -lc '
+                set -e
+                source ./src/lib/config.sh
+                source ./src/lib/cli/cli.sh
+                build_usage_text
+        '
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"planning llama.cpp calls (default: bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf)."* ]]
+        [[ "$output" == *"ReAct llama.cpp calls (default: bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf)."* ]]
+        [[ "$output" == *"--model VALUE     HF repo[:file] used for both planner and ReAct models when specific flags are not set (default: bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf)."* ]]
+}

--- a/tests/lib/test_config_defaults.sh
+++ b/tests/lib/test_config_defaults.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+@test "config defaults prefer qwen3 planner/react split" {
+        run bash -lc '
+                set -e
+                source ./src/lib/config.sh
+                printf "%s\n%s\n%s\n%s\n%s\n%s\n" \
+                        "${DEFAULT_MODEL_SPEC_BASE}" \
+                        "${DEFAULT_REACT_MODEL_SPEC_BASE}" \
+                        "${DEFAULT_PLANNER_MODEL_SPEC_BASE}" \
+                        "${DEFAULT_MODEL_FILE_BASE}" \
+                        "${DEFAULT_PLANNER_MODEL_FILE_BASE}" \
+                        "${DEFAULT_MODEL_BRANCH_BASE}"
+        '
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[1]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[2]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[3]}" = "Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[4]}" = "Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[5]}" = "main" ]
+}

--- a/tests/runtime/test_settings.sh
+++ b/tests/runtime/test_settings.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "settings helpers persist arbitrary JSON fields" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 source ./src/lib/runtime.sh
                 create_default_settings compat
@@ -13,36 +13,40 @@
                         "$(jq -r ".config_dir" <<<"${doc}")" \
                         "$(jq -r ".config_file" <<<"${doc}")"
         '
-	[ "$status" -eq 0 ]
-	config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-	[ "$output" = "value|value|${config_dir_expected}|${config_dir_expected}/config.env" ]
+        [ "$status" -eq 0 ]
+        config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+        [ "$output" = "value|value|${config_dir_expected}|${config_dir_expected}/config.env" ]
 }
 
 @test "create_default_settings wires derived defaults and react toggle" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 unset USE_REACT_LLAMA
                 source ./src/lib/runtime.sh
                 create_default_settings compat
                 doc="$(settings_get_json_document compat)"
-                printf "%s\n%s\n%s\n%s\n%s" \
+                printf "%s\n%s\n%s\n%s\n%s\n%s\n%s" \
                         "$(jq -r ".config_dir" <<<"${doc}")" \
                         "$(jq -r ".config_file" <<<"${doc}")" \
                         "$(jq -r ".use_react_llama" <<<"${doc}")" \
                         "$(jq -r ".planner_model_spec" <<<"${doc}")" \
-                        "$(jq -r ".react_model_spec" <<<"${doc}")"
+                        "$(jq -r ".react_model_spec" <<<"${doc}")" \
+                        "$(jq -r ".default_model_file" <<<"${doc}")" \
+                        "$(jq -r ".default_planner_model_file" <<<"${doc}")"
         '
-	[ "$status" -eq 0 ]
-	config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-	[ "${lines[0]}" = "${config_dir_expected}" ]
-	[ "${lines[1]}" = "${config_dir_expected}/config.env" ]
-	[ "${lines[2]}" = "true" ]
-	[ "${lines[3]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
-	[ "${lines[4]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "$status" -eq 0 ]
+        config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+        [ "${lines[0]}" = "${config_dir_expected}" ]
+        [ "${lines[1]}" = "${config_dir_expected}/config.env" ]
+        [ "${lines[2]}" = "true" ]
+        [ "${lines[3]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+        [ "${lines[4]}" = "bartowski/Qwen_Qwen3-1.7B-GGUF:Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[5]}" = "Qwen_Qwen3-1.7B-Q4_K_M.gguf" ]
+        [ "${lines[6]}" = "Qwen_Qwen3-8B-Q4_K_M.gguf" ]
 }
 
 @test "settings json helpers round-trip through globals" {
-	run bash -lc '
+        run bash -lc '
                 set -e
                 source ./src/lib/runtime.sh
                 create_default_settings compat
@@ -54,7 +58,7 @@
                 after="$(settings_get_json compat llama_bin)"
                 printf "%s\n%s" "${before}" "${after}"
         '
-	[ "$status" -eq 0 ]
-	[ "${lines[0]}" = "/custom/bin" ]
-	[ "${lines[1]}" = "/changed/bin" ]
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "/custom/bin" ]
+        [ "${lines[1]}" = "/changed/bin" ]
 }


### PR DESCRIPTION
## Summary
- point default planner and ReAct model references to the Qwen3-8B and Qwen3-1.7B GGUFs across CLI help and docs
- document the legacy shared MODEL_SPEC default and refresh the local entrypoint help text
- add regression coverage for model defaults, CLI help strings, and runtime settings defaults

## Testing
- bats tests/lib/test_config_defaults.sh tests/lib/test_cli_help.sh tests/runtime/test_settings.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458e2729dc83258b81c5ef07253268)