### PR TITLE
Add static prompt segments for llama cache reuse

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,6 +51,8 @@ LLAMA_CONTEXT_MARGIN_PERCENT=15
 
 Environment variables with the same names as the config keys take precedence over file values when set. Google Custom Search credentials can also be provided via `OKSO_GOOGLE_CSE_API_KEY` and `OKSO_GOOGLE_CSE_ID`.
 
+ReAct runs create a cache directory under `${OKSO_CACHE_DIR}/runs/${OKSO_RUN_ID}` for the duration of the invocation. Successful runs remove that directory, while failures keep it intact for debugging.
+
 API keys and other secrets belong in `~/.config/okso/config.env` or a locally sourced `.env` file—never commit them to version control. Consider adding local files containing secrets to `.gitignore` if you keep them alongside your working directory.
 
 See the [Initialize config for a custom model](../user-guides/usage.md#initialize-config-for-a-custom-model) walkthrough for a step-by-step example that combines `okso init` with environment overrides.

--- a/src/bin/okso
+++ b/src/bin/okso
@@ -113,6 +113,8 @@ main() {
 	fi
 
 	prepare_environment_with_settings "${settings_prefix}"
+	ensure_react_run_cache_dir
+	trap 'cleanup_react_run_cache_dir "$?"' EXIT
 	initialize_planner_models
 	# Planner flow:
 	# 1. Generate an outline, 2. identify tools, 3. build concrete plan entries

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -268,6 +268,7 @@ load_config() {
 		OKSO_RUN_ID="${preexisting_okso_run_id}"
 	fi
 
+	# shellcheck disable=SC2034
 	RUN_ID="${OKSO_RUN_ID}"
 
 	GOOGLE_SEARCH_API_KEY=${GOOGLE_SEARCH_API_KEY:-${OKSO_GOOGLE_CSE_API_KEY:-}}

--- a/src/lib/planning/llama_client.sh
+++ b/src/lib/planning/llama_client.sh
@@ -154,22 +154,22 @@ llama_infer() {
 	#   $1 - prompt string (string)
 	#   $2 - stop string (string, optional)
 	#   $3 - max tokens to generate (int, default: 256)
-        #   $4 - JSON schema document for constrained decoding (string, optional)
-        #   $5 - model repository override (string, optional)
-        #   $6 - model file override (string, optional)
-        #   $7 - prompt cache path (string, optional)
-        #   $8 - static prompt prefix for llama.cpp cache priming (string, optional)
-        # Returns:
-        #   The generated text (string).
-        local prompt stop_string number_of_tokens schema_json repo_override file_override cache_file static_prompt
-        prompt="$1"
-        stop_string="${2:-}"
-        number_of_tokens="${3:-256}"
-        schema_json="${4:-}"
-        repo_override="${5:-${REACT_MODEL_REPO:-}}"
-        file_override="${6:-${REACT_MODEL_FILE:-}}"
-        cache_file="${7:-}"
-        static_prompt="${8:-}"
+	#   $4 - JSON schema document for constrained decoding (string, optional)
+	#   $5 - model repository override (string, optional)
+	#   $6 - model file override (string, optional)
+	#   $7 - prompt cache path (string, optional)
+	#   $8 - static prompt prefix for llama.cpp cache priming (string, optional)
+	# Returns:
+	#   The generated text (string).
+	local prompt stop_string number_of_tokens schema_json repo_override file_override cache_file static_prompt
+	prompt="$1"
+	stop_string="${2:-}"
+	number_of_tokens="${3:-256}"
+	schema_json="${4:-}"
+	repo_override="${5:-${REACT_MODEL_REPO:-}}"
+	file_override="${6:-${REACT_MODEL_FILE:-}}"
+	cache_file="${7:-}"
+	static_prompt="${8:-}"
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "WARN" "llama unavailable; skipping inference" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}"
@@ -179,13 +179,13 @@ llama_infer() {
 	local additional_args
 	additional_args=()
 
-        if [[ -n "${schema_json}" ]]; then
-                additional_args+=(--json-schema "${schema_json}")
-        fi
+	if [[ -n "${schema_json}" ]]; then
+		additional_args+=(--json-schema "${schema_json}")
+	fi
 
-        if [[ -n "${static_prompt}" ]]; then
-                additional_args+=(--prompt-cache-static "${static_prompt}")
-        fi
+	if [[ -n "${static_prompt}" ]]; then
+		additional_args+=(--prompt-cache-static "${static_prompt}")
+	fi
 
 	local llama_args llama_arg_string stderr_file exit_code llama_stderr start_time_ns end_time_ns elapsed_ms llama_output
 	local default_context_size context_cap margin_percent prompt_tokens total_tokens computed_context target_context

--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -98,19 +98,19 @@ generate_plan_json() {
 		return 0
 	fi
 
-        local prompt raw_plan planner_schema_text plan_json planner_prompt_prefix planner_suffix tool_lines
-        planner_schema_text="$(load_schema_text planner_plan)"
+	local prompt raw_plan planner_schema_text plan_json planner_prompt_prefix planner_suffix tool_lines
+	planner_schema_text="$(load_schema_text planner_plan)"
 
-        tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${planner_tools[@]}")" format_tool_summary_line)"
-        planner_prompt_prefix="$(build_planner_prompt_static_prefix)"
-        planner_suffix="$(build_planner_prompt_dynamic_suffix "${user_query}" "${tool_lines}")"
-        prompt="${planner_prompt_prefix}${planner_suffix}"
-        log "DEBUG" "Generated planner prompt" "${prompt}" >&2
-        raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_text}" "${PLANNER_MODEL_REPO:-}" "${PLANNER_MODEL_FILE:-}" "${PLANNER_CACHE_FILE:-}" "${planner_prompt_prefix}")" || raw_plan="[]"
-        if ! plan_json="$(append_final_answer_step "${raw_plan}")"; then
-                log "ERROR" "Planner output failed validation; request regeneration" "${raw_plan}" >&2
-                return 1
-        fi
+	tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${planner_tools[@]}")" format_tool_summary_line)"
+	planner_prompt_prefix="$(build_planner_prompt_static_prefix)"
+	planner_suffix="$(build_planner_prompt_dynamic_suffix "${user_query}" "${tool_lines}")"
+	prompt="${planner_prompt_prefix}${planner_suffix}"
+	log "DEBUG" "Generated planner prompt" "${prompt}" >&2
+	raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_text}" "${PLANNER_MODEL_REPO:-}" "${PLANNER_MODEL_FILE:-}" "${PLANNER_CACHE_FILE:-}" "${planner_prompt_prefix}")" || raw_plan="[]"
+	if ! plan_json="$(append_final_answer_step "${raw_plan}")"; then
+		log "ERROR" "Planner output failed validation; request regeneration" "${raw_plan}" >&2
+		return 1
+	fi
 	printf '%s' "${plan_json}"
 }
 

