### PR TITLE
Refine react action schema generation

### DIFF
--- a/src/lib/planning/react.sh
+++ b/src/lib/planning/react.sh
@@ -300,12 +300,15 @@ schema_doc = {
         "args": {"type": "object"},
     },
     "$defs": {"args_by_tool": args_by_tool},
-    "allOf": [
+    "oneOf": [
         {
-            "if": {"properties": {"tool": {"const": name}}, "required": ["tool"]},
-            "then": {"properties": {"args": tool_schema}},
+            "properties": {
+                "tool": {"const": name},
+                "args": {"$ref": f"#/$defs/args_by_tool/{name}"},
+            },
+            "required": ["tool", "args"],
         }
-        for name, tool_schema in args_by_tool.items()
+        for name in tool_enum
     ],
 }
 


### PR DESCRIPTION
## Summary
- restructure ReAct action schema generation to use oneOf entries with const tool selection and referenced argument schemas while preserving required fields
- retain strict additionalProperties handling and shared args definitions for allowed tools
- add regression coverage confirming the new schema layout and validation for allowed/disallowed tools
- format the planner bats regression tests with shfmt to satisfy linting

## Testing
- bats tests/planner/test_react_action.sh
- shellcheck src/lib/planning/react.sh tests/planner/test_react_action.sh
- shfmt -d src/lib/planning/react.sh tests/planner/test_react_action.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f7d2ba148325811be31ceb06d979)