### PR TITLE
Document relocated ReAct module

### DIFF
--- a/src/lib/planning/README.md
+++ b/src/lib/planning/README.md
@@ -4,3 +4,9 @@ Planner-related helpers reside here, including the planner and responder flows, 
 client glue, schema resolution, and prompt builders. Modules in this package coordinate
 model interactions and planning responses while relying on `../core` for logging/state and
 `../cli` for user-facing output.
+
+The ReAct loop now lives in `../react`. Existing callers that previously sourced
+`planning/react.sh` still work through the compatibility shim in this directory, but new
+entry points should source `../react/react.sh` directly. The planner populates plan
+entries, schema constraints, and llama.cpp client wiring that the ReAct loop consumes to
+execute tool calls and emit final answers.

--- a/src/lib/react/README.md
+++ b/src/lib/react/README.md
@@ -1,0 +1,36 @@
+# ReAct library
+
+This package hosts the ReAct execution loop extracted from the planning helpers. The
+planner populates allowed tools, plan entries, and llama.cpp wiring, then delegates tool
+selection and execution to `react_loop` defined here. Callers that previously sourced
+`planning/react.sh` remain supported via the shim in that directory, but new entry points
+should source `react/react.sh` directly.
+
+## Usage
+
+Source the entry point to load the ReAct helpers and run the loop:
+
+```bash
+source "${PROJECT_ROOT}/src/lib/react/react.sh"
+react_loop "${user_query}" "${allowed_tools}" "${plan_entries}" "${plan_outline}"
+```
+
+- `user_query`: original user request string.
+- `allowed_tools`: newline-delimited tool names passed to schema generation and validation.
+- `plan_entries`: newline-delimited JSON plan rows (optional; planner-provided).
+- `plan_outline`: plain-text planner outline used to guide the loop.
+
+## Dependencies
+
+- bash 3.2+
+- jq
+- python3 (for rich history formatting)
+- llama.cpp binaries and model assets configured via the planner (loaded through
+  `planning/llama_client.sh`)
+
+## Sourcing notes
+
+The library expects to live alongside the planner utilities because it shells out to
+`planning/prompts.sh`, `planning/execution.sh`, and related helpers. When moving or
+vendoring the module, ensure those dependencies are available and update the compatibility
+shim at `src/lib/planning/react.sh` if needed.


### PR DESCRIPTION
## Summary
- clarify planning docs about the ReAct library location and planner handoff
- add a README for the extracted ReAct helpers covering usage, dependencies, and sourcing

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69480859c7508325997a350e24dc02a5)