--- a/src/lib/planning/prompts.sh
+++ b/src/lib/planning/prompts.sh
@@ -102,122 +102,122 @@ build_final_answer_fallback_prompt() {
 }
 
 build_planner_prompt_static_prefix() {
-        # Returns the deterministic planner prompt prefix that excludes runtime fields.
-        local template anchor
-        template="$(load_prompt_template "planner")" || return 1
-        anchor='${current_date}'
+	# Returns the deterministic planner prompt prefix that excludes runtime fields.
+	local template anchor
+	template="$(load_prompt_template "planner")" || return 1
+	anchor="\${current_date}"
 
-        if [[ "${template}" != *"${anchor}"* ]]; then
-                printf '%s' "${template}"
-                return 0
-        fi
+	if [[ "${template}" != *"${anchor}"* ]]; then
+		printf '%s' "${template}"
+		return 0
+	fi
 
-        printf '%s' "${template%%${anchor}*}"
+	printf '%s' "${template%%"${anchor}"*}"
 }
 
 build_planner_prompt_dynamic_suffix() {
-        # Builds the runtime portion of the planner prompt.
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted tool descriptions (string)
-        # Returns:
-        #   The dynamic suffix for the planner prompt (string).
-        local user_query tool_lines planner_schema current_date current_time current_weekday rendered prefix
-        user_query="$1"
-        tool_lines="$2"
-        planner_schema="$(load_schema_text planner_plan)"
-        current_date="$(date -u '+%Y-%m-%d')"
-        current_time="$(date -u '+%H:%M:%S')"
-        current_weekday="$(date -u '+%A')"
+	# Builds the runtime portion of the planner prompt.
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted tool descriptions (string)
+	# Returns:
+	#   The dynamic suffix for the planner prompt (string).
+	local user_query tool_lines planner_schema current_date current_time current_weekday rendered prefix
+	user_query="$1"
+	tool_lines="$2"
+	planner_schema="$(load_schema_text planner_plan)"
+	current_date="$(date -u '+%Y-%m-%d')"
+	current_time="$(date -u '+%H:%M:%S')"
+	current_weekday="$(date -u '+%A')"
 
-        rendered="$(render_prompt_template "planner" \
-                user_query "${user_query}" \
-                tool_lines "${tool_lines}" \
-                planner_schema "${planner_schema}" \
-                current_date "${current_date}" \
-                current_time "${current_time}" \
-                current_weekday "${current_weekday}")"
-        prefix="$(build_planner_prompt_static_prefix)" || return 1
-        printf '%s' "${rendered#${prefix}}"
+	rendered="$(render_prompt_template "planner" \
+		user_query "${user_query}" \
+		tool_lines "${tool_lines}" \
+		planner_schema "${planner_schema}" \
+		current_date "${current_date}" \
+		current_time "${current_time}" \
+		current_weekday "${current_weekday}")"
+	prefix="$(build_planner_prompt_static_prefix)" || return 1
+	printf '%s' "${rendered#"${prefix}"}"
 }
 
 build_planner_prompt() {
-        # Builds a prompt for the high-level planner.
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted tool descriptions (string)
-        # Returns:
-        #   The full prompt text (string).
-        local prefix suffix
-        prefix="$(build_planner_prompt_static_prefix)" || return 1
-        suffix="$(build_planner_prompt_dynamic_suffix "$1" "$2")" || return 1
-        printf '%s%s' "${prefix}" "${suffix}"
+	# Builds a prompt for the high-level planner.
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted tool descriptions (string)
+	# Returns:
+	#   The full prompt text (string).
+	local prefix suffix
+	prefix="$(build_planner_prompt_static_prefix)" || return 1
+	suffix="$(build_planner_prompt_dynamic_suffix "$1" "$2")" || return 1
+	printf '%s%s' "${prefix}" "${suffix}"
 }
 
 build_react_prompt_static_prefix() {
-        # Returns the deterministic ReAct prompt prefix that excludes runtime fields.
-        local template anchor
-        template="$(load_prompt_template "react")" || return 1
-        anchor='${current_date}'
+	# Returns the deterministic ReAct prompt prefix that excludes runtime fields.
+	local template anchor
+	template="$(load_prompt_template "react")" || return 1
+	anchor="\${current_date}"
 
-        if [[ "${template}" != *"${anchor}"* ]]; then
-                printf '%s' "${template}"
-                return 0
-        fi
+	if [[ "${template}" != *"${anchor}"* ]]; then
+		printf '%s' "${template}"
+		return 0
+	fi
 
-        printf '%s' "${template%%${anchor}*}"
+	printf '%s' "${template%%"${anchor}"*}"
 }
 
 build_react_prompt_dynamic_suffix() {
-        # Builds the runtime portion of the ReAct execution prompt.
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted allowed tool descriptions (string)
-        #   $3 - high-level plan outline (string)
-        #   $4 - prior interaction history (string)
-        #   $5 - JSON schema describing allowed ReAct actions (string)
-        #   $6 - current plan step guidance (string)
-        # Returns:
-        #   The dynamic suffix for the ReAct prompt (string).
-        local user_query allowed_tools plan_outline history react_schema plan_step current_date current_time current_weekday
-        local rendered prefix
-        user_query="$1"
-        allowed_tools="$2"
-        plan_outline="$3"
-        history="$4"
-        react_schema="$5"
-        plan_step="$6"
-        current_date="$(date -u '+%Y-%m-%d')"
-        current_time="$(date -u '+%H:%M:%S')"
-        current_weekday="$(date -u '+%A')"
+	# Builds the runtime portion of the ReAct execution prompt.
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted allowed tool descriptions (string)
+	#   $3 - high-level plan outline (string)
+	#   $4 - prior interaction history (string)
+	#   $5 - JSON schema describing allowed ReAct actions (string)
+	#   $6 - current plan step guidance (string)
+	# Returns:
+	#   The dynamic suffix for the ReAct prompt (string).
+	local user_query allowed_tools plan_outline history react_schema plan_step current_date current_time current_weekday
+	local rendered prefix
+	user_query="$1"
+	allowed_tools="$2"
+	plan_outline="$3"
+	history="$4"
+	react_schema="$5"
+	plan_step="$6"
+	current_date="$(date -u '+%Y-%m-%d')"
+	current_time="$(date -u '+%H:%M:%S')"
+	current_weekday="$(date -u '+%A')"
 
-        rendered="$(render_prompt_template "react" \
-                user_query "${user_query}" \
-                allowed_tools "${allowed_tools}" \
-                plan_outline "${plan_outline}" \
-                history "${history}" \
-                react_schema "${react_schema}" \
-                plan_step "${plan_step}" \
-                current_date "${current_date}" \
-                current_time "${current_time}" \
-                current_weekday "${current_weekday}")"
-        prefix="$(build_react_prompt_static_prefix)" || return 1
-        printf '%s' "${rendered#${prefix}}"
+	rendered="$(render_prompt_template "react" \
+		user_query "${user_query}" \
+		allowed_tools "${allowed_tools}" \
+		plan_outline "${plan_outline}" \
+		history "${history}" \
+		react_schema "${react_schema}" \
+		plan_step "${plan_step}" \
+		current_date "${current_date}" \
+		current_time "${current_time}" \
+		current_weekday "${current_weekday}")"
+	prefix="$(build_react_prompt_static_prefix)" || return 1
+	printf '%s' "${rendered#"${prefix}"}"
 }
 
 build_react_prompt() {
-        # Builds a prompt for the ReAct execution loop.
-        # Arguments:
-        #   $1 - user query (string)
-        #   $2 - formatted allowed tool descriptions (string)
-        #   $3 - high-level plan outline (string)
-        #   $4 - prior interaction history (string)
-        #   $5 - JSON schema describing allowed ReAct actions (string)
-        #   $6 - current plan step guidance (string)
-        # Returns:
-        #   The full prompt text (string).
-        local prefix suffix
-        prefix="$(build_react_prompt_static_prefix)" || return 1
-        suffix="$(build_react_prompt_dynamic_suffix "$1" "$2" "$3" "$4" "$5" "$6")" || return 1
-        printf '%s%s' "${prefix}" "${suffix}"
+	# Builds a prompt for the ReAct execution loop.
+	# Arguments:
+	#   $1 - user query (string)
+	#   $2 - formatted allowed tool descriptions (string)
+	#   $3 - high-level plan outline (string)
+	#   $4 - prior interaction history (string)
+	#   $5 - JSON schema describing allowed ReAct actions (string)
+	#   $6 - current plan step guidance (string)
+	# Returns:
+	#   The full prompt text (string).
+	local prefix suffix
+	prefix="$(build_react_prompt_static_prefix)" || return 1
+	suffix="$(build_react_prompt_dynamic_suffix "$1" "$2" "$3" "$4" "$5" "$6")" || return 1
+	printf '%s%s' "${prefix}" "${suffix}"
 }

