### PR TITLE
Silence chpwd_functions shellcheck warning

### DIFF
--- a/src/lib/core/settings.sh
+++ b/src/lib/core/settings.sh
@@ -31,105 +31,105 @@ CORE_SETTINGS_LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "${CORE_SETTINGS_LIB_DIR}/json_state.sh"
 
 settings_namespace_json_var() {
-        # Generates the shell variable name for a settings namespace.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        json_state_namespace_var "$@"
+	# Generates the shell variable name for a settings namespace.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	json_state_namespace_var "$@"
 }
 
 settings_get_json_document() {
-        # Retrieves the JSON document for a namespace with optional fallback.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - fallback JSON (string, optional; defaults to '{}')
-        #   $3 - output variable name (string, optional)
-        json_state_get_document "$@"
+	# Retrieves the JSON document for a namespace with optional fallback.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - fallback JSON (string, optional; defaults to '{}')
+	#   $3 - output variable name (string, optional)
+	json_state_get_document "$@"
 }
 
 settings_set_json_document() {
-        # Sets the JSON document for a namespace after validating JSON.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - JSON document (string)
-        json_state_set_document "$@"
+	# Sets the JSON document for a namespace after validating JSON.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - JSON document (string)
+	json_state_set_document "$@"
 }
 
 settings_clear_namespace() {
-        # Clears a settings namespace to an empty JSON document or provided value.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - JSON document to write (string, optional; defaults to '{}')
-        local prefix document
-        prefix="$1"
-        document="${2:-{}}"
-        settings_set_json_document "${prefix}" "${document}"
+	# Clears a settings namespace to an empty JSON document or provided value.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - JSON document to write (string, optional; defaults to '{}')
+	local prefix document
+	prefix="$1"
+	document="${2:-{}}"
+	settings_set_json_document "${prefix}" "${document}"
 }
 
 settings_set() {
-        # Sets a logical key in the settings document.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - logical key (string)
-        #   $3 - value (string)
-        settings_set_json "$@"
+	# Sets a logical key in the settings document.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - logical key (string)
+	#   $3 - value (string)
+	settings_set_json "$@"
 }
 
 settings_get() {
-        # Fetches a logical key from the settings document.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - logical key (string)
-        settings_get_json "$@"
+	# Fetches a logical key from the settings document.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - logical key (string)
+	settings_get_json "$@"
 }
 
 settings_set_json() {
-        # Writes a JSON-serializable value at the provided key.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - logical key (string)
-        #   $3 - value (string)
-        json_state_set_key "$@"
+	# Writes a JSON-serializable value at the provided key.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - logical key (string)
+	#   $3 - value (string)
+	json_state_set_key "$@"
 }
 
 settings_get_json() {
-        # Reads a JSON value at the provided key.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - logical key (string)
-        json_state_get_key "$@"
+	# Reads a JSON value at the provided key.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - logical key (string)
+	json_state_get_key "$@"
 }
 
 create_default_settings() {
-        # Builds and stores the default settings document for the namespace.
-        # Arguments:
-        #   $1 - settings namespace prefix (string)
-        #   $2 - overrides JSON to merge with defaults (string, optional)
-        local settings_prefix overrides default_model_file default_planner_model_file config_dir config_file
-        local planner_model_spec react_model_spec default_json override_json
-        settings_prefix="$1"
-        overrides="${2:-}"
+	# Builds and stores the default settings document for the namespace.
+	# Arguments:
+	#   $1 - settings namespace prefix (string)
+	#   $2 - overrides JSON to merge with defaults (string, optional)
+	local settings_prefix overrides default_model_file default_planner_model_file config_dir config_file
+	local planner_model_spec react_model_spec default_json override_json
+	settings_prefix="$1"
+	overrides="${2:-}"
 
-        config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-        default_model_file="${DEFAULT_MODEL_FILE_BASE:-Qwen_Qwen3-4B-Q4_K_M.gguf}"
-        default_planner_model_file="${DEFAULT_PLANNER_MODEL_FILE_BASE:-Qwen_Qwen3-8B-Q4_K_M.gguf}"
-        config_file="${config_dir}/config.env"
-        planner_model_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:${default_planner_model_file}}"
-        react_model_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:${default_model_file}}"
+	config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+	default_model_file="${DEFAULT_MODEL_FILE_BASE:-Qwen_Qwen3-4B-Q4_K_M.gguf}"
+	default_planner_model_file="${DEFAULT_PLANNER_MODEL_FILE_BASE:-Qwen_Qwen3-8B-Q4_K_M.gguf}"
+	config_file="${config_dir}/config.env"
+	planner_model_spec="${DEFAULT_PLANNER_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-8B-GGUF:${default_planner_model_file}}"
+	react_model_spec="${DEFAULT_REACT_MODEL_SPEC_BASE:-bartowski/Qwen_Qwen3-4B-GGUF:${default_model_file}}"
 
