### PR TITLE
Enforce tool arg enum validation

### DIFF
--- a/src/lib/planning/react.sh
+++ b/src/lib/planning/react.sh
@@ -395,35 +395,49 @@ validate_react_action() {
 		fi
 	done
 
-	_react_enforce_arg_type() {
-		# Validates an argument value against a schema fragment using jq types.
-		# Arguments:
-		#   $1 - argument key (string)
-		#   $2 - argument JSON value (string)
-		#   $3 - schema JSON string
-		local arg_key value_json schema_fragment expected_type min_length item_type
-		arg_key="$1"
-		value_json="$2"
-		schema_fragment="$3"
+        _react_enforce_arg_type() {
+                # Validates an argument value against a schema fragment using jq types.
+                # Arguments:
+                #   $1 - argument key (string)
+                #   $2 - argument JSON value (string)
+                #   $3 - schema JSON string
+                local arg_key value_json schema_fragment expected_type min_length item_type enum_values const_value
+                arg_key="$1"
+                value_json="$2"
+                schema_fragment="$3"
 
-		expected_type=$(jq -r '.type // empty' <<<"${schema_fragment}")
-		if [[ -z "${expected_type}" ]]; then
-			return 0
-		fi
+                expected_type=$(jq -r '.type // empty' <<<"${schema_fragment}")
+                if [[ -z "${expected_type}" ]]; then
+                        return 0
+                fi
 
-		case "${expected_type}" in
-		string)
-			if ! jq -e 'type == "string"' <<<"${value_json}" >/dev/null; then
-				printf 'Arg %s must be a string\n' "${arg_key}" >&2
-				return 1
-			fi
-			min_length=$(jq -r '.minLength // 0' <<<"${schema_fragment}")
-			if [[ "${min_length}" -gt 0 ]] && [[ -z "$(jq -r 'gsub("^\\s+|\\s+$"; "")' <<<"${value_json}")" ]]; then
-				printf 'Arg %s cannot be empty\n' "${arg_key}" >&2
-				return 1
-			fi
-			;;
-		object)
+                case "${expected_type}" in
+                string)
+                        enum_values=$(jq -c '.enum // empty' <<<"${schema_fragment}")
+                        const_value=$(jq -c '.const // empty' <<<"${schema_fragment}")
+                        if ! jq -e 'type == "string"' <<<"${value_json}" >/dev/null; then
+                                printf 'Arg %s must be a string\n' "${arg_key}" >&2
+                                return 1
+                        fi
+                        min_length=$(jq -r '.minLength // 0' <<<"${schema_fragment}")
+                        if [[ "${min_length}" -gt 0 ]] && [[ -z "$(jq -r 'gsub("^\\s+|\\s+$"; "")' <<<"${value_json}")" ]]; then
+                                printf 'Arg %s cannot be empty\n' "${arg_key}" >&2
+                                return 1
+                        fi
+                        if [[ -n "${const_value}" && "${const_value}" != "null" ]]; then
+                                if ! jq -e --argjson const "${const_value}" --argjson val "${value_json}" '$const == $val' <<<"null" >/dev/null; then
+                                        printf 'Arg %s must equal %s\n' "${arg_key}" "${const_value}" >&2
+                                        return 1
+                                fi
+                        fi
+                        if [[ -n "${enum_values}" && "${enum_values}" != "null" ]]; then
+                                if ! jq -e --argjson enum "${enum_values}" --argjson val "${value_json}" '$enum | index($val)' <<<"null" >/dev/null; then
+                                        printf 'Arg %s must be one of: %s\n' "${arg_key}" "${enum_values}" >&2
+                                        return 1
+                                fi
+                        fi
+                        ;;
+                object)
 			if ! jq -e 'type == "object"' <<<"${value_json}" >/dev/null; then
 				printf 'Arg %s must be a object\n' "${arg_key}" >&2
 				return 1