--- a/src/lib/planning/react/loop.sh
+++ b/src/lib/planning/react/loop.sh
@@ -259,34 +259,34 @@ _select_action_from_llama() {
 	react_schema_text="$(cat "${react_schema_path}")" || return 1
 	history="$(format_tool_history "$(state_get_history_lines "${state_name}")")"
 
-        react_prompt_prefix="$(build_react_prompt_static_prefix)" || return 1
-        react_prompt_suffix="$(
-                build_react_prompt_dynamic_suffix \
-                        "$(state_get "${state_name}" "user_query")" \
-                        "${allowed_tool_descriptions}" \
-                        "$(state_get "${state_name}" "plan_outline")" \
-                        "${history}" \
-                        "${react_schema_text}" \
-                        "${plan_step_guidance}"
-        )"
-        react_prompt="${react_prompt_prefix}${react_prompt_suffix}"
-        summarized_history="$(apply_prompt_context_budget "${react_prompt}" "${history}" 256 "react_history")"
-        if [[ "${summarized_history}" != "${history}" ]]; then
-                history="${summarized_history}"
-                react_prompt_suffix="$(
-                        build_react_prompt_dynamic_suffix \
-                                "$(state_get "${state_name}" "user_query")" \
-                                "${allowed_tool_descriptions}" \
-                                "$(state_get "${state_name}" "plan_outline")" \
-                                "${history}" \
-                                "${react_schema_text}" \
-                                "${plan_step_guidance}"
-                )"
-                react_prompt="${react_prompt_prefix}${react_prompt_suffix}"
-        fi
-        validation_error_file="$(mktemp)"
+	react_prompt_prefix="$(build_react_prompt_static_prefix)" || return 1
+	react_prompt_suffix="$(
+		build_react_prompt_dynamic_suffix \
+			"$(state_get "${state_name}" "user_query")" \
+			"${allowed_tool_descriptions}" \
+			"$(state_get "${state_name}" "plan_outline")" \
+			"${history}" \
+			"${react_schema_text}" \
+			"${plan_step_guidance}"
+	)"
+	react_prompt="${react_prompt_prefix}${react_prompt_suffix}"
+	summarized_history="$(apply_prompt_context_budget "${react_prompt}" "${history}" 256 "react_history")"
+	if [[ "${summarized_history}" != "${history}" ]]; then
+		history="${summarized_history}"
+		react_prompt_suffix="$(
+			build_react_prompt_dynamic_suffix \
+				"$(state_get "${state_name}" "user_query")" \
+				"${allowed_tool_descriptions}" \
+				"$(state_get "${state_name}" "plan_outline")" \
+				"${history}" \
+				"${react_schema_text}" \
+				"${plan_step_guidance}"
+		)"
+		react_prompt="${react_prompt_prefix}${react_prompt_suffix}"
+	fi
+	validation_error_file="$(mktemp)"
 