-        default_json=$(jq -c -n \
-                --arg version "0.1.0" \
-                --arg llama_bin "${LLAMA_BIN:-llama-cli}" \
-                --arg default_model_file "${default_model_file}" \
-                --arg default_planner_model_file "${default_planner_model_file}" \
-                --arg config_dir "${config_dir}" \
-                --arg config_file "${config_file}" \
-                --arg planner_model_spec "${planner_model_spec}" \
-                --arg react_model_spec "${react_model_spec}" \
-                --arg planner_model_branch "${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}" \
-                --arg react_model_branch "${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}" \
-                --arg notes_dir "${HOME}/.okso" \
-                --arg use_react_llama "${USE_REACT_LLAMA:-true}" \
-                '{
+	default_json=$(jq -c -n \
+		--arg version "0.1.0" \
+		--arg llama_bin "${LLAMA_BIN:-llama-cli}" \
+		--arg default_model_file "${default_model_file}" \
+		--arg default_planner_model_file "${default_planner_model_file}" \
+		--arg config_dir "${config_dir}" \
+		--arg config_file "${config_file}" \
+		--arg planner_model_spec "${planner_model_spec}" \
+		--arg react_model_spec "${react_model_spec}" \
+		--arg planner_model_branch "${DEFAULT_PLANNER_MODEL_BRANCH_BASE:-main}" \
+		--arg react_model_branch "${DEFAULT_REACT_MODEL_BRANCH_BASE:-main}" \
+		--arg notes_dir "${HOME}/.okso" \
+		--arg use_react_llama "${USE_REACT_LLAMA:-true}" \
+		'{
                         version: $version,
                         llama_bin: $llama_bin,
                         default_model_file: $default_model_file,
@@ -157,13 +157,13 @@ create_default_settings() {
                         user_query: ""
                 }')
 
-        if [[ -n "${overrides}" ]]; then
-                if override_json=$(printf '%s' "${overrides}" | jq -c '.' 2>/dev/null); then
-                        default_json=$(jq -c --argjson overrides "${override_json}" '. * $overrides' <<<"${default_json}")
-                else
-                        log "ERROR" "create_default_settings: invalid overrides JSON" "namespace=${settings_prefix}" || true
-                fi
-        fi
+	if [[ -n "${overrides}" ]]; then
+		if override_json=$(printf '%s' "${overrides}" | jq -c '.' 2>/dev/null); then
+			default_json=$(jq -c --argjson overrides "${override_json}" '. * $overrides' <<<"${default_json}")
+		else
+			log "ERROR" "create_default_settings: invalid overrides JSON" "namespace=${settings_prefix}" || true
+		fi
+	fi
 
-        settings_set_json_document "${settings_prefix}" "${default_json}"
+	settings_set_json_document "${settings_prefix}" "${default_json}"
 }

--- a/src/lib/planning/execution.sh
+++ b/src/lib/planning/execution.sh
@@ -31,115 +31,115 @@ source "${PLANNING_EXECUTION_DIR}/../config.sh"
 source "${PLANNING_EXECUTION_DIR}/../tools.sh"
 
 should_prompt_for_tool() {
-        if [[ "${PLAN_ONLY}" == true || "${DRY_RUN}" == true ]]; then
-                return 1
-        fi
-        if [[ "${FORCE_CONFIRM}" == true ]]; then
-                return 0
-        fi
-        if [[ "${APPROVE_ALL}" == true ]]; then
-                return 1
-        fi
+	if [[ "${PLAN_ONLY}" == true || "${DRY_RUN}" == true ]]; then
+		return 1
+	fi
+	if [[ "${FORCE_CONFIRM}" == true ]]; then
+		return 0
+	fi
+	if [[ "${APPROVE_ALL}" == true ]]; then
+		return 1
+	fi
 
-        return 0
+	return 0
 }
 
 confirm_tool() {
-        local tool_name context
-        tool_name="$1"
-        context="$2"
-        if ! should_prompt_for_tool; then
-                return 0
-        fi
+	local tool_name context
+	tool_name="$1"
+	context="$2"
+	if ! should_prompt_for_tool; then
+		return 0
+	fi
 
-        local prompt
-        prompt="Execute tool \"${tool_name}\"?"
-        if [[ -n "${context}" ]]; then
-                prompt+=$'\n'"${context}"
-        fi
-        if command -v gum >/dev/null 2>&1; then
-                if ! gum confirm --affirmative "Run" --negative "Skip" "${prompt}"; then
-                        log "WARN" "Tool execution declined" "${tool_name}"
-                        printf '[%s skipped]\n' "${tool_name}"
-                        return 1
-                fi
-                return 0
-        fi
+	local prompt
+	prompt="Execute tool \"${tool_name}\"?"
+	if [[ -n "${context}" ]]; then
+		prompt+=$'\n'"${context}"
+	fi
+	if command -v gum >/dev/null 2>&1; then
+		if ! gum confirm --affirmative "Run" --negative "Skip" "${prompt}"; then
+			log "WARN" "Tool execution declined" "${tool_name}"
+			printf '[%s skipped]\n' "${tool_name}"
+			return 1
+		fi
+		return 0
+	fi
 
-        printf '%s [y/N]: ' "${prompt}" >&2
-        read -r reply
-        if [[ "${reply}" != "y" && "${reply}" != "Y" ]]; then
-                log "WARN" "Tool execution declined" "${tool_name}"
-                printf '[%s skipped]\n' "${tool_name}"
-                return 1
-        fi
-        return 0
+	printf '%s [y/N]: ' "${prompt}" >&2
+	read -r reply
+	if [[ "${reply}" != "y" && "${reply}" != "Y" ]]; then
+		log "WARN" "Tool execution declined" "${tool_name}"
+		printf '[%s skipped]\n' "${tool_name}"
+		return 1
+	fi
+	return 0
 }
 
 execute_tool_with_query() {
-        # Arguments:
-        #   $1 - tool name
-        #   $2 - tool query (legacy string)
-        #   $3 - human-readable context
-        #   $4 - structured args JSON
-        local tool_name tool_query context handler output status tool_args_json
-        tool_name="$1"
-        tool_query="$2"
-        context="$3"
-        tool_args_json="$4"
-        handler="$(tool_handler "${tool_name}")"
+	# Arguments:
+	#   $1 - tool name
+	#   $2 - tool query (legacy string)
+	#   $3 - human-readable context
+	#   $4 - structured args JSON
+	local tool_name tool_query context handler output status tool_args_json
+	tool_name="$1"
+	tool_query="$2"
+	context="$3"
+	tool_args_json="$4"
+	handler="$(tool_handler "${tool_name}")"
 
-        local requires_confirmation
-        requires_confirmation=false
-        if [[ "${tool_name}" != "final_answer" ]] && should_prompt_for_tool; then
-                requires_confirmation=true
-        fi
+	local requires_confirmation
+	requires_confirmation=false
+	if [[ "${tool_name}" != "final_answer" ]] && should_prompt_for_tool; then
+		requires_confirmation=true
+	fi
 
-        if [[ -z "${handler}" ]]; then
-                log "ERROR" "No handler registered for tool" "${tool_name}" >&2
-                return 1
-        fi
+	if [[ -z "${handler}" ]]; then
+		log "ERROR" "No handler registered for tool" "${tool_name}" >&2
+		return 1
+	fi
 
-        if [[ "${tool_name}" != "final_answer" ]]; then
-                if [[ "${requires_confirmation}" == true ]]; then
-                        log "INFO" "Requesting tool confirmation" "$(printf 'tool=%s query=%s' "${tool_name}" "${tool_query}")" >&2
-                fi
+	if [[ "${tool_name}" != "final_answer" ]]; then
+		if [[ "${requires_confirmation}" == true ]]; then
+			log "INFO" "Requesting tool confirmation" "$(printf 'tool=%s query=%s' "${tool_name}" "${tool_query}")" >&2
+		fi
 
-                if ! confirm_tool "${tool_name}" "${context}"; then
-                        printf 'Declined %s\n' "${tool_name}"
-                        return 0
-                fi
-        fi
+		if ! confirm_tool "${tool_name}" "${context}"; then
+			printf 'Declined %s\n' "${tool_name}"
+			return 0
+		fi
+	fi
 
-        if [[ "${DRY_RUN}" == true || "${PLAN_ONLY}" == true ]]; then
-                log "INFO" "Skipping execution in preview mode" "${tool_name}" >&2
-                return 0
-        fi
+	if [[ "${DRY_RUN}" == true || "${PLAN_ONLY}" == true ]]; then
+		log "INFO" "Skipping execution in preview mode" "${tool_name}" >&2
+		return 0
+	fi
 
-        local stdout_file stderr_file stderr_output
-        stdout_file="$(mktemp)"
-        stderr_file="$(mktemp)"
+	local stdout_file stderr_file stderr_output
+	stdout_file="$(mktemp)"
+	stderr_file="$(mktemp)"
 
-        TOOL_QUERY="${tool_query}" TOOL_ARGS="${tool_args_json}" ${handler} >"${stdout_file}" 2>"${stderr_file}"
-        status=$?
-        output="$(cat "${stdout_file}")"
-        stderr_output="$(cat "${stderr_file}")"
+	TOOL_QUERY="${tool_query}" TOOL_ARGS="${tool_args_json}" ${handler} >"${stdout_file}" 2>"${stderr_file}"
+	status=$?
+	output="$(cat "${stdout_file}")"
+	stderr_output="$(cat "${stderr_file}")"
 
-        rm -f "${stdout_file}" "${stderr_file}"
+	rm -f "${stdout_file}" "${stderr_file}"
 
-        if [[ -n "${stderr_output}" ]]; then
-                log "INFO" "Tool emitted stderr" "$(printf 'tool=%s stderr=%s' "${tool_name}" "${stderr_output}")" >&2
-        fi
-        if ((status != 0)); then
-                log "WARN" "Tool reported non-zero exit" "${tool_name}" >&2
-        fi
+	if [[ -n "${stderr_output}" ]]; then
+		log "INFO" "Tool emitted stderr" "$(printf 'tool=%s stderr=%s' "${tool_name}" "${stderr_output}")" >&2
+	fi
+	if ((status != 0)); then
+		log "WARN" "Tool reported non-zero exit" "${tool_name}" >&2
+	fi
 
-        jq -nc \
-                --arg output "${output}" \
-                --arg error "${stderr_output}" \
-                --argjson exit_code "${status}" \
-                '{output: $output, error: $error, exit_code: $exit_code}'
-        return 0
+	jq -nc \
+		--arg output "${output}" \
+		--arg error "${stderr_output}" \
+		--argjson exit_code "${status}" \
+		'{output: $output, error: $error, exit_code: $exit_code}'
+	return 0
 }
 
 export -f should_prompt_for_tool

--- a/src/lib/planning/prompting.sh
+++ b/src/lib/planning/prompting.sh
@@ -28,43 +28,43 @@ source "${PLANNING_PROMPTING_DIR}/schema.sh"
 source "${PLANNING_PROMPTING_DIR}/normalization.sh"
 
 build_planner_prompt_with_tools() {
-        # Builds the planner prompt using available tool descriptions.
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2... - tool names (strings)
-        local user_query tool_lines
-        local -a tools=()
-        user_query="$1"
-        shift
-        tools=("$@")
+	# Builds the planner prompt using available tool descriptions.
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2... - tool names (strings)
+	local user_query tool_lines
+	local -a tools=()
+	user_query="$1"
+	shift
+	tools=("$@")
 
-        if ((${#tools[@]} > 0)); then
-                tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${tools[@]}")" format_tool_summary_line)"
-        else
-                tool_lines=""
-        fi
+	if ((${#tools[@]} > 0)); then
+		tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${tools[@]}")" format_tool_summary_line)"
+	else
+		tool_lines=""
+	fi
 
-        build_planner_prompt "${user_query}" "${tool_lines}"
+	build_planner_prompt "${user_query}" "${tool_lines}"
 }
 
 plan_json_to_outline() {
-        # Converts a JSON array of plan steps into a numbered outline string.
-        # Arguments:
-        #   $1 - plan JSON array (string)
-        local plan_json plan_clean
-        plan_json="${1:-[]}"
+	# Converts a JSON array of plan steps into a numbered outline string.
+	# Arguments:
+	#   $1 - plan JSON array (string)
+	local plan_json plan_clean
+	plan_json="${1:-[]}"
 
-        if jq -e 'type == "array"' <<<"${plan_json}" >/dev/null 2>&1; then
-                plan_clean="${plan_json}"
-        else
-                plan_clean="$(printf '%s' "$plan_json" | normalize_planner_plan)" || return 1
-        fi
+	if jq -e 'type == "array"' <<<"${plan_json}" >/dev/null 2>&1; then
+		plan_clean="${plan_json}"
+	else
+		plan_clean="$(printf '%s' "$plan_json" | normalize_planner_plan)" || return 1
+	fi
 
-        if [[ -z "${plan_clean}" ]]; then
-                return 1
-        fi
+	if [[ -z "${plan_clean}" ]]; then
+		return 1
+	fi
 
-        jq -r 'to_entries | map("\(.key + 1). " + (if (.value.thought // "") != "" then (.value.thought // "") else "Use " + (.value.tool // "unknown") end)) | join("\n")' <<<"${plan_clean}"
+	jq -r 'to_entries | map("\(.key + 1). " + (if (.value.thought // "") != "" then (.value.thought // "") else "Use " + (.value.tool // "unknown") end)) | join("\n")' <<<"${plan_clean}"
 }
 
 export -f plan_json_to_outline

--- a/src/lib/planning/react.sh
+++ b/src/lib/planning/react.sh
@@ -20,6 +20,7 @@
 #   None directly; functions return status of operations.
 
 PLANNING_REACT_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC2034 # consumed by sourced React helpers
 PLANNING_REACT_ROOT_DIR="${PLANNING_REACT_DIR}"
 
 # shellcheck source=./react/schema.sh disable=SC1091

--- a/src/lib/planning/react/history.sh
+++ b/src/lib/planning/react/history.sh
@@ -28,23 +28,23 @@ source "${PLANNING_REACT_ROOT_DIR}/respond.sh"
 source "${PLANNING_REACT_ROOT_DIR}/../formatting.sh"
 
 initialize_react_state() {
-        # Initializes the ReAct state document with user query, tools, and plan.
-        # Arguments:
-        #   $1 - state prefix to populate (string)
-        #   $2 - user query (string)
-        #   $3 - allowed tools (string, newline delimited)
-        #   $4 - ranked plan entries (string)
-        #   $5 - plan outline text (string)
-        local state_prefix
-        state_prefix="$1"
+	# Initializes the ReAct state document with user query, tools, and plan.
+	# Arguments:
+	#   $1 - state prefix to populate (string)
+	#   $2 - user query (string)
+	#   $3 - allowed tools (string, newline delimited)
+	#   $4 - ranked plan entries (string)
+	#   $5 - plan outline text (string)
+	local state_prefix
+	state_prefix="$1"
 
-        state_set_json_document "${state_prefix}" "$(jq -c -n \
-                --arg user_query "$2" \
-                --arg allowed_tools "$3" \
-                --arg plan_entries "$4" \
-                --arg plan_outline "$5" \
-                --argjson max_steps "${MAX_STEPS:-6}" \
-                '{
+	state_set_json_document "${state_prefix}" "$(jq -c -n \
+		--arg user_query "$2" \
+		--arg allowed_tools "$3" \
+		--arg plan_entries "$4" \
+		--arg plan_outline "$5" \
+		--argjson max_steps "${MAX_STEPS:-6}" \
+		'{
                         user_query: $user_query,
                         allowed_tools: $allowed_tools,
                         plan_entries: $plan_entries,
@@ -59,55 +59,55 @@ initialize_react_state() {
 }
 
 record_history() {
-        # Appends a formatted history entry to the ReAct state.
-        # Arguments:
-        #   $1 - state prefix (string)
-        #   $2 - formatted history entry (string)
-        local entry
-        entry="$2"
-        state_append_history "$1" "${entry}"
+	# Appends a formatted history entry to the ReAct state.
+	# Arguments:
+	#   $1 - state prefix (string)
+	#   $2 - formatted history entry (string)
+	local entry
+	entry="$2"
+	state_append_history "$1" "${entry}"
 }
 
 state_get_history_lines() {
-        # Retrieves history as a newline-delimited string.
-        # Arguments:
-        #   $1 - state prefix (string)
-        # Returns:
-        #   Newline-delimited string of history entries.
-        local state_prefix history_raw
-        state_prefix="$1"
-        history_raw="$(state_get "${state_prefix}" "history")"
+	# Retrieves history as a newline-delimited string.
+	# Arguments:
+	#   $1 - state prefix (string)
+	# Returns:
+	#   Newline-delimited string of history entries.
+	local state_prefix history_raw
+	state_prefix="$1"
+	history_raw="$(state_get "${state_prefix}" "history")"
 
-        if jq -e 'type == "array"' <<<"${history_raw}" >/dev/null 2>&1; then
-                jq -r '.[]' <<<"${history_raw}"
-                return 0
-        fi
+	if jq -e 'type == "array"' <<<"${history_raw}" >/dev/null 2>&1; then
+		jq -r '.[]' <<<"${history_raw}"
+		return 0
+	fi
 
-        printf '%s' "${history_raw}"
+	printf '%s' "${history_raw}"
 }
 
 record_tool_execution() {
-        # Records a tool execution into history.
-        # Arguments:
-        #   $1 - state prefix
-        #   $2 - tool name
-        #   $3 - thought text
-        #   $4 - args JSON
-        #   $5 - observation text
-        #   $6 - step index
-        local state_name
-        local tool thought args_json observation step_index entry
-        state_name="$1"
-        tool="$2"
-        thought="$3"
-        args_json="$4"
-        observation="$5"
-        step_index="$6"
-        if [[ -z "${args_json}" ]]; then
-                args_json="{}"
-        fi
-        entry=$(
-                python3 - "$step_index" "$thought" "$tool" "$args_json" "$observation" <<'PY'
+	# Records a tool execution into history.
+	# Arguments:
+	#   $1 - state prefix
+	#   $2 - tool name
+	#   $3 - thought text
+	#   $4 - args JSON
+	#   $5 - observation text
+	#   $6 - step index
+	local state_name
+	local tool thought args_json observation step_index entry
+	state_name="$1"
+	tool="$2"
+	thought="$3"
+	args_json="$4"
+	observation="$5"
+	step_index="$6"
+	if [[ -z "${args_json}" ]]; then
+		args_json="{}"
+	fi
+	entry=$(
+		python3 - "$step_index" "$thought" "$tool" "$args_json" "$observation" <<'PY'
 import json
 import sys
 
@@ -134,43 +134,43 @@ print(json.dumps({
     "observation": obs_payload,
 }, separators=(",", ":")))
 PY
-        )
-        record_history "${state_name}" "${entry}"
-        log "INFO" "Recorded tool execution" "$(printf 'step=%s tool=%s' "${step_index}" "${tool}")"
+	)
+	record_history "${state_name}" "${entry}"
+	log "INFO" "Recorded tool execution" "$(printf 'step=%s tool=%s' "${step_index}" "${tool}")"
 }
 
 finalize_react_result() {
-        # Finalizes and emits the ReAct run result.
-        # Arguments:
-        #   $1 - state prefix
-        local state_name history_formatted final_answer observation
-        state_name="$1"
-        observation="$(state_get "${state_name}" "final_answer")"
-        if [[ -z "${observation}" ]]; then
-                log "ERROR" "Final answer missing; generating fallback" "${state_name}"
-                history_formatted="$(format_tool_history "$(state_get_history_lines "${state_name}")")"
-                final_answer="$(respond_text "$(state_get "${state_name}" "user_query")" 1000 "${history_formatted}")"
-                state_set "${state_name}" "final_answer" "${final_answer}"
-        else
-                if jq -e '.output != null and .exit_code != null' <<<"${observation}" >/dev/null 2>&1; then
-                        final_answer=$(jq -r '.output' <<<"${observation}")
-                else
-                        final_answer="${observation}"
-                fi
-        fi
+	# Finalizes and emits the ReAct run result.
+	# Arguments:
+	#   $1 - state prefix
+	local state_name history_formatted final_answer observation
+	state_name="$1"
+	observation="$(state_get "${state_name}" "final_answer")"
+	if [[ -z "${observation}" ]]; then
+		log "ERROR" "Final answer missing; generating fallback" "${state_name}"
+		history_formatted="$(format_tool_history "$(state_get_history_lines "${state_name}")")"
+		final_answer="$(respond_text "$(state_get "${state_name}" "user_query")" 1000 "${history_formatted}")"
+		state_set "${state_name}" "final_answer" "${final_answer}"
+	else
+		if jq -e '.output != null and .exit_code != null' <<<"${observation}" >/dev/null 2>&1; then
+			final_answer=$(jq -r '.output' <<<"${observation}")
+		else
+			final_answer="${observation}"
+		fi
+	fi
 
-        state_set "${state_name}" "final_answer" "${final_answer}"
+	state_set "${state_name}" "final_answer" "${final_answer}"
 
-        log_pretty "INFO" "Final answer" "${final_answer}"
-        if [[ -z "$(format_tool_history "$(state_get_history_lines "${state_name}")")" ]]; then
-                log "INFO" "Execution summary" "No tool runs"
-        else
-                log_pretty "INFO" "Execution summary" "$(format_tool_history "$(state_get_history_lines "${state_name}")")"
-        fi
+	log_pretty "INFO" "Final answer" "${final_answer}"
+	if [[ -z "$(format_tool_history "$(state_get_history_lines "${state_name}")")" ]]; then
+		log "INFO" "Execution summary" "No tool runs"
+	else
+		log_pretty "INFO" "Execution summary" "$(format_tool_history "$(state_get_history_lines "${state_name}")")"
+	fi
 
-        emit_boxed_summary \
-                "$(state_get "${state_name}" "user_query")" \
-                "$(state_get "${state_name}" "plan_outline")" \
-                "$(state_get_history_lines "${state_name}")" \
-                "${final_answer}"
+	emit_boxed_summary \
+		"$(state_get "${state_name}" "user_query")" \
+		"$(state_get "${state_name}" "plan_outline")" \
+		"$(state_get_history_lines "${state_name}")" \
+		"${final_answer}"
 }

--- a/src/lib/planning/react/loop.sh
+++ b/src/lib/planning/react/loop.sh
@@ -41,420 +41,420 @@ source "${PLANNING_REACT_ROOT_DIR}/react/history.sh"
 source "${PLANNING_REACT_ROOT_DIR}/context_budget.sh"
 
 format_tool_args() {
-        # Formats tool arguments into a JSON object.
-        # Arguments:
-        #   $1 - tool name (string)
-        #   $2 - primary payload string (string)
-        # Returns:
-        #   A JSON string representing the tool arguments.
-        local tool payload text_key
-        tool="$1"
-        payload="$2"
-        text_key="${CANONICAL_TEXT_ARG_KEY:-input}"
-        case "${tool}" in
-        terminal)
-                read -r -a terminal_tokens <<<"${payload}"
-                if ((${#terminal_tokens[@]} == 0)); then
-                        terminal_tokens=("status")
-                fi
-                jq -nc --arg command "${terminal_tokens[0]}" --argjson args "$(printf '%s\n' "${terminal_tokens[@]:1}" | jq -Rcs 'split("\n") | map(select(length > 0))')" '{command:$command,args:$args}'
-                ;;
-        python_repl)
-                jq -nc --arg code "${payload}" '{code:$code}'
-                ;;
-        notes_search | calendar_search | mail_search)
-                jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
-                ;;
-        web_search)
-                jq -nc --arg query "${payload}" '{query:$query}'
-                ;;
-        clipboard_copy)
-                jq -nc --arg text "${payload}" '{text:$text}'
-                ;;
-        clipboard_paste | notes_list | reminders_list | calendar_list | mail_list_inbox | mail_list_unread)
-                jq -nc '{}'
-                ;;
-        notes_create | notes_append)
-                local title body
-                title=${payload%%$'\n'*}
-                body=${payload#"${title}"}
-                body=${body#$'\n'}
-                jq -nc --arg title "${title}" --arg body "${body}" '{title:$title,body:$body}'
-                ;;
-        notes_read)
-                jq -nc --arg title "${payload}" '{title:$title}'
-                ;;
-        reminders_create)
-                local title notes time
-                title=${payload%%$'\n'*}
-                notes=${payload#"${title}"}
-                notes=${notes#$'\n'}
-                time=""
-                jq -nc --arg title "${title}" --arg time "${time}" --arg notes "${notes}" '{title:$title,time:$time,notes:$notes}'
-                ;;
-        reminders_complete)
-                jq -nc --arg title "${payload}" '{title:$title}'
-                ;;
-        calendar_create)
-                local title start_time location
-                title=${payload%%$'\n'*}
-                start_time=${payload#"${title}"}
-                start_time=${start_time#$'\n'}
-                location=${start_time#*$'\n'}
-                start_time=${start_time%%$'\n'*}
-                jq -nc --arg title "${title}" --arg start_time "${start_time}" --arg location "${location}" '{title:$title,start_time:$start_time,location:$location}'
-                ;;
-        mail_draft | mail_send)
-                jq -nc --arg envelope "${payload}" '{envelope:$envelope}'
-                ;;
-        applescript)
-                jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
-                ;;
-        final_answer)
-                jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
-                ;;
-        *)
-                jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
-                ;;
-        esac
+	# Formats tool arguments into a JSON object.
+	# Arguments:
+	#   $1 - tool name (string)
+	#   $2 - primary payload string (string)
+	# Returns:
+	#   A JSON string representing the tool arguments.
+	local tool payload text_key
+	tool="$1"
+	payload="$2"
+	text_key="${CANONICAL_TEXT_ARG_KEY:-input}"
+	case "${tool}" in
+	terminal)
+		read -r -a terminal_tokens <<<"${payload}"
+		if ((${#terminal_tokens[@]} == 0)); then
+			terminal_tokens=("status")
+		fi
+		jq -nc --arg command "${terminal_tokens[0]}" --argjson args "$(printf '%s\n' "${terminal_tokens[@]:1}" | jq -Rcs 'split("\n") | map(select(length > 0))')" '{command:$command,args:$args}'
+		;;
+	python_repl)
+		jq -nc --arg code "${payload}" '{code:$code}'
+		;;
+	notes_search | calendar_search | mail_search)
+		jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
+		;;
+	web_search)
+		jq -nc --arg query "${payload}" '{query:$query}'
+		;;
+	clipboard_copy)
+		jq -nc --arg text "${payload}" '{text:$text}'
+		;;
+	clipboard_paste | notes_list | reminders_list | calendar_list | mail_list_inbox | mail_list_unread)
+		jq -nc '{}'
+		;;
+	notes_create | notes_append)
+		local title body
+		title=${payload%%$'\n'*}
+		body=${payload#"${title}"}
+		body=${body#$'\n'}
+		jq -nc --arg title "${title}" --arg body "${body}" '{title:$title,body:$body}'
+		;;
+	notes_read)
+		jq -nc --arg title "${payload}" '{title:$title}'
+		;;
+	reminders_create)
+		local title notes time
+		title=${payload%%$'\n'*}
+		notes=${payload#"${title}"}
+		notes=${notes#$'\n'}
+		time=""
+		jq -nc --arg title "${title}" --arg time "${time}" --arg notes "${notes}" '{title:$title,time:$time,notes:$notes}'
+		;;
+	reminders_complete)
+		jq -nc --arg title "${payload}" '{title:$title}'
+		;;
+	calendar_create)
+		local title start_time location
+		title=${payload%%$'\n'*}
+		start_time=${payload#"${title}"}
+		start_time=${start_time#$'\n'}
+		location=${start_time#*$'\n'}
+		start_time=${start_time%%$'\n'*}
+		jq -nc --arg title "${title}" --arg start_time "${start_time}" --arg location "${location}" '{title:$title,start_time:$start_time,location:$location}'
+		;;
+	mail_draft | mail_send)
+		jq -nc --arg envelope "${payload}" '{envelope:$envelope}'
+		;;
+	applescript)
+		jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
+		;;
+	final_answer)
+		jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
+		;;
+	*)
+		jq -nc --arg key "${text_key}" --arg value "${payload}" '{($key):$value}'
+		;;
+	esac
 }
 
 extract_tool_query() {
-        # Arguments:
-        #   $1 - tool name
-        #   $2 - args JSON
-        # Returns a human-readable summary derived from structured args.
-        local tool args_json text_key
-        tool="$1"
-        args_json="$2"
-        text_key="${CANONICAL_TEXT_ARG_KEY:-input}"
-        case "${tool}" in
-        terminal)
-                jq -r '(.command // "") as $cmd | ($cmd + " " + ((.args // []) | map(tostring) | join(" ")))|rtrimstr(" ")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        notes_create | notes_append)
-                jq -r '[(.title // ""), (.body // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        reminders_create)
-                jq -r '[(.title // ""), (.time // ""), (.notes // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        notes_read | reminders_complete)
-                jq -r '(.title // "")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        calendar_create)
-                jq -r '[(.title // ""), (.start_time // ""), (.location // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        python_repl)
-                jq -r '(.code // "")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        notes_search | calendar_search | mail_search)
-                jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        web_search)
-                jq -r '.query // ""' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        clipboard_copy)
-                jq -r '(.text // "")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        mail_draft | mail_send)
-                jq -r '(.envelope // "")' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        applescript)
-                jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        final_answer)
-                jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        clipboard_paste | notes_list | reminders_list | calendar_list | mail_list_inbox | mail_list_unread)
-                printf ''
-                ;;
-        *)
-                jq -r --arg key "${text_key}" '.[$key] // .query // ""' <<<"${args_json}" 2>/dev/null || printf ''
-                ;;
-        esac
+	# Arguments:
+	#   $1 - tool name
+	#   $2 - args JSON
+	# Returns a human-readable summary derived from structured args.
+	local tool args_json text_key
+	tool="$1"
+	args_json="$2"
+	text_key="${CANONICAL_TEXT_ARG_KEY:-input}"
+	case "${tool}" in
+	terminal)
+		jq -r '(.command // "") as $cmd | ($cmd + " " + ((.args // []) | map(tostring) | join(" ")))|rtrimstr(" ")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	notes_create | notes_append)
+		jq -r '[(.title // ""), (.body // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	reminders_create)
+		jq -r '[(.title // ""), (.time // ""), (.notes // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	notes_read | reminders_complete)
+		jq -r '(.title // "")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	calendar_create)
+		jq -r '[(.title // ""), (.start_time // ""), (.location // "")] | map(select(length>0)) | join("\n")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	python_repl)
+		jq -r '(.code // "")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	notes_search | calendar_search | mail_search)
+		jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	web_search)
+		jq -r '.query // ""' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	clipboard_copy)
+		jq -r '(.text // "")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	mail_draft | mail_send)
+		jq -r '(.envelope // "")' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	applescript)
+		jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	final_answer)
+		jq -r --arg key "${text_key}" '.[$key] // ""' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	clipboard_paste | notes_list | reminders_list | calendar_list | mail_list_inbox | mail_list_unread)
+		printf ''
+		;;
+	*)
+		jq -r --arg key "${text_key}" '.[$key] // .query // ""' <<<"${args_json}" 2>/dev/null || printf ''
+		;;
+	esac
 }
 
 format_action_context() {
-        # Arguments:
-        #   $1 - thought text
-        #   $2 - tool name
-        #   $3 - args JSON
-        local thought tool args_json args_pretty
-        thought="$1"
-        tool="$2"
-        args_json="$3"
-        args_pretty="$(jq -c '.' <<<"${args_json}" 2>/dev/null || printf '%s' "${args_json}")"
-        printf 'Thought: %s\nTool: %s\nArgs: %s' "${thought}" "${tool}" "${args_pretty}"
+	# Arguments:
+	#   $1 - thought text
+	#   $2 - tool name
+	#   $3 - args JSON
+	local thought tool args_json args_pretty
+	thought="$1"
+	tool="$2"
+	args_json="$3"
+	args_pretty="$(jq -c '.' <<<"${args_json}" 2>/dev/null || printf '%s' "${args_json}")"
+	printf 'Thought: %s\nTool: %s\nArgs: %s' "${thought}" "${tool}" "${args_pretty}"
 }
 
 _select_action_from_llama() {
-        # Selects an action via llama.cpp, validates it, and writes into the provided variable name.
-        # Arguments:
-        #   $1 - state prefix
-        #   $2 - output variable name for validated JSON
-        local state_name output_name allowed_tools react_schema_path react_schema_text react_prompt raw_action validated_action validation_error_file validation_error
-        local history plan_step_guidance plan_index planned_entry tool planned_thought planned_args_json invoke_llama allowed_tool_lines allowed_tool_descriptions summarized_history
-        state_name="$1"
-        output_name="$2"
+	# Selects an action via llama.cpp, validates it, and writes into the provided variable name.
+	# Arguments:
+	#   $1 - state prefix
+	#   $2 - output variable name for validated JSON
+	local state_name output_name allowed_tools react_schema_path react_schema_text react_prompt raw_action validated_action validation_error_file validation_error
+	local history plan_step_guidance plan_index planned_entry tool planned_thought planned_args_json invoke_llama allowed_tool_lines allowed_tool_descriptions summarized_history
+	state_name="$1"
+	output_name="$2"
 
-        plan_index="$(state_get "${state_name}" "plan_index")"
-        plan_index=${plan_index:-0}
-        planned_entry=$(printf '%s\n' "$(state_get "${state_name}" "plan_entries")" | sed -n "$((plan_index + 1))p")
-        tool=""
-        planned_thought="Following planned step"
-        planned_args_json="{}"
-        plan_step_guidance="Planner provided no additional steps; choose the best next action."
-        if [[ -n "${planned_entry}" ]]; then
-                tool="$(printf '%s' "${planned_entry}" | jq -r '.tool // empty' 2>/dev/null || printf '')"
-                planned_thought="$(printf '%s' "${planned_entry}" | jq -r '.thought // "Following planned step"' 2>/dev/null || printf '')"
-                planned_args_json="$(printf '%s' "${planned_entry}" | jq -c '.args // {}' 2>/dev/null || printf '{}')"
-                plan_step_guidance="$(
-                        jq -rn \
-                                --arg step "$((plan_index + 1))" \
-                                --arg tool "${tool:-}" \
-                                --arg thought "${planned_thought}" \
-                                --argjson args "${planned_args_json}" \
-                                '"Step \($step) suggested by the planner:\n- tool: \($tool // "(unspecified)")\n- thought: \($thought // "")\n- args: \($args|@json)"'
-                )"
-        fi
+	plan_index="$(state_get "${state_name}" "plan_index")"
+	plan_index=${plan_index:-0}
+	planned_entry=$(printf '%s\n' "$(state_get "${state_name}" "plan_entries")" | sed -n "$((plan_index + 1))p")
+	tool=""
+	planned_thought="Following planned step"
+	planned_args_json="{}"
+	plan_step_guidance="Planner provided no additional steps; choose the best next action."
+	if [[ -n "${planned_entry}" ]]; then
+		tool="$(printf '%s' "${planned_entry}" | jq -r '.tool // empty' 2>/dev/null || printf '')"
+		planned_thought="$(printf '%s' "${planned_entry}" | jq -r '.thought // "Following planned step"' 2>/dev/null || printf '')"
+		planned_args_json="$(printf '%s' "${planned_entry}" | jq -c '.args // {}' 2>/dev/null || printf '{}')"
+		plan_step_guidance="$(
+			jq -rn \
+				--arg step "$((plan_index + 1))" \
+				--arg tool "${tool:-}" \
+				--arg thought "${planned_thought}" \
+				--argjson args "${planned_args_json}" \
+				'"Step \($step) suggested by the planner:\n- tool: \($tool // "(unspecified)")\n- thought: \($thought // "")\n- args: \($args|@json)"'
+		)"
+	fi
 
