### PR TITLE
Fail calendar create on invalid details

### DIFF
--- a/src/tools/calendar/create.sh
+++ b/src/tools/calendar/create.sh
@@ -20,7 +20,7 @@
 #   - register_tool from tools/registry.sh
 #
 # Exit codes:
-#   Returns non-zero only when registration is misused.
+#   Returns non-zero when input validation fails or registration is misused.
 
 # shellcheck source=../registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/calendar/create.sh}/registry.sh"
@@ -66,9 +66,9 @@ tool_calendar_create() {
 		return 0
 	fi
 
-	if ! { IFS= read -r -d '' title && IFS= read -r -d '' start_time && IFS= read -r -d '' location; } < <(calendar_extract_event_fields "${details}"); then
-		return 0
-	fi
+        if ! { IFS= read -r -d '' title && IFS= read -r -d '' start_time && IFS= read -r -d '' location; } < <(calendar_extract_event_fields "${details}"); then
+                return 1
+        fi
 
 	calendar_script="$(calendar_resolve_calendar_script)"
 

--- a/tests/tools/test_calendar_create.sh
+++ b/tests/tools/test_calendar_create.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+#
+# Focused tests for Apple Calendar create tool helpers.
+#
+# Usage: bats tests/tools/test_calendar_create.sh
+#
+# Dependencies:
+#   - bats
+#   - bash 3.2+
+#
+# Exit codes:
+#   Inherits Bats semantics; individual tests assert script exit codes.
+
+@test "calendar_create fails when details omit start time" {
+        run bash -lc '
+                export CALENDAR_OSASCRIPT_BIN="$(pwd)/tests/fixtures/osascript_stub.sh"
+                export IS_MACOS=true
+                export VERBOSITY=0
+                TOOL_ARGS='"'"'{"input":"Title only"}'"'"'
+                source ./src/tools/calendar/create.sh
+                tool_calendar_create
+        '
+
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"Event title and time are required"* ]]
+}


### PR DESCRIPTION
## Summary
- return a non-zero status when calendar event field extraction fails
- document the calendar create exit behavior and add a regression test for missing start time inputs

## Testing
- bats tests/tools/test_calendar_create.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694800aec38c8325b3345b2576dc4da3)