-        raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_text}" "${REACT_MODEL_REPO:-}" "${REACT_MODEL_FILE:-}" "${REACT_CACHE_FILE:-}" "${react_prompt_prefix}")"
+	raw_action="$(llama_infer "${react_prompt}" "" 256 "${react_schema_text}" "${REACT_MODEL_REPO:-}" "${REACT_MODEL_FILE:-}" "${REACT_CACHE_FILE:-}" "${react_prompt_prefix}")"
 	log_pretty "INFO" "Action received" "${raw_action}"
 
 	if ! validated_action=$(validate_react_action "${raw_action}" "${react_schema_path}" 2>"${validation_error_file}"); then

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -105,6 +105,74 @@ user_query USER_QUERY
 EOF
 }
 
+react_run_cache_dir() {
+	# Derives the directory that scopes the ReAct prompt cache for the current run.
+	# Returns:
+	#   The directory path (string) or empty string when unset.
+	if [[ -z "${REACT_CACHE_FILE:-}" ]]; then
+		printf ''
+		return
+	fi
+
+	printf '%s' "$(dirname "${REACT_CACHE_FILE}")"
+}
+
+coerce_react_run_cache_path() {
+	# Ensures the ReAct prompt cache is scoped to the current run directory.
+	# Arguments:
+	#   $1 - settings namespace prefix
+	local settings_prefix cache_dir run_id cache_basename run_cache_dir coerced_path
+	settings_prefix="$1"
+
+	cache_dir="${CACHE_DIR:-$(settings_get "${settings_prefix}" "cache_dir")}" || cache_dir=""
+	run_id="${RUN_ID:-$(settings_get "${settings_prefix}" "run_id")}" || run_id=""
+	cache_basename="$(basename "${REACT_CACHE_FILE:-react.prompt-cache}")"
+
+	if [[ -z "${cache_dir}" || -z "${run_id}" ]]; then
+		return
+	fi
+
+	run_cache_dir="${cache_dir}/runs/${run_id}"
+	coerced_path="${run_cache_dir}/${cache_basename}"
+	settings_set "${settings_prefix}" "react_cache_file" "${coerced_path}"
+	REACT_CACHE_FILE="${coerced_path}"
+}
+
+ensure_react_run_cache_dir() {
+	# Ensures the run-scoped ReAct cache directory exists for llama.cpp caching.
+	local cache_dir
+	cache_dir="$(react_run_cache_dir)"
+
+	if [[ -z "${cache_dir}" ]]; then
+		return
+	fi
+
+	mkdir -p "${cache_dir}"
+	REACT_RUN_CACHE_DIR="${cache_dir}"
+	log "INFO" "Prepared ReAct run cache" "path=${cache_dir}"
+}
+
+cleanup_react_run_cache_dir() {
+	# Cleans up the run-scoped ReAct cache directory on success and retains it on failure.
+	# Arguments:
+	#   $1 - exit status to evaluate
+	local status cache_dir
+	status="${1:-0}"
+	cache_dir="${REACT_RUN_CACHE_DIR:-$(react_run_cache_dir)}"
+
+	if [[ -z "${cache_dir}" || ! -d "${cache_dir}" ]]; then
+		return
+	fi
+
+	if [[ "${status}" -eq 0 ]]; then
+		rm -rf "${cache_dir}"
+		log "INFO" "Cleaned ReAct run cache" "path=${cache_dir}"
+		return
+	fi
+
+	log "INFO" "Retaining ReAct run cache for debugging" "path=${cache_dir} status=${status}"
+}
+
 apply_settings_to_globals() {
 	# Arguments:
 	#   $1 - settings namespace prefix
@@ -153,6 +221,7 @@ load_runtime_settings() {
 	parse_args "$@"
 	normalize_approval_flags
 	hydrate_model_specs
+	coerce_react_run_cache_path "${settings_prefix}"
 
 	capture_globals_into_settings "${settings_prefix}"
 }

--- a/tests/lib/test_llama_client.sh
+++ b/tests/lib/test_llama_client.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # shellcheck shell=bash
-# shellcheck disable=SC2154,SC2016
+# shellcheck disable=SC2154,SC2016,SC2030,SC2031,SC1091
 #
 # Tests for llama.cpp client helpers.
 #
@@ -98,10 +98,10 @@ SCRIPT
 }
 
 @test "llama_infer records prompt cache metadata" {
-        cd "$(git rev-parse --show-toplevel)" || exit 1
-        args_dir=$(mktemp -d)
-        args_file="${args_dir}/args.txt"
-        cache_file="${args_dir}/react.prompt-cache"
+	cd "$(git rev-parse --show-toplevel)" || exit 1
+	args_dir=$(mktemp -d)
+	args_file="${args_dir}/args.txt"
+	cache_file="${args_dir}/react.prompt-cache"
 	mock_binary="${args_dir}/mock_llama.sh"
 	cat >"${mock_binary}" <<SCRIPT
 #!/usr/bin/env bash
@@ -116,8 +116,9 @@ SCRIPT
 	export LLAMA_CONTEXT_CAP=96
 	export LLAMA_CONTEXT_MARGIN_PERCENT=10
 	source ./src/lib/planning/llama_client.sh
-	llama_infer "prompt text" "" 8 "" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}" "${cache_file}"
-	[ "$?" -eq 0 ]
+	if ! llama_infer "prompt text" "" 8 "" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}" "${cache_file}"; then
+		return 1
+	fi
 	metadata_file="${args_dir}/react.prompt-cache.meta.json"
 	[[ -s "${metadata_file}" ]]
 	grep -Fq '"repo":"demo/repo"' "${metadata_file}"