-        invoke_llama=false
-        if [[ "${USE_REACT_LLAMA:-false}" == true && "${LLAMA_AVAILABLE}" == true ]]; then
-                invoke_llama=true
-        fi
-        if [[ "${tool}" == "react_fallback" && "${LLAMA_AVAILABLE}" == true ]]; then
-                invoke_llama=true
-        fi
+	invoke_llama=false
+	if [[ "${USE_REACT_LLAMA:-false}" == true && "${LLAMA_AVAILABLE}" == true ]]; then
+		invoke_llama=true
+	fi
+	if [[ "${tool}" == "react_fallback" && "${LLAMA_AVAILABLE}" == true ]]; then
+		invoke_llama=true
+	fi
 
-        allowed_tools="$(state_get "${state_name}" "allowed_tools")"
-        if [[ -z "${allowed_tools}" ]]; then
-                allowed_tools="$(tool_names)"
-        fi
+	allowed_tools="$(state_get "${state_name}" "allowed_tools")"
+	if [[ -z "${allowed_tools}" ]]; then
+		allowed_tools="$(tool_names)"
+	fi
 
-        if [[ "${tool}" == "react_fallback" ]]; then
-                allowed_tools="$(tool_names)"
-        fi
+	if [[ "${tool}" == "react_fallback" ]]; then
+		allowed_tools="$(tool_names)"
+	fi
 
