### PR TITLE
Update ReAct entrypoint resolution

### DIFF
--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -13,6 +13,7 @@
 #   PLANNER_MODEL_FILE (string): model file within the repository for planner inference.
 #   REACT_MODEL_REPO (string): Hugging Face repository name for ReAct inference.
 #   REACT_MODEL_FILE (string): model file within the repository for ReAct inference.
+#   REACT_ENTRYPOINT (string): optional path override for the ReAct entrypoint script.
 #   TOOLS (array): optional array of tool names available to the planner.
 #   PLAN_ONLY, DRY_RUN (bool): control execution and preview behaviour.
 #   APPROVE_ALL, FORCE_CONFIRM (bool): confirmation toggles.
@@ -234,5 +235,12 @@ plan_json_to_entries() {
 	printf '%s' "${plan_json}" | jq -cr '.[]'
 }
 
-# shellcheck source=./react.sh disable=SC1091
-source "${PLANNING_LIB_DIR}/react.sh"
+REACT_ENTRYPOINT=${REACT_ENTRYPOINT:-"${PLANNING_LIB_DIR}/../react/react.sh"}
+
+if [[ ! -f "${REACT_ENTRYPOINT}" ]]; then
+        log "ERROR" "ReAct entrypoint missing" "REACT_ENTRYPOINT=${REACT_ENTRYPOINT}" >&2
+        return 1 2>/dev/null || exit 1
+fi
+
+# shellcheck source=../react/react.sh disable=SC1091
+source "${REACT_ENTRYPOINT}"

--- a/tests/planning/react_loop.bats
+++ b/tests/planning/react_loop.bats
@@ -7,12 +7,22 @@ setup() {
 	chpwd_functions=()
 }
 
+@test "planner fails fast when ReAct entrypoint is missing" {
+        run env -i HOME="$HOME" PATH="$PATH" REACT_ENTRYPOINT="/tmp/missing-react.sh" bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/planning/planner.sh
+SCRIPT
+
+        [ "$status" -ne 0 ]
+        [[ "$output" == *"ReAct entrypoint missing"* ]]
+}
+
 @test "react_loop finalizes after invalid action selection" {
-	run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
+        run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=1
 LLAMA_AVAILABLE=false
-source ./src/lib/planning/react.sh
+source ./src/lib/react/react.sh
 log() { :; }
 log_pretty() { :; }
 emit_boxed_summary() { :; }
@@ -31,11 +41,11 @@ SCRIPT
 }
 
 @test "react_loop records duplicate actions with warning observation" {
-	run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
+        run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=2
 LLAMA_AVAILABLE=false
-source ./src/lib/planning/react.sh
+source ./src/lib/react/react.sh
 log() { :; }
 log_pretty() { :; }
 emit_boxed_summary() { :; }
@@ -66,11 +76,11 @@ SCRIPT
 }
 
 @test "react_loop clears plan entries after tool failure" {
-	run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
+        run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=1
 LLAMA_AVAILABLE=true
-source ./src/lib/planning/react.sh
+source ./src/lib/react/react.sh
 log() { :; }
 log_pretty() { :; }
 emit_boxed_summary() { :; }
@@ -91,11 +101,11 @@ SCRIPT
 }
 
 @test "react_loop stops after final_answer" {
-	run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
+        run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 MAX_STEPS=3
 LLAMA_AVAILABLE=false
-source ./src/lib/planning/react.sh
+source ./src/lib/react/react.sh
 log() { :; }
 log_pretty() { :; }
 emit_boxed_summary() { :; }


### PR DESCRIPTION
## Summary
- point planner sourcing at the relocated ReAct entrypoint with a configurable override and explicit missing-module failure
- update ReAct loop tests to use the new entrypoint and add coverage for the missing entrypoint error path

## Testing
- bats tests/planning/react_loop.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948084906dc8325b0b8557d0e2d78d5)