### PR TITLE
Validate terminal command enum

### DIFF
--- a/src/tools/terminal/index.sh
+++ b/src/tools/terminal/index.sh
@@ -102,14 +102,19 @@ terminal_args_from_json() {
 		return 1
 	fi
 
-	if [[ -z "${TERMINAL_CMD}" ]]; then
-		TERMINAL_CMD="status"
-	fi
+        if [[ -z "${TERMINAL_CMD}" ]]; then
+                TERMINAL_CMD="status"
+        fi
 
-	TERMINAL_CMD_ARGS=()
-	while IFS= read -r line; do
-		TERMINAL_CMD_ARGS+=("$line")
-	done < <(jq -r '(.args // []) | map(tostring) | .[]' <<<"${args_json}" 2>/dev/null || true)
+        if ! terminal_allowed "${TERMINAL_CMD}"; then
+                log "ERROR" "terminal command not permitted" "${TERMINAL_CMD}" || true
+                return 1
+        fi
+
+        TERMINAL_CMD_ARGS=()
+        while IFS= read -r line; do
+                TERMINAL_CMD_ARGS+=("$line")
+        done < <(jq -r '(.args // []) | map(tostring) | .[]' <<<"${args_json}" 2>/dev/null || true)
 	return 0
 }
 
@@ -345,11 +350,11 @@ tool_terminal() {
 register_terminal() {
 	local args_schema
 
-	args_schema=$(
-		cat <<'JSON'
-{"type":"object","required":["command"],"properties":{"command":{"type":"string","minLength":1},"args":{"type":"array","items":{"type":"string"}}},"additionalProperties":false}
+        args_schema=$(
+                cat <<'JSON'
+{"type":"object","required":["command"],"properties":{"command":{"type":"string","enum":["status","pwd","ls","cd","cat","head","tail","find","grep","open","mkdir","rmdir","mv","cp","touch","rm","stat","wc","du","base64"]},"args":{"type":"array","items":{"type":"string"}}},"additionalProperties":false}
 JSON
-	)
+        )
 	register_tool \
 		"terminal" \
 		"Persistent terminal session for navigation, inspection, and safe mutations (pwd, ls, du, cd, cat, head, tail, find, grep, stat, wc, base64 encode/decode, mkdir, rmdir, mv, cp, touch, rm -i default; open on macOS)." \

--- a/tests/tools/test_terminal.sh
+++ b/tests/tools/test_terminal.sh
@@ -26,10 +26,10 @@
 	[[ "${lines[$last_index]}" == *"/tests" ]]
 }
 
-@test "unknown command falls back to status" {
-	run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"launch\",\"args\":[\"rockets\"]}"; tool_terminal'
-	[ "$status" -eq 0 ]
-	[[ "${output}" == *"Allowed commands:"* ]]
+@test "rejects commands outside allowed enum" {
+        run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"launch\",\"args\":[\"rockets\"]}"; tool_terminal'
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"terminal command not permitted"* ]]
 }
 
 @test "mkdir and rmdir operate within working directory" {


### PR DESCRIPTION
## Summary
- enumerate allowed terminal commands in the tool schema and enforce validation in argument parsing
- add test coverage for rejecting disallowed commands

## Testing
- bats tests/tools/test_terminal.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946dc7b55108325b765050c4c9be161)