-        if [[ -n "${allowed_tools}" ]] && ! grep -Fxq "final_answer" <<<"${allowed_tools}"; then
-                allowed_tools+=$'\nfinal_answer'
-        fi
+	if [[ -n "${allowed_tools}" ]] && ! grep -Fxq "final_answer" <<<"${allowed_tools}"; then
+		allowed_tools+=$'\nfinal_answer'
+	fi
 
-        allowed_tools="$(printf '%s\n' "${allowed_tools}" | sed '/^react_fallback$/d' | awk '!seen[$0]++')"
+	allowed_tools="$(printf '%s\n' "${allowed_tools}" | sed '/^react_fallback$/d' | awk '!seen[$0]++')"
 
-        if [[ -z "${plan_step_guidance}" ]]; then
-                plan_step_guidance="Planner provided no additional steps; choose the best next action."
-        fi
+	if [[ -z "${plan_step_guidance}" ]]; then
+		plan_step_guidance="Planner provided no additional steps; choose the best next action."
+	fi
 
-        if [[ "${invoke_llama}" != true ]]; then
-                return 1
-        fi
+	if [[ "${invoke_llama}" != true ]]; then
+		return 1
+	fi
 
-        allowed_tool_lines="$(format_tool_descriptions "${allowed_tools}" format_tool_example_line)"
-        allowed_tool_descriptions="Available tools:"
-        if [[ -n "${allowed_tool_lines}" ]]; then
-                allowed_tool_descriptions+=$'\n'"${allowed_tool_lines}"
-        fi
+	allowed_tool_lines="$(format_tool_descriptions "${allowed_tools}" format_tool_example_line)"
+	allowed_tool_descriptions="Available tools:"
+	if [[ -n "${allowed_tool_lines}" ]]; then
+		allowed_tool_descriptions+=$'\n'"${allowed_tool_lines}"
+	fi
 
-        react_schema_path="$(build_react_action_schema "${allowed_tools}")" || return 1
-        react_schema_text="$(cat "${react_schema_path}")" || return 1
-        history="$(format_tool_history "$(state_get_history_lines "${state_name}")")"
+	react_schema_path="$(build_react_action_schema "${allowed_tools}")" || return 1
+	react_schema_text="$(cat "${react_schema_path}")" || return 1
+	history="$(format_tool_history "$(state_get_history_lines "${state_name}")")"
 