--- a/tests/planner/test_react_action.sh
+++ b/tests/planner/test_react_action.sh
@@ -146,8 +146,8 @@ INNERSCRIPT
 }
 
 @test "validate_react_action enforces argument type schemas" {
-	script=$(
-		cat <<'INNERSCRIPT'
+        script=$(
+                cat <<'INNERSCRIPT'
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
@@ -185,10 +185,49 @@ fi
 grep -F "Arg input must be a string" err.log
 rm -f "${schema_path}" err.log
 INNERSCRIPT
-	)
+        )
 
-	run bash -lc "${script}"
-	[ "$status" -eq 0 ]
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
+}
+
+@test "validate_react_action enforces enum constraints" {
+        script=$(
+                cat <<'INNERSCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+source ./src/lib/planning/planner.sh
+
+tool_registry_json() {
+        cat <<'JSON'
+{"names":["terminal"],"registry":{"terminal":{"args_schema":{"type":"object","required":["command"],"properties":{"command":{"type":"string","enum":["status","pwd"]}},"additionalProperties":false}}}}
+JSON
+}
+
+tool_names() { printf "%s\n" "terminal"; }
+
+schema_path="$(build_react_action_schema "terminal")"
+
+invalid_action='{"thought":"check time","tool":"terminal","args":{"command":"date"}}'
+
+set +e
+validate_react_action "${invalid_action}" "${schema_path}" 2>err.log
+status=$?
+set -e
+
+if [[ ${status} -eq 0 ]]; then
+        echo "validation unexpectedly succeeded"
+        exit 1
+fi
+
+grep -F "Arg command must be one of" err.log
+rm -f "${schema_path}" err.log
+INNERSCRIPT
+        )
+
+        run bash -lc "${script}"
+        [ "$status" -eq 0 ]
 }
 
 @test "validate_react_action accepts terminal arg arrays" {
@@ -201,7 +240,7 @@ source ./src/lib/planning/planner.sh
 
 schema_path="$(build_react_action_schema "terminal")"
 
-action='{"thought":"execute","tool":"terminal","args":{"command":"echo","args":["hi"]}}'
+action='{"thought":"execute","tool":"terminal","args":{"command":"ls","args":["-la"]}}'
 validate_react_action "${action}" "${schema_path}" >/dev/null
 
 rm -f "${schema_path}"
@@ -247,12 +286,12 @@ source ./src/lib/planning/planner.sh
 llama_prompt_file=$(mktemp)
 llama_infer() {
         printf '%s' "$1" >"${llama_prompt_file}"
-        printf '%s' '{"thought":"llama chose","tool":"terminal","args":{"command":"echo","args":["hi"]}}'
+        printf '%s' '{"thought":"llama chose","tool":"terminal","args":{"command":"ls","args":["-la"]}}'
 }
 
 state_prefix=react
-plan_entry=$(jq -nc '{tool:"terminal",args:{command:"echo",args:["hi"]},thought:"planned guidance"}')
-plan_outline=$'1. terminal -> echo hi\n2. final_answer -> summarize'
+plan_entry=$(jq -nc '{tool:"terminal",args:{command:"ls",args:["-la"]},thought:"planned guidance"}')
+plan_outline=$'1. terminal -> ls -la\n2. final_answer -> summarize'
 
 initialize_react_state "${state_prefix}" "demo request" $'terminal\nfinal_answer' "${plan_entry}" "${plan_outline}"
 
@@ -277,12 +316,12 @@ if ! grep -F 'planned guidance' "${llama_prompt_file}" >/dev/null; then
         exit 1
 fi
 
-if ! grep -F '"command":"echo"' "${llama_prompt_file}" >/dev/null; then
-        echo "plan args missing from prompt"
-        exit 1
-fi
+        if ! grep -F '"command":"ls"' "${llama_prompt_file}" >/dev/null; then
+                echo "plan args missing from prompt"
+                exit 1
+        fi
 
-jq -e '.tool == "terminal" and .args.command == "echo" and .thought == "llama chose"' <<<"${action_json}"
+        jq -e '.tool == "terminal" and .args.command == "ls" and .thought == "llama chose"' <<<"${action_json}"
 rm -f "${llama_prompt_file}"
 INNERSCRIPT
 	)
@@ -306,8 +345,8 @@ llama_infer() {
 }
 
 state_prefix=react
-plan_entry=$(jq -nc '{tool:"terminal",args:{command:"echo",args:["hi"]},thought:"planned guidance"}')
-plan_outline=$'1. terminal -> echo hi\n2. final_answer -> summarize'
+plan_entry=$(jq -nc '{tool:"terminal",args:{command:"ls",args:["-la"]},thought:"planned guidance"}')
+plan_outline=$'1. terminal -> ls -la\n2. final_answer -> summarize'
 
 initialize_react_state "${state_prefix}" "demo request" $'terminal\nfinal_answer' "${plan_entry}" "${plan_outline}"
 


### PR DESCRIPTION
## Summary
- enforce enum and const values during ReAct tool argument validation to block disallowed commands
- add regression coverage for enum enforcement and update planner tests to use permitted terminal commands

## Testing
- bats tests/planner/test_react_action.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946e0a82e388325a1a2a7254ab09006)