### PR TITLE
Add explicit planner initialization

### DIFF
--- a/src/bin/okso
+++ b/src/bin/okso
@@ -113,6 +113,7 @@ main() {
 	fi
 
 	prepare_environment_with_settings "${settings_prefix}"
+	initialize_planner_models
 	# Planner flow:
 	# 1. Generate an outline, 2. identify tools, 3. build concrete plan entries
 	# for execution, then 4. render plan outputs before proceeding.

--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -51,12 +51,11 @@ source "${PLANNING_LIB_DIR}/../formatting.sh"
 source "${PLANNING_LIB_DIR}/../config.sh"
 
 initialize_planner_models() {
-	if [[ -z "${PLANNER_MODEL_REPO:-}" || -z "${PLANNER_MODEL_FILE:-}" || -z "${REACT_MODEL_REPO:-}" || -z "${REACT_MODEL_FILE:-}" ]]; then
-		hydrate_model_specs
-	fi
+        if [[ -z "${PLANNER_MODEL_REPO:-}" || -z "${PLANNER_MODEL_FILE:-}" || -z "${REACT_MODEL_REPO:-}" || -z "${REACT_MODEL_FILE:-}" ]]; then
+                hydrate_model_specs
+        fi
 }
-
-initialize_planner_models
+export -f initialize_planner_models
 
 lowercase() {
 	# Arguments:

--- a/tests/planner/test_planner_init.sh
+++ b/tests/planner/test_planner_init.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Regression tests for planner initialization.
+#
+# Usage:
+#   bats tests/planner/test_planner_init.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 3.2+
+
+@test "planner models remain unset until initialized" {
+        run bash -lc '
+                set -euo pipefail
+                cd "$(git rev-parse --show-toplevel)" || exit 1
+
+                source ./src/lib/planning/planner.sh
+
+                [[ -z "${PLANNER_MODEL_REPO:-}" ]]
+                [[ -z "${PLANNER_MODEL_FILE:-}" ]]
+                [[ -z "${REACT_MODEL_REPO:-}" ]]
+                [[ -z "${REACT_MODEL_FILE:-}" ]]
+
+                initialize_planner_models
+
+                [[ "${PLANNER_MODEL_REPO}" == "${DEFAULT_PLANNER_MODEL_REPO_BASE}" ]]
+                [[ "${PLANNER_MODEL_FILE}" == "${DEFAULT_PLANNER_MODEL_FILE_BASE}" ]]
+                [[ "${REACT_MODEL_REPO}" == "${DEFAULT_MODEL_REPO_BASE}" ]]
+                [[ "${REACT_MODEL_FILE}" == "${DEFAULT_MODEL_FILE_BASE}" ]]
+        '
+        [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- make planner model initialization explicit and export the helper
- invoke planner initialization from the CLI planning entrypoint before generating a plan
- add a bats regression test covering lazy initialization of planner and react models

## Testing
- bats tests/planner/test_planner_init.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694711e30c3083259c814243cd1ce666)