-        react_prompt="$(
-                build_react_prompt \
-                        "$(state_get "${state_name}" "user_query")" \
-                        "${allowed_tool_descriptions}" \
-                        "$(state_get "${state_name}" "plan_outline")" \
-                        "${history}" \
-                        "${react_schema_text}" \
-                        "${plan_step_guidance}"
-        )"
-        summarized_history="$(apply_prompt_context_budget "${react_prompt}" "${history}" 256 "react_history")"
-        if [[ "${summarized_history}" != "${history}" ]]; then
-                history="${summarized_history}"
-                react_prompt="$(
-                        build_react_prompt \
-                                "$(state_get "${state_name}" "user_query")" \
-                                "${allowed_tool_descriptions}" \
-                                "$(state_get "${state_name}" "plan_outline")" \
-                                "${history}" \
-                                "${react_schema_text}" \
-                                "${plan_step_guidance}"
-                )"
-        fi
-        validation_error_file="$(mktemp)"
+	react_prompt="$(
+		build_react_prompt \
+			"$(state_get "${state_name}" "user_query")" \
+			"${allowed_tool_descriptions}" \
+			"$(state_get "${state_name}" "plan_outline")" \
+			"${history}" \
+			"${react_schema_text}" \
+			"${plan_step_guidance}"
+	)"
+	summarized_history="$(apply_prompt_context_budget "${react_prompt}" "${history}" 256 "react_history")"
+	if [[ "${summarized_history}" != "${history}" ]]; then
+		history="${summarized_history}"
+		react_prompt="$(
+			build_react_prompt \
+				"$(state_get "${state_name}" "user_query")" \
+				"${allowed_tool_descriptions}" \
+				"$(state_get "${state_name}" "plan_outline")" \
+				"${history}" \
+				"${react_schema_text}" \
+				"${plan_step_guidance}"
+		)"
+	fi
+	validation_error_file="$(mktemp)"
 
-        raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_text}" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}")"
-        log_pretty "INFO" "Action received" "${raw_action}"
+	raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_text}" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}")"
+	log_pretty "INFO" "Action received" "${raw_action}"
 
-        if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
-                validation_error="$(cat "${validation_error_file}")"
-                record_history "${state_name}" "$(printf 'Invalid action from model: %s' "${validation_error}")"
-                log "WARN" "Invalid action output from llama" "${validation_error}"
-                rm -f "${validation_error_file}"
-                rm -f "${react_schema_path}"
-                return 1
-        fi
+	if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then
+		validation_error="$(cat "${validation_error_file}")"
+		record_history "${state_name}" "$(printf 'Invalid action from model: %s' "${validation_error}")"
+		log "WARN" "Invalid action output from llama" "${validation_error}"
+		rm -f "${validation_error_file}"
+		rm -f "${react_schema_path}"
+		return 1
+	fi
 
-        rm -f "${validation_error_file}"
-        rm -f "${react_schema_path}"
+	rm -f "${validation_error_file}"
+	rm -f "${react_schema_path}"
 
-        printf -v "${output_name}" '%s' "${validated_action}"
-        return 0
+	printf -v "${output_name}" '%s' "${validated_action}"
+	return 0
 }
 
 select_next_action() {
-        # Chooses the next action either from the plan or LLM.
-        # Arguments:
-        #   $1 - state prefix
-        #   $2 - (optional) name of variable to receive JSON action output
-        local state_name output_name react_fallback_action react_action_json plan_index planned_entry planned_thought planned_args_json
-        state_name="$1"
-        output_name="${2:-}"
+	# Chooses the next action either from the plan or LLM.
+	# Arguments:
+	#   $1 - state prefix
+	#   $2 - (optional) name of variable to receive JSON action output
+	local state_name output_name react_fallback_action react_action_json plan_index planned_entry planned_thought planned_args_json
+	state_name="$1"
+	output_name="${2:-}"
 
-        plan_index="$(state_get "${state_name}" "plan_index")"
-        plan_index=${plan_index:-0}
-        planned_entry=$(printf '%s\n' "$(state_get "${state_name}" "plan_entries")" | sed -n "$((plan_index + 1))p")
+	plan_index="$(state_get "${state_name}" "plan_index")"
+	plan_index=${plan_index:-0}
+	planned_entry=$(printf '%s\n' "$(state_get "${state_name}" "plan_entries")" | sed -n "$((plan_index + 1))p")
 
-        if [[ -n "${planned_entry}" ]]; then
-                react_fallback_action=$(jq -nc --arg thought "$(printf '%s' "${planned_entry}" | jq -r '.thought // "Following planned step"' 2>/dev/null || printf '')" --arg tool "$(printf '%s' "${planned_entry}" | jq -r '.tool // empty' 2>/dev/null || printf '')" --argjson args "$(printf '%s' "${planned_entry}" | jq -c '.args // {}' 2>/dev/null || printf '{}')" '{thought:$thought,tool:$tool,args:$args}')
-        else
-                react_fallback_action=""
-        fi
+	if [[ -n "${planned_entry}" ]]; then
+		react_fallback_action=$(jq -nc --arg thought "$(printf '%s' "${planned_entry}" | jq -r '.thought // "Following planned step"' 2>/dev/null || printf '')" --arg tool "$(printf '%s' "${planned_entry}" | jq -r '.tool // empty' 2>/dev/null || printf '')" --argjson args "$(printf '%s' "${planned_entry}" | jq -c '.args // {}' 2>/dev/null || printf '{}')" '{thought:$thought,tool:$tool,args:$args}')
+	else
+		react_fallback_action=""
+	fi
 
-        if ! _select_action_from_llama "${state_name}" react_action_json; then
-                if [[ -z "${react_fallback_action}" ]]; then
-                        return 1
-                fi
-                react_action_json="${react_fallback_action}"
-        else
-                state_set "${state_name}" "plan_index" "$((plan_index + 1))"
-        fi
+	if ! _select_action_from_llama "${state_name}" react_action_json; then
+		if [[ -z "${react_fallback_action}" ]]; then
+			return 1
+		fi
+		react_action_json="${react_fallback_action}"
+	else
+		state_set "${state_name}" "plan_index" "$((plan_index + 1))"
+	fi
 
-        if [[ -n "${output_name}" ]]; then
-                printf -v "${output_name}" '%s' "${react_action_json}"
-        else
-                printf '%s' "${react_action_json}"
-        fi
+	if [[ -n "${output_name}" ]]; then
+		printf -v "${output_name}" '%s' "${react_action_json}"
+	else
+		printf '%s' "${react_action_json}"
+	fi
 }
 
 validate_tool_permission() {
-        # Confirms that the provided tool is permitted for the current run.
-        # Arguments:
-        #   $1 - state prefix
-        #   $2 - tool name to validate
-        local state_name tool
-        state_name="$1"
-        tool="$2"
-        if grep -Fxq "${tool}" <<<"$(state_get "${state_name}" "allowed_tools")"; then
-                return 0
-        fi
+	# Confirms that the provided tool is permitted for the current run.
+	# Arguments:
+	#   $1 - state prefix
+	#   $2 - tool name to validate
+	local state_name tool
+	state_name="$1"
+	tool="$2"
+	if grep -Fxq "${tool}" <<<"$(state_get "${state_name}" "allowed_tools")"; then
+		return 0
+	fi
 
-        record_history "${state_name}" "$(printf 'Tool %s not permitted.' "${tool}")"
-        return 1
+	record_history "${state_name}" "$(printf 'Tool %s not permitted.' "${tool}")"
+	return 1
 }
 
 execute_tool_action() {
-        # Executes the selected tool.
-        # Arguments:
-        #   $1 - tool name
-        #   $2 - tool query
-        #   $3 - human-readable context (optional)
-        #   $4 - structured args JSON (optional)
-        local tool query context args_json
-        tool="$1"
-        query="$2"
-        context="$3"
-        args_json="$4"
-        execute_tool_with_query "${tool}" "${query}" "${context}" "${args_json}" || true
+	# Executes the selected tool.
+	# Arguments:
+	#   $1 - tool name
+	#   $2 - tool query
+	#   $3 - human-readable context (optional)
+	#   $4 - structured args JSON (optional)
+	local tool query context args_json
+	tool="$1"
+	query="$2"
+	context="$3"
+	args_json="$4"
+	execute_tool_with_query "${tool}" "${query}" "${context}" "${args_json}" || true
 }
 
 is_duplicate_action() {
-        # Determines whether the supplied action matches the previous non-final answer action.
-        # Arguments:
-        #   $1 - last action JSON
-        #   $2 - candidate tool name
-        #   $3 - candidate args JSON
-        local last_action tool args_json last_tool last_args
-        last_action="$1"
-        tool="$2"
-        args_json="$3"
+	# Determines whether the supplied action matches the previous non-final answer action.
+	# Arguments:
+	#   $1 - last action JSON
+	#   $2 - candidate tool name
+	#   $3 - candidate args JSON
+	local last_action tool args_json last_tool last_args
+	last_action="$1"
+	tool="$2"
+	args_json="$3"
 
-        if [[ "${last_action}" == "null" ]]; then
-                return 1
-        fi
+	if [[ "${last_action}" == "null" ]]; then
+		return 1
+	fi
 
-        last_tool="$(printf '%s' "${last_action}" | jq -r '.tool // empty')"
-        last_args="$(printf '%s' "${last_action}" | jq -c '.args // {}')"
-        if [[ "${tool}" == "${last_tool}" && "${args_json}" == "${last_args}" && "${tool}" != "final_answer" ]]; then
-                return 0
-        fi
+	last_tool="$(printf '%s' "${last_action}" | jq -r '.tool // empty')"
+	last_args="$(printf '%s' "${last_action}" | jq -c '.args // {}')"
+	if [[ "${tool}" == "${last_tool}" && "${args_json}" == "${last_args}" && "${tool}" != "final_answer" ]]; then
+		return 0
+	fi
 
-        return 1
+	return 1
 }
 
 react_loop() {
-        local user_query allowed_tools plan_entries plan_outline action_json tool query observation current_step thought args_json action_context
-        local state_prefix last_action
-        user_query="$1"
-        allowed_tools="$2"
-        plan_entries="$3"
-        plan_outline="$4"
+	local user_query allowed_tools plan_entries plan_outline action_json tool query observation current_step thought args_json action_context
+	local state_prefix last_action
+	user_query="$1"
+	allowed_tools="$2"
+	plan_entries="$3"
+	plan_outline="$4"
 
-        state_prefix="react_state"
-        initialize_react_state "${state_prefix}" "${user_query}" "${allowed_tools}" "${plan_entries}" "${plan_outline}"
-        action_json=""
+	state_prefix="react_state"
+	initialize_react_state "${state_prefix}" "${user_query}" "${allowed_tools}" "${plan_entries}" "${plan_outline}"
+	action_json=""
 
-        while (($(state_get "${state_prefix}" "step") < $(state_get "${state_prefix}" "max_steps"))); do
-                current_step=$(($(state_get "${state_prefix}" "step") + 1))
-                action_json=""
+	while (($(state_get "${state_prefix}" "step") < $(state_get "${state_prefix}" "max_steps"))); do
+		current_step=$(($(state_get "${state_prefix}" "step") + 1))
+		action_json=""
 
-                if ! select_next_action "${state_prefix}" action_json; then
-                        log "WARN" "Skipping step due to invalid action selection" "step=${current_step}"
-                        state_set "${state_prefix}" "step" "${current_step}"
-                        continue
-                fi
-                tool="$(printf '%s' "${action_json}" | jq -r '.tool // empty' 2>/dev/null || true)"
-                thought="$(printf '%s' "${action_json}" | jq -r '.thought // empty' 2>/dev/null || true)"
-                args_json="$(printf '%s' "${action_json}" | jq -c '.args // {}' 2>/dev/null || printf '{}')"
+		if ! select_next_action "${state_prefix}" action_json; then
+			log "WARN" "Skipping step due to invalid action selection" "step=${current_step}"
+			state_set "${state_prefix}" "step" "${current_step}"
+			continue
+		fi
+		tool="$(printf '%s' "${action_json}" | jq -r '.tool // empty' 2>/dev/null || true)"
+		thought="$(printf '%s' "${action_json}" | jq -r '.thought // empty' 2>/dev/null || true)"
+		args_json="$(printf '%s' "${action_json}" | jq -c '.args // {}' 2>/dev/null || printf '{}')"
 
-                last_action="$(state_get "${state_prefix}" "last_action")"
-                if is_duplicate_action "${last_action}" "${tool}" "${args_json}"; then
-                        log "WARN" "Duplicate action detected" "${tool}"
-                        observation="Duplicate action detected. Please try a different approach or call final_answer if you are stuck."
-                        record_tool_execution "${state_prefix}" "${tool}" "${thought} (REPEATED)" "${args_json}" "${observation}" "${current_step}"
-                        state_set "${state_prefix}" "step" "${current_step}"
-                        continue
-                fi
-                state_set_json_document "${state_prefix}" "$(state_get_json_document "${state_prefix}" | jq -c --argjson action "${action_json}" '.last_action = $action')"
+		last_action="$(state_get "${state_prefix}" "last_action")"
+		if is_duplicate_action "${last_action}" "${tool}" "${args_json}"; then
+			log "WARN" "Duplicate action detected" "${tool}"
+			observation="Duplicate action detected. Please try a different approach or call final_answer if you are stuck."
+			record_tool_execution "${state_prefix}" "${tool}" "${thought} (REPEATED)" "${args_json}" "${observation}" "${current_step}"
+			state_set "${state_prefix}" "step" "${current_step}"
+			continue
+		fi
+		state_set_json_document "${state_prefix}" "$(state_get_json_document "${state_prefix}" | jq -c --argjson action "${action_json}" '.last_action = $action')"
 
-                query="$(extract_tool_query "${tool}" "${args_json}")"
-                action_context="$(format_action_context "${thought}" "${tool}" "${args_json}")"
+		query="$(extract_tool_query "${tool}" "${args_json}")"
+		action_context="$(format_action_context "${thought}" "${tool}" "${args_json}")"
 
-                if ! validate_tool_permission "${state_prefix}" "${tool}"; then
-                        state_set "${state_prefix}" "step" "${current_step}"
-                        continue
-                fi
+		if ! validate_tool_permission "${state_prefix}" "${tool}"; then
+			state_set "${state_prefix}" "step" "${current_step}"
+			continue
+		fi
 
-                observation="$(execute_tool_action "${tool}" "${query}" "${action_context}" "${args_json}")"
-                record_tool_execution "${state_prefix}" "${tool}" "${thought}" "${args_json}" "${observation}" "${current_step}"
+		observation="$(execute_tool_action "${tool}" "${query}" "${action_context}" "${args_json}")"
+		record_tool_execution "${state_prefix}" "${tool}" "${thought}" "${args_json}" "${observation}" "${current_step}"
 
-                local exit_code
-                exit_code=$(printf '%s' "${observation}" | jq -r '.exit_code // 0' 2>/dev/null || echo 0)
-                if ((exit_code != 0)); then
-                        local plan_entries_text
-                        plan_entries_text="$(state_get "${state_prefix}" "plan_entries")"
-                        if [[ -n "${plan_entries_text}" && "${LLAMA_AVAILABLE}" == true ]]; then
-                                log "INFO" "Tool failed during planned execution; falling back to LLM" "${tool}"
-                                state_set "${state_prefix}" "plan_entries" ""
-                        fi
-                fi
+		local exit_code
+		exit_code=$(printf '%s' "${observation}" | jq -r '.exit_code // 0' 2>/dev/null || echo 0)
+		if ((exit_code != 0)); then
+			local plan_entries_text
+			plan_entries_text="$(state_get "${state_prefix}" "plan_entries")"
+			if [[ -n "${plan_entries_text}" && "${LLAMA_AVAILABLE}" == true ]]; then
+				log "INFO" "Tool failed during planned execution; falling back to LLM" "${tool}"
+				state_set "${state_prefix}" "plan_entries" ""
+			fi
+		fi
 
-                state_set "${state_prefix}" "step" "${current_step}"
-                if [[ "${tool}" == "final_answer" ]]; then
-                        state_set "${state_prefix}" "final_answer" "${observation}"
-                        break
-                fi
-        done
+		state_set "${state_prefix}" "step" "${current_step}"
+		if [[ "${tool}" == "final_answer" ]]; then
+			state_set "${state_prefix}" "final_answer" "${observation}"
+			break
+		fi
+	done
 
-        finalize_react_result "${state_prefix}"
+	finalize_react_result "${state_prefix}"
 }

