### PR TITLE
Ensure plan index advances when using fallback actions

### DIFF
--- a/src/lib/planning/react/loop.sh
+++ b/src/lib/planning/react/loop.sh
@@ -324,17 +324,18 @@ select_next_action() {
 		react_fallback_action=""
 	fi
 
-	if ! _select_action_from_llama "${state_name}" react_action_json; then
-		if [[ "${USE_REACT_LLAMA:-false}" == true && "${LLAMA_AVAILABLE}" == true ]]; then
-			return 1
-		fi
-		if [[ -z "${react_fallback_action}" ]]; then
-			return 1
-		fi
-		react_action_json="${react_fallback_action}"
-	else
-		state_set "${state_name}" "plan_index" "$((plan_index + 1))"
-	fi
+        if ! _select_action_from_llama "${state_name}" react_action_json; then
+                if [[ "${USE_REACT_LLAMA:-false}" == true && "${LLAMA_AVAILABLE}" == true ]]; then
+                        return 1
+                fi
+                if [[ -z "${react_fallback_action}" ]]; then
+                        return 1
+                fi
+                react_action_json="${react_fallback_action}"
+                state_set "${state_name}" "plan_index" "$((plan_index + 1))"
+        else
+                state_set "${state_name}" "plan_index" "$((plan_index + 1))"
+        fi
 
 	if [[ -n "${output_name}" ]]; then
 		printf -v "${output_name}" '%s' "${react_action_json}"

--- a/tests/core/planner.sh
+++ b/tests/core/planner.sh
@@ -155,11 +155,16 @@ USE_REACT_LLAMA=false
 LLAMA_AVAILABLE=false
 select_next_action "${state_prefix}" action_json
 printf "%s\n" "${action_json}"
+plan_index="$(state_get "${state_prefix}" "plan_index")"
+if [[ "${plan_index}" -ne 1 ]]; then
+        echo "expected plan index to advance for fallback action"
+        exit 1
+fi
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	action_json=$(printf '%s' "${output}" | tail -n 1)
-	tool=$(printf '%s' "${action_json}" | jq -r '.tool')
+        [ "$status" -eq 0 ]
+        action_json=$(printf '%s' "${output}" | tail -n 1)
+        tool=$(printf '%s' "${action_json}" | jq -r '.tool')
 	command=$(printf '%s' "${action_json}" | jq -r '.args.command')
 	arg0=$(printf '%s' "${action_json}" | jq -r '.args.args[0]')
 	thought=$(printf '%s' "${action_json}" | jq -r '.thought')


### PR DESCRIPTION
## Summary
- advance the plan index when select_next_action falls back to a planned step
- add regression coverage ensuring deterministic fallback progress updates plan index

## Testing
- bats tests/core/planner.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694800afa23483258e9b63fde1e14080)