### PR TITLE
Fix terminal tool nounset handling

### DIFF
--- a/src/tools/terminal/index.sh
+++ b/src/tools/terminal/index.sh
@@ -30,8 +30,8 @@ source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/cli/output.sh"
 source "${BASH_SOURCE[0]%/terminal/index.sh}/registry.sh"
 
 TERMINAL_ALLOWED_COMMANDS=(
-	"status"
-	"pwd"
+        "status"
+        "pwd"
 	"ls"
 	"cd"
 	"cat"
@@ -50,8 +50,11 @@ TERMINAL_ALLOWED_COMMANDS=(
 	"wc"
 	"du"
 	"base64"
-	"date"
+        "date"
 )
+
+TERMINAL_CMD=""       # string command parsed from TOOL_ARGS
+TERMINAL_CMD_ARGS=()   # array command arguments parsed from TOOL_ARGS
 
 TERMINAL_SESSION_ID="${TERMINAL_SESSION_ID:-}" # string session identifier
 TERMINAL_WORKDIR="${TERMINAL_WORKDIR:-}"       # string working directory for the persistent session

--- a/tests/tools/test_terminal.sh
+++ b/tests/tools/test_terminal.sh
@@ -171,6 +171,13 @@
         [ "$status" -eq 0 ]
 }
 
+@test "terminal operates under nounset" {
+        run bash -lc 'set -euo pipefail; source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"status\",\"args\":[]}"; tool_terminal'
+
+        [ "$status" -eq 0 ]
+        [[ "${lines[0]}" == Session:* ]]
+}
+
 @test "malformed TOOL_ARGS surface JSON errors" {
         run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":}"; tool_terminal'
         [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary
- initialize terminal command variables to avoid unbound errors when running under `set -u`
- add regression test covering terminal execution with nounset enabled

## Testing
- bats tests/tools/test_terminal.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484251fd408325a397976a7880d2a0)