--- a/src/lib/planning/react/schema.sh
+++ b/src/lib/planning/react/schema.sh
@@ -26,18 +26,18 @@ source "${PLANNING_REACT_ROOT_DIR}/../core/logging.sh"
 source "${PLANNING_REACT_ROOT_DIR}/../tools.sh"
 
 build_react_action_schema() {
-        # Constructs a JSON schema for allowed ReAct tools.
-        # Arguments:
-        #   $1 - newline-delimited allowed tools (optional)
-        local allowed_tools registry_json
-        allowed_tools="$1"
+	# Constructs a JSON schema for allowed ReAct tools.
+	# Arguments:
+	#   $1 - newline-delimited allowed tools (optional)
+	local allowed_tools registry_json
+	allowed_tools="$1"
 
-        if [[ -z "$(tool_names)" ]] && declare -F initialize_tools >/dev/null 2>&1; then
-                initialize_tools >/dev/null 2>&1 || true
-        fi
-        registry_json="$(tool_registry_json)"
+	if [[ -z "$(tool_names)" ]] && declare -F initialize_tools >/dev/null 2>&1; then
+		initialize_tools >/dev/null 2>&1 || true
+	fi
+	registry_json="$(tool_registry_json)"
 
-        python3 - "${allowed_tools}" "${registry_json}" "${CANONICAL_TEXT_ARG_KEY:-input}" <<'PY'
+	python3 - "${allowed_tools}" "${registry_json}" "${CANONICAL_TEXT_ARG_KEY:-input}" <<'PY'
 import json
 import sys
 import tempfile
@@ -117,192 +117,192 @@ PY
 }
 
 validate_react_action() {
-        # Validates a llama-produced action against the generated schema.
-        # Arguments:
-        #   $1 - raw action JSON string
-        #   $2 - schema path
-        local raw_action schema_path action_json schema_json allowed_tools tool tool_schema properties_json additional_properties
-        local err_log required_args thought_trimmed
-        raw_action="$1"
-        schema_path="$2"
+	# Validates a llama-produced action against the generated schema.
+	# Arguments:
+	#   $1 - raw action JSON string
+	#   $2 - schema path
+	local raw_action schema_path action_json schema_json allowed_tools tool tool_schema properties_json additional_properties
+	local err_log required_args thought_trimmed
+	raw_action="$1"
+	schema_path="$2"
 
-        err_log=$(mktemp)
+	err_log=$(mktemp)
 
-        if ! action_json=$(jq -ce '.' <<<"${raw_action}" 2>"${err_log}"); then
-                printf 'Invalid JSON: %s\n' "$(<"${err_log}")" >&2
-                rm -f "${err_log}"
-                return 1
-        fi
+	if ! action_json=$(jq -ce '.' <<<"${raw_action}" 2>"${err_log}"); then
+		printf 'Invalid JSON: %s\n' "$(<"${err_log}")" >&2
+		rm -f "${err_log}"
+		return 1
+	fi
 
-        if ! schema_json=$(jq -ce '.' "${schema_path}" 2>"${err_log}"); then
-                printf 'Schema load failed: %s\n' "$(<"${err_log}")" >&2
-                rm -f "${err_log}"
-                return 1
-        fi
+	if ! schema_json=$(jq -ce '.' "${schema_path}" 2>"${err_log}"); then
+		printf 'Schema load failed: %s\n' "$(<"${err_log}")" >&2
+		rm -f "${err_log}"
+		return 1
+	fi
 
-        rm -f "${err_log}"
+	rm -f "${err_log}"
 
-        for key in thought tool args; do
-                if ! jq -e --arg key "${key}" 'has($key)' <<<"${action_json}" >/dev/null; then
-                        printf 'Missing field: %s\n' "${key}" >&2
-                        return 1
-                fi
-        done
+	for key in thought tool args; do
+		if ! jq -e --arg key "${key}" 'has($key)' <<<"${action_json}" >/dev/null; then
+			printf 'Missing field: %s\n' "${key}" >&2
+			return 1
+		fi
+	done
 
-        local unexpected
-        unexpected=$(jq -er 'keys_unsorted | map(select(. != "thought" and . != "tool" and . != "args")) | first? // empty' <<<"${action_json}" 2>/dev/null || true)
-        if [[ -n "${unexpected}" ]]; then
-                        printf 'Unexpected field: %s\n' "${unexpected}" >&2
-                        return 1
-        fi
+	local unexpected
+	unexpected=$(jq -er 'keys_unsorted | map(select(. != "thought" and . != "tool" and . != "args")) | first? // empty' <<<"${action_json}" 2>/dev/null || true)
+	if [[ -n "${unexpected}" ]]; then
+		printf 'Unexpected field: %s\n' "${unexpected}" >&2
+		return 1
+	fi
 
-        if ! jq -e '.thought | type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0)' <<<"${action_json}" >/dev/null; then
-                        printf 'thought must be a non-empty string\n' >&2
-                        return 1
-        fi
+	if ! jq -e '.thought | type == "string" and (gsub("^\\s+|\\s+$"; "") | length > 0)' <<<"${action_json}" >/dev/null; then
+		printf 'thought must be a non-empty string\n' >&2
+		return 1
+	fi
 
-        if ! jq -e '.tool | type == "string"' <<<"${action_json}" >/dev/null; then
-                        printf 'tool must be a string\n' >&2
-                        return 1
-        fi
+	if ! jq -e '.tool | type == "string"' <<<"${action_json}" >/dev/null; then
+		printf 'tool must be a string\n' >&2
+		return 1
+	fi
 
-        tool=$(jq -r '.tool' <<<"${action_json}")
-        allowed_tools=$(jq -cr '.properties.tool.enum // []' <<<"${schema_json}")
-        if ! jq -e --arg tool "${tool}" --argjson allowed "${allowed_tools}" '$allowed | index($tool)' <<<"null" >/dev/null; then
-                        printf 'Unsupported tool: %s\n' "${tool}" >&2
-                        return 1
-        fi
+	tool=$(jq -r '.tool' <<<"${action_json}")
+	allowed_tools=$(jq -cr '.properties.tool.enum // []' <<<"${schema_json}")
+	if ! jq -e --arg tool "${tool}" --argjson allowed "${allowed_tools}" '$allowed | index($tool)' <<<"null" >/dev/null; then
+		printf 'Unsupported tool: %s\n' "${tool}" >&2
+		return 1
+	fi
 
-        if ! jq -e '.args | type == "object"' <<<"${action_json}" >/dev/null; then
-                        printf 'args must be an object\n' >&2
-                        return 1
-        fi
+	if ! jq -e '.args | type == "object"' <<<"${action_json}" >/dev/null; then
+		printf 'args must be an object\n' >&2
+		return 1
+	fi
 
-        tool_schema=$(jq -c --arg tool "${tool}" '."$defs".args_by_tool[$tool]' <<<"${schema_json}")
-        if [[ -z "${tool_schema}" || "${tool_schema}" == "null" ]]; then
-                        printf 'No schema for tool: %s\n' "${tool}" >&2
-                        return 1
-        fi
+	tool_schema=$(jq -c --arg tool "${tool}" '."$defs".args_by_tool[$tool]' <<<"${schema_json}")
+	if [[ -z "${tool_schema}" || "${tool_schema}" == "null" ]]; then
+		printf 'No schema for tool: %s\n' "${tool}" >&2
+		return 1
+	fi
 
-        properties_json=$(jq -c 'if (.properties | type == "object") then .properties else {} end' <<<"${tool_schema}")
-        required_args=$(jq -r '(.required // [])[]?' <<<"${tool_schema}")
-        additional_properties=$(jq -c 'if .additionalProperties == null then false else .additionalProperties end' <<<"${tool_schema}")
+	properties_json=$(jq -c 'if (.properties | type == "object") then .properties else {} end' <<<"${tool_schema}")
+	required_args=$(jq -r '(.required // [])[]?' <<<"${tool_schema}")
+	additional_properties=$(jq -c 'if .additionalProperties == null then false else .additionalProperties end' <<<"${tool_schema}")
 
-        local required
-        for required in ${required_args}; do
-                if ! jq -e --arg key "${required}" '.args | has($key)' <<<"${action_json}" >/dev/null; then
-                        printf 'Missing arg: %s\n' "${required}" >&2
-                        return 1
-                fi
-        done
+	local required
+	for required in ${required_args}; do
+		if ! jq -e --arg key "${required}" '.args | has($key)' <<<"${action_json}" >/dev/null; then
+			printf 'Missing arg: %s\n' "${required}" >&2
+			return 1
+		fi
+	done
 
-        _react_enforce_arg_type() {
-                # Validates an argument value against a schema fragment using jq types.
-                # Arguments:
-                #   $1 - argument key (string)
-                #   $2 - argument JSON value (string)
-                #   $3 - schema JSON string
-                local arg_key value_json schema_fragment expected_type min_length item_type enum_values const_value
-                arg_key="$1"
-                value_json="$2"
-                schema_fragment="$3"
+	_react_enforce_arg_type() {
+		# Validates an argument value against a schema fragment using jq types.
+		# Arguments:
+		#   $1 - argument key (string)
+		#   $2 - argument JSON value (string)
+		#   $3 - schema JSON string
+		local arg_key value_json schema_fragment expected_type min_length item_type enum_values const_value
+		arg_key="$1"
+		value_json="$2"
+		schema_fragment="$3"
 
-                expected_type=$(jq -r '.type // empty' <<<"${schema_fragment}")
-                if [[ -z "${expected_type}" ]]; then
-                        return 0
-                fi
+		expected_type=$(jq -r '.type // empty' <<<"${schema_fragment}")
+		if [[ -z "${expected_type}" ]]; then
+			return 0
+		fi
 
-                case "${expected_type}" in
-                string)
-                        enum_values=$(jq -c '.enum // empty' <<<"${schema_fragment}")
-                        const_value=$(jq -c '.const // empty' <<<"${schema_fragment}")
-                        if ! jq -e 'type == "string"' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a string\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        min_length=$(jq -r '.minLength // 0' <<<"${schema_fragment}")
-                        if [[ "${min_length}" -gt 0 ]] && [[ -z "$(jq -r 'gsub("^\\s+|\\s+$"; "")' <<<"${value_json}")" ]]; then
-                                printf 'Arg %s cannot be empty\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        if [[ -n "${const_value}" && "${const_value}" != "null" ]]; then
-                                if ! jq -e --argjson const "${const_value}" --argjson val "${value_json}" '$const == $val' <<<"null" >/dev/null; then
-                                        printf 'Arg %s must equal %s\n' "${arg_key}" "${const_value}" >&2
-                                        return 1
-                                fi
-                        fi
-                        if [[ -n "${enum_values}" && "${enum_values}" != "null" ]]; then
-                                if ! jq -e --argjson enum "${enum_values}" --argjson val "${value_json}" '$enum | index($val)' <<<"null" >/dev/null; then
-                                        printf 'Arg %s must be one of: %s\n' "${arg_key}" "${enum_values}" >&2
-                                        return 1
-                                fi
-                        fi
-                        ;;
-                object)
-                        if ! jq -e 'type == "object"' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a object\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        ;;
-                array)
-                        if ! jq -e 'type == "array"' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a array\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        item_type=$(jq -r '.items.type // empty' <<<"${schema_fragment}")
-                        if [[ "${item_type}" == "string" ]] && ! jq -e 'all(.[]?; type == "string")' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s items must be strings\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        ;;
-                boolean)
-                        if ! jq -e 'type == "boolean"' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a boolean\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        ;;
-                number)
-                        if ! jq -e 'type == "number"' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a number\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        ;;
-                integer)
-                        if ! jq -e '(type == "number") and (.|floor == .)' <<<"${value_json}" >/dev/null; then
-                                printf 'Arg %s must be a integer\n' "${arg_key}" >&2
-                                return 1
-                        fi
-                        ;;
-                esac
+		case "${expected_type}" in
+		string)
+			enum_values=$(jq -c '.enum // empty' <<<"${schema_fragment}")
+			const_value=$(jq -c '.const // empty' <<<"${schema_fragment}")
+			if ! jq -e 'type == "string"' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a string\n' "${arg_key}" >&2
+				return 1
+			fi
+			min_length=$(jq -r '.minLength // 0' <<<"${schema_fragment}")
+			if [[ "${min_length}" -gt 0 ]] && [[ -z "$(jq -r 'gsub("^\\s+|\\s+$"; "")' <<<"${value_json}")" ]]; then
+				printf 'Arg %s cannot be empty\n' "${arg_key}" >&2
+				return 1
+			fi
+			if [[ -n "${const_value}" && "${const_value}" != "null" ]]; then
+				if ! jq -e --argjson const "${const_value}" --argjson val "${value_json}" '$const == $val' <<<"null" >/dev/null; then
+					printf 'Arg %s must equal %s\n' "${arg_key}" "${const_value}" >&2
+					return 1
+				fi
+			fi
+			if [[ -n "${enum_values}" && "${enum_values}" != "null" ]]; then
+				if ! jq -e --argjson enum "${enum_values}" --argjson val "${value_json}" '$enum | index($val)' <<<"null" >/dev/null; then
+					printf 'Arg %s must be one of: %s\n' "${arg_key}" "${enum_values}" >&2
+					return 1
+				fi
+			fi
+			;;
+		object)
+			if ! jq -e 'type == "object"' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a object\n' "${arg_key}" >&2
+				return 1
+			fi
+			;;
+		array)
+			if ! jq -e 'type == "array"' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a array\n' "${arg_key}" >&2
+				return 1
+			fi
+			item_type=$(jq -r '.items.type // empty' <<<"${schema_fragment}")
+			if [[ "${item_type}" == "string" ]] && ! jq -e 'all(.[]?; type == "string")' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s items must be strings\n' "${arg_key}" >&2
+				return 1
+			fi
+			;;
+		boolean)
+			if ! jq -e 'type == "boolean"' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a boolean\n' "${arg_key}" >&2
+				return 1
+			fi
+			;;
+		number)
+			if ! jq -e 'type == "number"' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a number\n' "${arg_key}" >&2
+				return 1
+			fi
+			;;
+		integer)
+			if ! jq -e '(type == "number") and (.|floor == .)' <<<"${value_json}" >/dev/null; then
+				printf 'Arg %s must be a integer\n' "${arg_key}" >&2
+				return 1
+			fi
+			;;
+		esac
 
