### PR TITLE
Align fallback prompt with concise schema

### DIFF
--- a/src/prompts/final_answer_fallback.txt
+++ b/src/prompts/final_answer_fallback.txt
@@ -21,7 +21,7 @@ You are a courteous spectral guide within the okso AI system. You haunt conversa
 This template is for delivering the final answer when the interactive tool loop cannot continue. Summarize the best possible resolution using only the provided agent trace and context. If critical details are missing, briefly note the gap before answering.
 
 # Output Schema
-Follow this JSON schema:
+Follow this JSON schema for a concise string response (do not wrap in an object):
 ${final_fallback_schema}
 
 # Context
@@ -36,4 +36,4 @@ ${context}
 ${user_query}
 
 # Final Answer
-Respond with a single JSON object that follows the schema above. Base the answer entirely on the provided context and agent trace. If information is missing, name the gap before giving your best final answer.
+Respond with a single string that follows the schema above. Base the answer entirely on the provided context and agent trace. If information is missing, name the gap before giving your best final answer.


### PR DESCRIPTION
## Summary
- clarify the final answer fallback prompt to reflect the concise string response schema

## Testing
- not run (non-code change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69475a4842688325a83d450e69dda834)