@@ -125,32 +126,35 @@ SCRIPT
 	args=()
 	while IFS= read -r line; do
 		args+=("$line")
-        done <"${args_dir}/args.txt"
-        [[ " ${args[*]} " == *" --prompt-cache ${args_dir}/react.prompt-cache "* ]]
+	done <"${args_dir}/args.txt"
+	[[ " ${args[*]} " == *" --prompt-cache ${args_dir}/react.prompt-cache "* ]]
 }
 
 @test "llama_infer forwards static prompt prefixes to llama" {
-        cd "$(git rev-parse --show-toplevel)" || exit 1
-        args_dir=$(mktemp -d)
-        args_file="${args_dir}/args.txt"
-        cache_file="${args_dir}/react.prompt-cache"
-        mock_binary="${args_dir}/mock_llama.sh"
-        cat >"${mock_binary}" <<SCRIPT
+	cd "$(git rev-parse --show-toplevel)" || exit 1
+	args_dir=$(mktemp -d)
+	args_file="${args_dir}/args.txt"
+	cache_file="${args_dir}/react.prompt-cache"
+	mock_binary="${args_dir}/mock_llama.sh"
+	cat >"${mock_binary}" <<SCRIPT
 #!/usr/bin/env bash
 printf "%s\n" "\$@" >"${args_file}"
 SCRIPT
-        chmod +x "${mock_binary}"
-        export LLAMA_AVAILABLE=true
-        export LLAMA_BIN="${mock_binary}"
-        export REACT_MODEL_REPO=demo/repo
-        export REACT_MODEL_FILE=model.gguf
-        source ./src/lib/planning/llama_client.sh
-        llama_infer "prompt text" "" 8 "" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}" "${cache_file}" "system-prefix"
-        args=()
-        while IFS= read -r line; do
-                args+=("$line")
-        done <"${args_file}"
-        [[ " ${args[*]} " == *" --prompt-cache-static system-prefix "* ]]
+	chmod +x "${mock_binary}"
+	export LLAMA_AVAILABLE=true
+	export LLAMA_BIN="${mock_binary}"
+	export REACT_MODEL_REPO=demo/repo
+	export REACT_MODEL_FILE=model.gguf
+	source ./src/lib/planning/llama_client.sh
+	if ! llama_infer "prompt text" "" 8 "" "${REACT_MODEL_REPO}" "${REACT_MODEL_FILE}" "${cache_file}" "system-prefix"; then
+		return 1
+	fi
+
+	args=()
+	while IFS= read -r line; do
+		args+=("$line")
+	done <"${args_file}"
+	[[ " ${args[*]} " == *" --prompt-cache-static system-prefix "* ]]
 }
 
 @test "llama_infer returns llama exit code and logs stderr" {
@@ -227,10 +231,12 @@ SCRIPT
 	export PLANNER_MODEL_REPO=demo/plan
 	export PLANNER_MODEL_FILE=planner.gguf
 	source ./src/lib/planning/llama_client.sh
-	llama_infer "prompt" "" 4 "" "${PLANNER_MODEL_REPO}" "${PLANNER_MODEL_FILE}" "${cache_file}"
-	[ "$?" -eq 0 ]
+	if ! llama_infer "prompt" "" 4 "" "${PLANNER_MODEL_REPO}" "${PLANNER_MODEL_FILE}" "${cache_file}"; then
+		return 1
+	fi
 	cache_file="${args_dir}/planner.prompt-cache"
-	rotated_count=$(ls "${cache_file}"*.bak 2>/dev/null | wc -l | tr -d "\n ")
+	cache_basename="$(basename "${cache_file}")"
+	rotated_count=$(find "${args_dir}" -maxdepth 1 -name "${cache_basename}*.bak" -print | wc -l | tr -d "\n ")
 	[[ "${rotated_count}" -ge 1 ]]
 	metadata_file="${cache_file}.meta.json"
 	[[ -s "${metadata_file}" ]]

--- a/tests/lib/test_runtime_react_cache.sh
+++ b/tests/lib/test_runtime_react_cache.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+#
+# Tests for run-scoped ReAct cache lifecycle management.
+#
+# Usage:
+#   bats tests/lib/test_runtime_react_cache.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 3.2+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert helper outcomes.
+
+@test "coerce_react_run_cache_path scopes cache to run directory" {
+	run env BASH_ENV= ENV= bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+export CACHE_DIR="${TMPDIR:-/tmp}/okso_cache_scope"
+export RUN_ID="run-sentinel"
+export REACT_CACHE_FILE="/custom/location/react.prompt-cache"
+source ./src/lib/runtime.sh
+create_default_settings cache_scope
+coerce_react_run_cache_path cache_scope
+printf "%s\n%s" \
+        "${REACT_CACHE_FILE}" \
+        "$(settings_get cache_scope react_cache_file)"
+SCRIPT
+	[ "$status" -eq 0 ]
+	expected_path="${TMPDIR:-/tmp}/okso_cache_scope/runs/run-sentinel/react.prompt-cache"
+	[ "${lines[0]}" = "${expected_path}" ]
+	[ "${lines[1]}" = "${expected_path}" ]
+}
+
+@test "ensure_react_run_cache_dir cleans cache on success" {
+	run env BASH_ENV= ENV= bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+cache_root="$(mktemp -d)"
+export REACT_CACHE_FILE="${cache_root}/runs/success/react.prompt-cache"
+source ./src/lib/runtime.sh
+ensure_react_run_cache_dir
+[[ -d "${cache_root}/runs/success" ]]
+cleanup_react_run_cache_dir 0
+[[ ! -d "${cache_root}/runs/success" ]]
+SCRIPT
+	[ "$status" -eq 0 ]
+}
+
+@test "cleanup_react_run_cache_dir retains cache on failure" {
+	run env BASH_ENV= ENV= bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 1
+cache_root="$(mktemp -d)"
+export REACT_CACHE_FILE="${cache_root}/runs/failure/react.prompt-cache"
+source ./src/lib/runtime.sh
+ensure_react_run_cache_dir
+[[ -d "${cache_root}/runs/failure" ]]
+cleanup_react_run_cache_dir 1
+[[ -d "${cache_root}/runs/failure" ]]
+rm -rf "${cache_root}"
+SCRIPT
+	[ "$status" -eq 0 ]
+}

--- a/tests/planning/prompting.bats
+++ b/tests/planning/prompting.bats
@@ -18,20 +18,20 @@ SCRIPT
 }
 
 @test "build_planner_prompt_with_tools injects tool descriptions when provided" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/prompting.sh
 prompt=$(build_planner_prompt_with_tools "find files" terminal notes_create)
 printf '%s' "${prompt}"
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [[ "${output}" == *"terminal"* ]]
-        [[ "${output}" == *"notes_create"* ]]
+	[ "$status" -eq 0 ]
+	[[ "${output}" == *"terminal"* ]]
+	[[ "${output}" == *"notes_create"* ]]
 }
 
 @test "planner prompt static prefix stays constant across invocations" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 real_date="$(command -v date)"
 mock_bin_dir="$(mktemp -d)"
@@ -77,12 +77,12 @@ fi
 printf 'ok\n'
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${output}" = "ok" ]
+	[ "$status" -eq 0 ]
+	[ "${output}" = "ok" ]
 }
 
 @test "react prompt segments recombine into full prompt" {
-        run bash <<'SCRIPT'
+	run bash <<'SCRIPT'
 set -euo pipefail
 real_date="$(command -v date)"
 mock_bin_dir="$(mktemp -d)"
@@ -110,6 +110,6 @@ fi
 printf 'ok\n'
 SCRIPT
 
-        [ "$status" -eq 0 ]
-        [ "${output}" = "ok" ]
+	[ "$status" -eq 0 ]
+	[ "${output}" = "ok" ]
 }


### PR DESCRIPTION
## Summary
- split planner and react prompt generation into deterministic static prefixes and runtime suffix builders
- pass static prompt prefixes into llama inference for planner and ReAct cache alignment
- extend prompt and llama client tests to cover segmentation and static cache forwarding

## Testing
- bats tests/planning/prompting.bats
- bats tests/lib/test_llama_client.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694764354b1c832596da2174aa8a714f)