-                return 0
-        }
+		return 0
+	}
 
-        local arg_key arg_value prop_schema
-        for arg_key in $(jq -r '.args | keys_unsorted[]' <<<"${action_json}"); do
-                arg_value=$(jq -c --arg key "${arg_key}" '.args[$key]' <<<"${action_json}")
-                prop_schema=$(jq -c --arg key "${arg_key}" --argjson props "${properties_json}" '$props[$key]' <<<"null")
+	local arg_key arg_value prop_schema
+	for arg_key in $(jq -r '.args | keys_unsorted[]' <<<"${action_json}"); do
+		arg_value=$(jq -c --arg key "${arg_key}" '.args[$key]' <<<"${action_json}")
+		prop_schema=$(jq -c --arg key "${arg_key}" --argjson props "${properties_json}" '$props[$key]' <<<"null")
 
-                if [[ -n "${prop_schema}" && "${prop_schema}" != "null" ]]; then
-                        if ! _react_enforce_arg_type "${arg_key}" "${arg_value}" "${prop_schema}"; then
-                                return 1
-                        fi
-                        continue
-                fi
+		if [[ -n "${prop_schema}" && "${prop_schema}" != "null" ]]; then
+			if ! _react_enforce_arg_type "${arg_key}" "${arg_value}" "${prop_schema}"; then
+				return 1
+			fi
+			continue
+		fi
 
-                if [[ "${additional_properties}" == "false" ]]; then
-                        printf 'Unexpected arg: %s\n' "${arg_key}" >&2
-                        return 1
-                fi
+		if [[ "${additional_properties}" == "false" ]]; then
+			printf 'Unexpected arg: %s\n' "${arg_key}" >&2
+			return 1
+		fi
 
-                if [[ "${additional_properties}" != "false" && "${additional_properties}" != "null" ]]; then
-                        if ! _react_enforce_arg_type "${arg_key}" "${arg_value}" "${additional_properties}"; then
-                                return 1
-                        fi
-                fi
-        done
+		if [[ "${additional_properties}" != "false" && "${additional_properties}" != "null" ]]; then
+			if ! _react_enforce_arg_type "${arg_key}" "${arg_value}" "${additional_properties}"; then
+				return 1
+			fi
+		fi
+	done
 
-        thought_trimmed=$(jq -r '.thought | gsub("^\\s+|\\s+$"; "")' <<<"${action_json}")
+	thought_trimmed=$(jq -r '.thought | gsub("^\\s+|\\s+$"; "")' <<<"${action_json}")
 
-        jq -c --arg thought "${thought_trimmed}" '.thought = $thought' <<<"${action_json}"
+	jq -c --arg thought "${thought_trimmed}" '.thought = $thought' <<<"${action_json}"
 }

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -61,10 +61,10 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 set_by_name() {
-        # Arguments:
-        #   $1 - variable name (string)
-        #   $2 - value (string)
-        printf -v "$1" '%s' "$2"
+	# Arguments:
+	#   $1 - variable name (string)
+	#   $2 - value (string)
+	printf -v "$1" '%s' "$2"
 }
 
 settings_field_mappings() {

--- a/tests/core/planner.sh
+++ b/tests/core/planner.sh
@@ -19,7 +19,7 @@ SCRIPT
 }
 
 @test "normalize_planner_plan rejects unstructured outline text" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/planner.sh
 normalize_planner_plan <<<"1) first step\n- second step"

