### PR TITLE
Harden terminal arg handling

### DIFF
--- a/src/lib/exec/dispatch.sh
+++ b/src/lib/exec/dispatch.sh
@@ -30,6 +30,11 @@ source "${EXEC_LIB_DIR}/../config.sh"
 # shellcheck source=../tools.sh disable=SC1091
 source "${EXEC_LIB_DIR}/../tools.sh"
 
+: "${PLAN_ONLY:=false}"
+: "${DRY_RUN:=false}"
+: "${FORCE_CONFIRM:=false}"
+: "${APPROVE_ALL:=false}"
+
 should_prompt_for_tool() {
 	if [[ "${PLAN_ONLY}" == true || "${DRY_RUN}" == true ]]; then
 		return 1
@@ -120,10 +125,9 @@ execute_tool_with_query() {
 	stdout_file="$(mktemp)"
 	stderr_file="$(mktemp)"
 
-	log "INFO" "Right before tool call" ""
-	TOOL_QUERY="${tool_query}" TOOL_ARGS="${tool_args_json}" ${handler}
-	TOOL_QUERY="${tool_query}" TOOL_ARGS="${tool_args_json}" ${handler} >"${stdout_file}" 2>"${stderr_file}"
-	log "INFO" "Right after tool call" ""
+        log "INFO" "Right before tool call" ""
+        TOOL_QUERY="${tool_query}" TOOL_ARGS="${tool_args_json}" ${handler} >"${stdout_file}" 2>"${stderr_file}"
+        log "INFO" "Right after tool call" ""
 
 	status=$?
 	output="$(cat "${stdout_file}")"

--- a/src/tools/terminal/index.sh
+++ b/src/tools/terminal/index.sh
@@ -30,8 +30,8 @@ source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/cli/output.sh"
 source "${BASH_SOURCE[0]%/terminal/index.sh}/registry.sh"
 
 TERMINAL_ALLOWED_COMMANDS=(
-	"status"
-	"pwd"
+        "status"
+        "pwd"
 	"ls"
 	"cd"
 	"cat"
@@ -50,8 +50,11 @@ TERMINAL_ALLOWED_COMMANDS=(
 	"wc"
 	"du"
 	"base64"
-	"date"
+        "date"
 )
+
+TERMINAL_CMD=""       # string command parsed from TOOL_ARGS
+TERMINAL_CMD_ARGS=()   # array command arguments parsed from TOOL_ARGS
 
 TERMINAL_SESSION_ID="${TERMINAL_SESSION_ID:-}" # string session identifier
 TERMINAL_WORKDIR="${TERMINAL_WORKDIR:-}"       # string working directory for the persistent session
@@ -202,8 +205,11 @@ tool_terminal() {
 	if ! terminal_args_from_json; then
 		return 1
 	fi
-	command="${TERMINAL_CMD}"
-	args=("${TERMINAL_CMD_ARGS[@]}")
+        command="${TERMINAL_CMD}"
+        args=()
+        if [[ ${TERMINAL_CMD_ARGS+set} == set && ${#TERMINAL_CMD_ARGS[@]} -gt 0 ]]; then
+                args=("${TERMINAL_CMD_ARGS[@]}")
+        fi
 
 	if ! terminal_allowed "${command}"; then
 		log "WARN" "Unknown terminal command; showing status" "${command}"

--- a/tests/tools/test_terminal.sh
+++ b/tests/tools/test_terminal.sh
@@ -171,6 +171,13 @@
         [ "$status" -eq 0 ]
 }
 
+@test "terminal operates under nounset" {
+        run bash -lc 'set -euo pipefail; source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"status\",\"args\":[]}"; tool_terminal'
+
+        [ "$status" -eq 0 ]
+        [[ "${lines[0]}" == Session:* ]]
+}
+
 @test "malformed TOOL_ARGS surface JSON errors" {
         run bash -lc 'source ./src/tools/terminal/index.sh; VERBOSITY=0; TOOL_ARGS="{\"command\":\"ls\",\"args\":}"; tool_terminal'
         [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary
- avoid double-invoking tool handlers during dispatch and set safe defaults for execution flags
- harden terminal argument expansion against nounset shells
- add regression coverage for dispatching the terminal tool with normalized args

## Testing
- bats tests/planning/execution.bats
- bats tests/tools/test_terminal.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484251fd408325a397976a7880d2a0)