### PR TITLE
Normalize scalar terminal args handling

### DIFF
--- a/tests/tools/test_terminal.sh
+++ b/tests/tools/test_terminal.sh
@@ -163,10 +163,18 @@
 	[[ "${output}" == *"base64 mode must be encode or decode"* ]]
 }
 
-@test "terminal args require array input" {
-	run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":\"bad\"}"; tool_terminal'
-	[ "$status" -eq 1 ]
-	[[ "${output}" == *"terminal args must supply an array for args"* ]]
+@test "terminal args normalize scalar inputs" {
+        run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":\".\"}"; tool_terminal'
+        [ "$status" -eq 0 ]
+
+        run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"date\",\"args\":\".\"}"; tool_terminal'
+        [ "$status" -eq 0 ]
+}
+
+@test "malformed TOOL_ARGS surface JSON errors" {
+        run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":}"; tool_terminal'
+        [ "$status" -eq 1 ]
+        [[ "${output}" == *"terminal args must be valid JSON"* ]]
 }
 
 @test "open warns on non-macOS hosts" {


### PR DESCRIPTION
## Summary
- allow the terminal tool to normalize scalar or null args to an empty array while still logging malformed JSON
- add regression Bats coverage for scalar args normalization and malformed input handling

## Testing
- bats tests/tools/test_terminal.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694835ab7c7883259d8dc1de3fccefc4)