--- a/tests/core/test_settings.sh
+++ b/tests/core/test_settings.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "create_default_settings seeds derived defaults" {
-        run bash -lc '
+	run bash -lc '
                 set -e
                 source ./src/lib/core/settings.sh
                 create_default_settings compat
@@ -13,17 +13,17 @@
                         "$(jq -r ".react_model_spec" <<<"${doc}")" \
                         "$(jq -r ".use_react_llama" <<<"${doc}")"
         '
-        [ "$status" -eq 0 ]
-        config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-        [ "${lines[0]}" = "${config_dir_expected}" ]
-        [ "${lines[1]}" = "${config_dir_expected}/config.env" ]
-        [ "${lines[2]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
-        [ "${lines[3]}" = "bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf" ]
-        [ "${lines[4]}" = "true" ]
+	[ "$status" -eq 0 ]
+	config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+	[ "${lines[0]}" = "${config_dir_expected}" ]
+	[ "${lines[1]}" = "${config_dir_expected}/config.env" ]
+	[ "${lines[2]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
+	[ "${lines[3]}" = "bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf" ]
+	[ "${lines[4]}" = "true" ]
 }
 
 @test "settings persist across shells using cache" {
-        run bash -lc '
+	run bash -lc '
                 set -e
                 prefix="persist_${RANDOM}"
                 source ./src/lib/core/settings.sh
@@ -33,12 +33,12 @@
                 unset "${cache_var}"
                 printf "%s" "$(settings_get_json_document "${prefix}" | jq -r ".example")"
         '
-        [ "$status" -eq 0 ]
-        [ "$output" = "value" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "value" ]
 }
 
 @test "default overrides merge onto base settings" {
-        run bash -lc '
+	run bash -lc '
                 set -e
                 prefix="override_${RANDOM}"
                 export DEFAULT_MODEL_FILE_BASE="Alt.gguf"
@@ -50,6 +50,6 @@
                         "$(jq -r ".verbosity" <<<"${doc}")" \
                         "$(jq -r ".notes_dir" <<<"${doc}")"
         '
-        [ "$status" -eq 0 ]
-        [ "$output" = "Alt.gguf|5|/tmp/custom_notes" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "Alt.gguf|5|/tmp/custom_notes" ]
 }

--- a/tests/planner/test_planner_init.sh
+++ b/tests/planner/test_planner_init.sh
@@ -10,7 +10,7 @@
 #   - bash 3.2+
 
 @test "planner models remain unset until initialized" {
-        run bash -lc '
+	run bash -lc '
                 set -euo pipefail
                 cd "$(git rev-parse --show-toplevel)" || exit 1
 
@@ -28,5 +28,5 @@
                 [[ "${REACT_MODEL_REPO}" == "${DEFAULT_MODEL_REPO_BASE}" ]]
                 [[ "${REACT_MODEL_FILE}" == "${DEFAULT_MODEL_FILE_BASE}" ]]
         '
-        [ "$status" -eq 0 ]
+	[ "$status" -eq 0 ]
 }

--- a/tests/planning/execution.bats
+++ b/tests/planning/execution.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 
 setup() {
-        unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f chpwd _mise_hook 2>/dev/null || true
 }
 
 @test "should_prompt_for_tool respects approval flags" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/execution.sh
 PLAN_ONLY=true
@@ -19,12 +19,12 @@ else
 fi
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${output}" = "skip" ]
+	[ "$status" -eq 0 ]
+	[ "${output}" = "skip" ]
 }
 
 @test "execute_tool_with_query runs handler and emits structured response" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/execution.sh
 APPROVE_ALL=true
@@ -40,10 +40,10 @@ fake_handler() {
 execute_tool_with_query "example" "do it" "context" '{"foo":1}'
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        payload=$(printf '%s' "${output}")
-        body=$(printf '%s' "${payload}" | jq -r '.output')
-        exit_code=$(printf '%s' "${payload}" | jq -r '.exit_code')
-        [ "${body}" = 'ran:do it:{"foo":1}' ]
-        [ "${exit_code}" -eq 0 ]
+	[ "$status" -eq 0 ]
+	payload=$(printf '%s' "${output}")
+	body=$(printf '%s' "${payload}" | jq -r '.output')
+	exit_code=$(printf '%s' "${payload}" | jq -r '.exit_code')
+	[ "${body}" = 'ran:do it:{"foo":1}' ]
+	[ "${exit_code}" -eq 0 ]
 }

--- a/tests/planning/normalization.bats
+++ b/tests/planning/normalization.bats
@@ -1,25 +1,25 @@
 #!/usr/bin/env bats
 
 setup() {
-        unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f chpwd _mise_hook 2>/dev/null || true
 }
 
 @test "normalize_planner_plan extracts JSON arrays from mixed text output" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/normalization.sh
 raw_plan=$'Here is the plan:\n[{"tool":"terminal","args":{"command":"pwd"},"thought":"check"}]\nThanks!'
 normalize_planner_plan <<<"${raw_plan}" | jq -r '.[0].tool,.[0].args.command,.[0].thought'
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "terminal" ]
-        [ "${lines[1]}" = "pwd" ]
-        [ "${lines[2]}" = "check" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "terminal" ]
+	[ "${lines[1]}" = "pwd" ]
+	[ "${lines[2]}" = "check" ]
 }
 
 @test "append_final_answer_step adds missing summary step without duplication" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/normalization.sh
 without_final=$(append_final_answer_step "[{\"tool\":\"terminal\",\"args\":{},\"thought\":\"list\"}]")
@@ -27,22 +27,22 @@ with_final=$(append_final_answer_step "[{\"tool\":\"final_answer\",\"args\":{},\
 printf "%s\n---\n%s\n" "${without_final}" "${with_final}"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        first_tools=$(printf '%s' "${lines[0]}" | jq -r '.[].tool')
-        [[ "${first_tools}" == *"final_answer" ]]
-        second_tools=$(printf '%s' "${lines[2]}" | jq -r '.[].tool')
-        [ "${second_tools}" = "final_answer" ]
-        second_thought=$(printf '%s' "${lines[2]}" | jq -r '.[0].thought')
-        [ "${second_thought}" = "done" ]
+	[ "$status" -eq 0 ]
+	first_tools=$(printf '%s' "${lines[0]}" | jq -r '.[].tool')
+	[[ "${first_tools}" == *"final_answer" ]]
+	second_tools=$(printf '%s' "${lines[2]}" | jq -r '.[].tool')
+	[ "${second_tools}" = "final_answer" ]
+	second_thought=$(printf '%s' "${lines[2]}" | jq -r '.[0].thought')
+	[ "${second_thought}" = "done" ]
 }
 
 @test "normalize_planner_plan rejects unstructured outline text" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/normalization.sh
 normalize_planner_plan <<<"1) first step\n- second step"
 SCRIPT
 
-        [ "$status" -ne 0 ]
-        [[ "${output}" == *"unable to parse planner output"* ]]
+	[ "$status" -ne 0 ]
+	[[ "${output}" == *"unable to parse planner output"* ]]
 }

--- a/tests/planning/planner.bats
+++ b/tests/planning/planner.bats
@@ -1,26 +1,26 @@
 #!/usr/bin/env bats
 
 setup() {
-        unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f chpwd _mise_hook 2>/dev/null || true
 }
 
 @test "generate_plan_json falls back when llama is unavailable" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/planner.sh
 LLAMA_AVAILABLE=false
 generate_plan_json "tell me a joke"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        thought=$(printf '%s' "${output}" | jq -r '.[0].thought')
-        tool=$(printf '%s' "${output}" | jq -r '.[0].tool')
-        [ "${tool}" = "final_answer" ]
-        [[ "${thought}" == *"Respond directly"* ]]
+	[ "$status" -eq 0 ]
+	thought=$(printf '%s' "${output}" | jq -r '.[0].thought')
+	tool=$(printf '%s' "${output}" | jq -r '.[0].tool')
+	[ "${tool}" = "final_answer" ]
+	[[ "${thought}" == *"Respond directly"* ]]
 }
 
 @test "generate_plan_json appends final step to llama output" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/planner.sh
 LLAMA_AVAILABLE=true
@@ -30,7 +30,7 @@ llama_infer() { printf '[{"tool":"terminal","args":{},"thought":"do"}]'; }
 generate_plan_json "list" | jq -r '.[].tool'
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "terminal" ]
-        [ "${lines[1]}" = "final_answer" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "terminal" ]
+	[ "${lines[1]}" = "final_answer" ]
 }

--- a/tests/planning/prompting.bats
+++ b/tests/planning/prompting.bats
@@ -1,31 +1,31 @@
 #!/usr/bin/env bats
 
 setup() {
-        unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f chpwd _mise_hook 2>/dev/null || true
 }
 
 @test "plan_json_to_outline numbers steps from raw planner text" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/prompting.sh
 raw_plan='[{"tool":"terminal","args":{"command":"ls"},"thought":"list"},{"tool":"final_answer","args":{},"thought":"wrap up"}]'
 plan_json_to_outline "${raw_plan}"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${lines[0]}" = "1. list" ]
-        [ "${lines[1]}" = "2. wrap up" ]
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "1. list" ]
+	[ "${lines[1]}" = "2. wrap up" ]
 }
 
 @test "build_planner_prompt_with_tools injects tool descriptions when provided" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/prompting.sh
 prompt=$(build_planner_prompt_with_tools "find files" terminal notes_create)
 printf '%s' "${prompt}"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [[ "${output}" == *"terminal"* ]]
-        [[ "${output}" == *"notes_create"* ]]
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"terminal"* ]]
+	[[ "${output}" == *"notes_create"* ]]
 }

--- a/tests/planning/react_loop.bats
+++ b/tests/planning/react_loop.bats
@@ -1,11 +1,11 @@
 #!/usr/bin/env bats
 
 setup() {
-        unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f chpwd _mise_hook 2>/dev/null || true
 }
 
 @test "react_loop finalizes after invalid action selection" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=1
 LLAMA_AVAILABLE=false
@@ -23,12 +23,12 @@ react_loop "what time is it" "alpha" "" ""
 printf 'final=%s step=%s' "$(state_get react_state final_answer)" "$(state_get react_state step)"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "$output" = "final=fallback_response step=1" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "final=fallback_response step=1" ]
 }
 
 @test "react_loop records duplicate actions with warning observation" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=2
 LLAMA_AVAILABLE=false
@@ -58,12 +58,12 @@ printf 'first_thought=%s second_thought=%s' \
         "$(printf '%s' "${second_entry}" | jq -r '.thought')"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "$output" = "first_thought=first second_thought=second (REPEATED)" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "first_thought=first second_thought=second (REPEATED)" ]
 }
 
 @test "react_loop clears plan entries after tool failure" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=1
 LLAMA_AVAILABLE=true
@@ -81,12 +81,12 @@ react_loop "question" "alpha" '{"tool":"alpha"}' ""
 printf 'plan_entries=%s' "$(state_get react_state plan_entries)"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "$output" = "plan_entries=" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "plan_entries=" ]
 }
 
 @test "react_loop stops after final_answer" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=3
 LLAMA_AVAILABLE=false
@@ -104,6 +104,6 @@ react_loop "question" "final_answer" "" ""
 printf 'final=%s step=%s' "$(state_get react_state final_answer)" "$(state_get react_state step)"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "$output" = "final=complete step=1" ]
+	[ "$status" -eq 0 ]
+	[ "$output" = "final=complete step=1" ]
 }


### PR DESCRIPTION
## Summary
- clear inherited `chpwd_functions` hooks in the planner module to avoid unintended directory changes
- document the intent and suppress shellcheck warning for the unused defensive assignment

## Testing
- find src scripts tests -type f \( -name '*.sh' -o -name 'okso' \) -print0 | xargs -0 shellcheck


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471ba1b5248325910e75f9cf8f625b)