### PR TITLE
Fix body length reporting after truncation

### DIFF
--- a/src/tools/web/http.sh
+++ b/src/tools/web/http.sh
@@ -139,14 +139,15 @@ web_http_request() {
 		return 1
 	fi
 
-	local body_size truncated truncated_bool
-	body_size=$(wc -c <"${body_file}")
-	truncated=false
-	if ((body_size > max_bytes)); then
-		head -c "${max_bytes}" "${body_file}" >"${body_file}.trimmed"
-		mv "${body_file}.trimmed" "${body_file}"
-		truncated=true
-	fi
+        local body_size truncated truncated_bool
+        body_size=$(wc -c <"${body_file}")
+        truncated=false
+        if ((body_size > max_bytes)); then
+                head -c "${max_bytes}" "${body_file}" >"${body_file}.trimmed"
+                mv "${body_file}.trimmed" "${body_file}"
+                truncated=true
+        fi
+        body_size=$(wc -c <"${body_file}")
 
 	truncated_bool=false
 	if [[ "${truncated}" == "true" ]]; then

--- a/tests/tools/test_web_http.sh
+++ b/tests/tools/test_web_http.sh
@@ -23,7 +23,7 @@ SCRIPT
 }
 
 @test "web_http_request returns metadata for HTTP errors" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 mock_bin="$(mktemp -d)"
 cat >"${mock_bin}/curl" <<'MOCK'
@@ -62,6 +62,56 @@ source ./src/tools/web/http.sh
 web_http_request "https://example.com/error" 1024
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	echo "$output" | jq -e '.status == 500'
+        [ "$status" -eq 0 ]
+        echo "$output" | jq -e '.status == 500'
+}
+
+@test "web_http_request reports truncated byte length" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+mock_bin="$(mktemp -d)"
+cat >"${mock_bin}/curl" <<'MOCK'
+#!/usr/bin/env bash
+output_file=""
+header_file=""
+while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --output)
+                output_file="$2"
+                shift 2
+                ;;
+        --dump-header)
+                header_file="$2"
+                shift 2
+                ;;
+        --write-out)
+                write_out="$2"
+                shift 2
+                ;;
+        *)
+                shift
+                ;;
+        esac
+done
+printf 'HTTP/1.1 200 OK\nContent-Type: text/plain\n\n' >"${header_file}"
+printf 'abcdefghij' >"${output_file}"
+if [[ -n "${write_out:-}" ]]; then
+        printf '200\nhttps://example.com/large\ntext/plain\n10'
+fi
+MOCK
+chmod +x "${mock_bin}/curl"
+export PATH="${mock_bin}:$PATH"
+source ./src/tools/web/http.sh
+response=$(web_http_request "https://example.com/large" 5)
+body_path=$(jq -r '.body_path' <<<"${response}")
+wc -c <"${body_path}"
+echo "${response}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        truncated_bytes=$(echo "$output" | sed -n '1p')
+        response_json=$(echo "$output" | sed -n '2p')
+        [ "$truncated_bytes" -eq 5 ]
+        echo "$response_json" | jq -e '.truncated == true'
+        echo "$response_json" | jq -e '.bytes == 5'
 }


### PR DESCRIPTION
## Summary
- recompute the persisted body size after any truncation in the web HTTP helper
- ensure JSON metadata reflects the trimmed body length when max_bytes is enforced
- add regression coverage for the truncated byte count

## Testing
- bats tests/tools/test_web_http.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694800ad2dbc8325b8c11cba89960f01)