### PR TITLE
Add python dependency guard and update tools

### DIFF
--- a/src/lib/dependency_guards/dependency_guards.sh
+++ b/src/lib/dependency_guards/dependency_guards.sh
@@ -4,7 +4,7 @@
 # Guard helpers for common platform and dependency requirements.
 #
 # Usage:
-#   source "${BASH_SOURCE[0]%/guards.sh}/guards.sh"
+#   source "${BASH_SOURCE[0]%/dependency_guards.sh}/dependency_guards.sh"
 #
 # Environment variables:
 #   LLAMA_AVAILABLE (bool): indicates whether llama.cpp is available for inference.
@@ -17,10 +17,10 @@
 # Exit codes:
 #   Functions return non-zero when requirements are unmet.
 
-GUARDS_LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+DEPENDENCY_GUARDS_LIB_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=../core/logging.sh disable=SC1091
-source "${GUARDS_LIB_DIR}/../core/logging.sh"
+source "${DEPENDENCY_GUARDS_LIB_DIR}/../core/logging.sh"
 
 require_llama_available() {
         # Ensures llama-backed features only run when llama.cpp is available.
@@ -54,5 +54,28 @@ require_macos_capable_terminal() {
         return 1
 }
 
+require_python3_available() {
+        # Ensures python3 is available before invoking Python-dependent helpers.
+        # Arguments:
+        #   $1 - feature name for logging context (string; optional)
+        local feature python_status
+        feature=${1:-"python3-dependent functionality"}
+        python_status=127
+
+        hash -r 2>/dev/null || true
+
+        if command -v python3 >/dev/null 2>&1; then
+                python3 --version >/dev/null 2>&1
+                python_status=$?
+                if [[ ${python_status} -eq 0 ]]; then
+                        return 0
+                fi
+        fi
+
+        log "ERROR" "python3 is required for ${feature}" "python3 unavailable or failed (exit_status=${python_status})" || true
+        return 1
+}
+
 export -f require_llama_available
 export -f require_macos_capable_terminal
+export -f require_python3_available

--- a/src/lib/planning/normalization.sh
+++ b/src/lib/planning/normalization.sh
@@ -20,16 +20,23 @@ PLANNING_NORMALIZATION_DIR=$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # shellcheck source=../core/logging.sh disable=SC1091
 source "${PLANNING_NORMALIZATION_DIR}/../core/logging.sh"
+# shellcheck source=../dependency_guards/dependency_guards.sh disable=SC1091
+source "${PLANNING_NORMALIZATION_DIR}/../dependency_guards/dependency_guards.sh"
 
 # Normalize noisy planner output into a clean PlannerPlan JSON array of objects.
 # Reads from stdin, writes clean JSON array to stdout.
 normalize_planner_plan() {
-	local raw plan_candidate normalized
+        local raw plan_candidate normalized
 
-	raw="$(cat)"
+        raw="$(cat)"
 
-	plan_candidate=$(
-		RAW_INPUT="${raw}" python3 - <<'PYTHON'
+        if ! require_python3_available "planner output normalization"; then
+                log "ERROR" "normalize_planner_plan: python3 unavailable" "${raw}" >&2
+                return 1
+        fi
+
+        plan_candidate=$(
+                RAW_INPUT="${raw}" python3 - <<'PYTHON'
 import json
 import os
 import re

--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -51,8 +51,8 @@ source "${PLANNING_LIB_DIR}/../prompt/build_planner.sh"
 source "${PLANNING_LIB_DIR}/../schema/schema.sh"
 # shellcheck source=../core/state.sh disable=SC1091
 source "${PLANNING_LIB_DIR}/../core/state.sh"
-# shellcheck source=../guards/guards.sh disable=SC1091
-source "${PLANNING_LIB_DIR}/../guards/guards.sh"
+# shellcheck source=../dependency_guards/dependency_guards.sh disable=SC1091
+source "${PLANNING_LIB_DIR}/../dependency_guards/dependency_guards.sh"
 # shellcheck source=../llm/llama_client.sh disable=SC1091
 source "${PLANNING_LIB_DIR}/../llm/llama_client.sh"
 # shellcheck source=../config.sh disable=SC1091

--- a/src/lib/react/history.sh
+++ b/src/lib/react/history.sh
@@ -26,6 +26,8 @@ source "${REACT_LIB_DIR}/../core/state.sh"
 source "${REACT_LIB_DIR}/../assistant/respond.sh"
 # shellcheck source=../formatting.sh disable=SC1091
 source "${REACT_LIB_DIR}/../formatting.sh"
+# shellcheck source=../dependency_guards/dependency_guards.sh disable=SC1091
+source "${REACT_LIB_DIR}/../dependency_guards/dependency_guards.sh"
 
 initialize_react_state() {
 	# Initializes the ReAct state document with user query, tools, and plan.
@@ -104,12 +106,18 @@ record_tool_execution() {
 	args_json="$4"
 	observation="$5"
 	step_index="$6"
-	if [[ -z "${args_json}" ]]; then
-		args_json="{}"
-	fi
-	args_json="$(jq -cS '.' <<<"${args_json}" 2>/dev/null || printf '{}')"
-	entry=$(
-		python3 - "$step_index" "$thought" "$tool" "$args_json" "$observation" <<'PY'
+        if [[ -z "${args_json}" ]]; then
+                args_json="{}"
+        fi
+        args_json="$(jq -cS '.' <<<"${args_json}" 2>/dev/null || printf '{}')"
+
+        if ! require_python3_available "ReAct history serialization"; then
+                log "ERROR" "Failed to record tool execution; python3 missing" "${tool}" >&2
+                return 1
+        fi
+
+        entry=$(
+                python3 - "$step_index" "$thought" "$tool" "$args_json" "$observation" <<'PY'
 import json
 import sys
 

--- a/src/lib/tools.sh
+++ b/src/lib/tools.sh
@@ -27,6 +27,8 @@ TOOLS_DIR="${TOOLS_SRC_ROOT}/tools"
 source "${TOOLS_LIB_DIR}/core/errors.sh"
 # shellcheck source=./core/logging.sh disable=SC1091
 source "${TOOLS_LIB_DIR}/core/logging.sh"
+# shellcheck source=./dependency_guards/dependency_guards.sh disable=SC1091
+source "${TOOLS_LIB_DIR}/dependency_guards/dependency_guards.sh"
 # shellcheck source=../tools/registry.sh disable=SC1091
 source "${TOOLS_DIR}/registry.sh"
 TOOL_WRITABLE_DIRECTORY_ALLOWLIST=(
@@ -53,15 +55,19 @@ source "${TOOLS_DIR}/feedback/index.sh"
 source "${TOOLS_DIR}/web/index.sh"
 
 tools_normalize_path() {
-	# Returns a normalized absolute path for allowlist checks.
-	# Arguments:
-	#   $1 - path to normalize (string)
-	if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
-		realpath -m "$1"
-		return
-	fi
+        # Returns a normalized absolute path for allowlist checks.
+        # Arguments:
+        #   $1 - path to normalize (string)
+        if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
+                realpath -m "$1"
+                return
+        fi
 
-	python3 - "$1" <<'PY'
+        if ! require_python3_available "path normalization fallback"; then
+                return 1
+        fi
+
+        python3 - "$1" <<'PY'
 import os, sys
 print(os.path.realpath(sys.argv[1]))
 PY

--- a/src/tools/osascript_helpers.sh
+++ b/src/tools/osascript_helpers.sh
@@ -21,8 +21,8 @@
 
 # shellcheck source=../lib/core/logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/osascript_helpers.sh}/lib/core/logging.sh"
-# shellcheck source=../lib/guards/guards.sh disable=SC1091
-source "${BASH_SOURCE[0]%/tools/osascript_helpers.sh}/lib/guards/guards.sh"
+# shellcheck source=../lib/dependency_guards/dependency_guards.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/osascript_helpers.sh}/lib/dependency_guards/dependency_guards.sh"
 
 assert_osascript_available() {
 	# Ensures osascript-based tools only run on macOS with the binary available.

--- a/src/tools/python_repl/index.sh
+++ b/src/tools/python_repl/index.sh
@@ -21,6 +21,8 @@
 
 # shellcheck source=../../lib/core/logging.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/python_repl/index.sh}/lib/core/logging.sh"
+# shellcheck source=../../lib/dependency_guards/dependency_guards.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/python_repl/index.sh}/lib/dependency_guards/dependency_guards.sh"
 # shellcheck source=../registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/python_repl/index.sh}/registry.sh"
 
@@ -128,12 +130,17 @@ python_repl_resolve_query() {
 }
 
 tool_python_repl() {
-	local query sandbox_dir startup_file repl_input status text_key create_status startup_status # strings and status code
-	text_key="$(canonical_text_arg_key)"
+        local query sandbox_dir startup_file repl_input status text_key create_status startup_status # strings and status code
+        text_key="$(canonical_text_arg_key)"
 
-	if ! query=$(python_repl_resolve_query); then
-		return 1
-	fi
+        if ! require_python3_available "python_repl tool"; then
+                log "ERROR" "python_repl requires python3" "TOOL_ARGS=${TOOL_ARGS:-${TOOL_QUERY:-}}" >&2
+                return 1
+        fi
+
+        if ! query=$(python_repl_resolve_query); then
+                return 1
+        fi
 
 	if [[ -z "${query}" ]]; then
 		log "ERROR" "Missing TOOL_ARGS.${text_key}" "${TOOL_ARGS:-${TOOL_QUERY:-}}"

--- a/src/tools/terminal/index.sh
+++ b/src/tools/terminal/index.sh
@@ -26,8 +26,8 @@
 source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/core/logging.sh"
 # shellcheck source=../../lib/cli/output.sh disable=SC1091
 source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/cli/output.sh"
-# shellcheck source=../../lib/guards/guards.sh disable=SC1091
-source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/guards/guards.sh"
+# shellcheck source=../../lib/dependency_guards/dependency_guards.sh disable=SC1091
+source "${BASH_SOURCE[0]%/tools/terminal/index.sh}/lib/dependency_guards/dependency_guards.sh"
 # shellcheck source=../registry.sh disable=SC1091
 source "${BASH_SOURCE[0]%/terminal/index.sh}/registry.sh"
 

--- a/tests/tools/test_path_normalization.sh
+++ b/tests/tools/test_path_normalization.sh
@@ -6,11 +6,14 @@
 #   bats tests/tools/test_path_normalization.sh
 
 @test "tools_normalize_path falls back when realpath lacks -m support" {
-	run bash -lc '
+        run bash --noprofile --norc -c '
                 set -euo pipefail
+
+                unset -f chpwd _mise_hook __zsh_like_cd cd 2>/dev/null || true
 
                 repo_root="$(git rev-parse --show-toplevel)"
                 tmpdir="$(mktemp -d)"
+                base_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
                 cat >"${tmpdir}/realpath" <<"SCRIPT"
 #!/usr/bin/env bash
@@ -26,7 +29,7 @@ print(os.path.realpath("README.md"))
 PY
 )"
 
-                PATH="${tmpdir}:${PATH}" bash -lc "
+                PATH="${tmpdir}:${base_path}" bash --noprofile --norc -c "
                         source \"${repo_root}/src/lib/tools.sh\"
                         cd \"${repo_root}\"
                         tools_normalize_path \"README.md\"
@@ -35,5 +38,40 @@ PY
                 diff -u <(printf "%s\n" "${expected}") "${tmpdir}/actual"
         '
 
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
+}
+
+@test "tools_normalize_path errors when python3 unavailable for fallback" {
+        run bash --noprofile --norc -c '
+                set -euo pipefail
+
+                unset -f chpwd _mise_hook __zsh_like_cd cd 2>/dev/null || true
+
+                repo_root="$(git rev-parse --show-toplevel)"
+                tmpdir="$(mktemp -d)"
+                base_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+                cat >"${tmpdir}/realpath" <<"SCRIPT"
+#!/usr/bin/env bash
+echo "realpath: illegal option -- m" >&2
+exit 1
+SCRIPT
+                chmod +x "${tmpdir}/realpath"
+
+                cat >"${tmpdir}/python3" <<"SCRIPT"
+#!/usr/bin/env bash
+echo "python3 unavailable" >&2
+exit 127
+SCRIPT
+                chmod +x "${tmpdir}/python3"
+
+                PATH="${tmpdir}:${base_path}" bash --noprofile --norc -c "
+                        source \"${repo_root}/src/lib/tools.sh\"
+                        cd \"${repo_root}\"
+                        tools_normalize_path \"README.md\"
+                "
+        '
+
+        [ "$status" -ne 0 ]
+        [[ "${output}" == *"python3 is required for path normalization fallback"* ]]
 }


### PR DESCRIPTION
## Summary
- move the guards library to `dependency_guards` and add a python3 availability guard
- invoke the new guard in python-dependent helpers before using interpreter fallbacks
- expand path normalization tests to cover missing python3 scenarios

## Testing
- bats tests/tools/test_path_normalization.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948988bb4d4832596089bbe65a32cc2)