### PR TITLE
Add quickdraw planner path

### DIFF
--- a/docs/contributor/development.md
+++ b/docs/contributor/development.md
@@ -26,10 +26,10 @@ Artifacts are written to `coverage/`. Set `COVERAGE_THRESHOLD=75` to warn when t
 
 The planner drives execution through a structured outline:
 
-1. `generate_plan_json` prompts the model with the tool catalog to produce a structured plan array that ends with `final_answer`.
-2. `derive_allowed_tools_from_plan` converts the structured plan into the allowed tool list, expanding `react_fallback` to the full catalog.
-3. `plan_json_to_entries` prepares newline-delimited entries for the ReAct loop while preserving the outline.
-4. The ReAct loop executes tools in order and finishes when the `final_answer` tool runs.
+1. `generate_planner_response` prompts the model with the tool catalog to produce either a tool-based plan (array ending with `final_answer`) or a quickdraw payload when no tools are required.
+2. `derive_allowed_tools_from_plan` converts the structured plan into the allowed tool list, expanding `react_fallback` to the full catalog; quickdraw responses emit no tools.
+3. `plan_json_to_entries` prepares newline-delimited entries for the ReAct loop while preserving the outline for tool-based plans.
+4. Quickdraw responses return the final answer directly; otherwise, the ReAct loop executes tools in order and finishes when the `final_answer` tool runs.
 
 ### Dependencies
 

--- a/src/bin/okso
+++ b/src/bin/okso
@@ -99,7 +99,7 @@ source "${LIB_DIR}/runtime.sh"
 
 main() {
 	local settings_prefix
-	local plan_outline required_tools plan_entries plan_action plan_json
+        local plan_outline required_tools plan_entries plan_action plan_response
 
 	settings_prefix="settings"
 
@@ -120,18 +120,18 @@ main() {
 	# 1. Generate an outline, 2. identify tools, 3. build concrete plan entries
 	# for execution, then 4. render plan outputs before proceeding.
 	log "INFO" "Starting plan generation" "$(settings_get "${settings_prefix}" "user_query")"
-	plan_json="$(generate_plan_json "$(settings_get "${settings_prefix}" "user_query")")"
-	plan_outline="$(plan_json_to_outline "${plan_json}")"
-	required_tools="$(derive_allowed_tools_from_plan "${plan_json}")"
-	log "INFO" "Planner identified tools" "${required_tools}"
-	plan_entries="$(plan_json_to_entries "${plan_json}")"
+        plan_response="$(generate_planner_response "$(settings_get "${settings_prefix}" "user_query")")"
+        plan_outline="$(plan_json_to_outline "${plan_response}")"
+        required_tools="$(derive_allowed_tools_from_plan "${plan_response}")"
+        log "INFO" "Planner identified tools" "${required_tools}"
+        plan_entries="$(plan_json_to_entries "${plan_response}")"
 
-	render_plan_outputs plan_action "${settings_prefix}" "${required_tools}" "${plan_entries}" "${plan_outline}"
-	if [[ "${plan_action}" == "exit" ]]; then
-		return 0
-	fi
+        render_plan_outputs plan_action "${settings_prefix}" "${required_tools}" "${plan_entries}" "${plan_outline}" "${plan_response}"
+        if [[ "${plan_action}" == "exit" ]]; then
+                return 0
+        fi
 
-	select_response_strategy "${settings_prefix}" "${required_tools}" "${plan_entries}" "${plan_outline}"
+        select_response_strategy "${settings_prefix}" "${required_tools}" "${plan_entries}" "${plan_outline}" "${plan_response}"
 }
 
 main "$@"

--- a/src/lib/planning/normalization.sh
+++ b/src/lib/planning/normalization.sh
@@ -26,17 +26,16 @@ source "${PLANNING_NORMALIZATION_DIR}/../dependency_guards/dependency_guards.sh"
 # Normalize noisy planner output into a clean PlannerPlan JSON array of objects.
 # Reads from stdin, writes clean JSON array to stdout.
 normalize_planner_plan() {
-	local raw plan_candidate normalized
+        local raw plan_candidate normalized
 
-	raw="$(cat)"
+        raw="$(cat)"
 
-	if ! require_python3_available "planner output normalization"; then
-		log "ERROR" "normalize_planner_plan: python3 unavailable" "${raw}" >&2
-		return 1
-	fi
+        if ! require_python3_available "planner output normalization"; then
+                log "ERROR" "normalize_planner_plan: python3 unavailable" "${raw}" >&2
+                return 1
+        fi
 
-	plan_candidate=$(
-		RAW_INPUT="${raw}" python3 - <<'PYTHON'
+        plan_candidate=$(RAW_INPUT="${raw}" python3 - <<'PYTHON'
 import json
 import os
 import re
@@ -66,10 +65,10 @@ json.dump(candidate, sys.stdout)
 
 PYTHON
 
-	) || plan_candidate=""
+        ) || plan_candidate=""
 
-	if [[ -n "${plan_candidate:-}" ]]; then
-		normalized=$(jq -ec '
+        if [[ -n "${plan_candidate:-}" ]]; then
+                normalized=$(jq -ec '
                         def valid_step:
                                 (.tool | type == "string")
                                 and (.tool | length) > 0
@@ -84,14 +83,93 @@ PYTHON
                                 map({tool: .tool, args: (.args // {}), thought: (.thought // "")})
                         end
                         ' <<<"${plan_candidate}" 2>/dev/null || true)
-		if [[ -n "${normalized}" && "${normalized}" != "[]" ]]; then
-			printf '%s' "${normalized}"
-			return 0
-		fi
-	fi
+                if [[ -n "${normalized}" && "${normalized}" != "[]" ]]; then
+                        printf '%s' "${normalized}"
+                        return 0
+                fi
+        fi
 
-	log "ERROR" "normalize_planner_plan: unable to parse planner output" "${raw}" >&2
-	return 1
+        log "ERROR" "normalize_planner_plan: unable to parse planner output" "${raw}" >&2
+        return 1
+}
+
+normalize_planner_response() {
+        local raw candidate normalized
+        raw="$(cat)"
+
+        if ! require_python3_available "planner output normalization"; then
+                log "ERROR" "normalize_planner_response: python3 unavailable" "${raw}" >&2
+                return 1
+        fi
+
+        candidate=$(RAW_INPUT="${raw}" python3 - <<'PYTHON'
+import json
+import os
+import re
+import sys
+
+raw_input = os.environ.get("RAW_INPUT", "")
+
+
+def try_parse(text: str):
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return None
+
+
+candidate = try_parse(raw_input)
+if candidate is None:
+    match = re.search(r"\{[\s\S]*?\}|\[[\s\S]*?\]", raw_input)
+    if match:
+        candidate = try_parse(match.group(0))
+
+if candidate is None:
+    sys.exit(1)
+
+json.dump(candidate, sys.stdout)
+
+PYTHON
+
+        ) || candidate=""
+
+        if [[ -z "${candidate:-}" ]]; then
+                log "ERROR" "normalize_planner_response: unable to parse planner output" "${raw}" >&2
+                return 1
+        fi
+
+        normalized=$(jq -ec '
+                def clamp_confidence:
+                        if . == null then null
+                        elif . < 0 then 0
+                        elif . > 1 then 1
+                        else . end;
+
+                def normalize_plan($plan):
+                        ($plan | tostring | fromjson) as $raw_plan
+                        | ($raw_plan | tostring | fromjson) // $raw_plan;
+
+                if type == "array" then
+                        {mode: "plan", plan: (normalize_plan(.) | . + [{tool:"final_answer",thought:"Summarize the result for the user.",args:{}}]), quickdraw: null}
+                elif (type == "object") and (.mode // "") == "quickdraw" then
+                        {mode: "quickdraw", plan: [], quickdraw: {
+                                final_answer: (.final_answer // .quickdraw.final_answer // ""),
+                                rationale: (.rationale // .quickdraw.rationale // ""),
+                                confidence: ((.confidence // .quickdraw.confidence // null) | clamp_confidence)
+                        }} | select(.quickdraw.final_answer != "" and .quickdraw.rationale != "")
+                elif (type == "object") and (.mode // "") == "plan" then
+                        {mode: "plan", plan: (normalize_plan(.plan) | . + [{tool:"final_answer",thought:"Summarize the result for the user.",args:{}}]), quickdraw: null}
+                else
+                        error("unrecognized planner response shape")
+                end
+                ' <<<"${candidate}" 2>/dev/null || true)
+
+        if [[ -z "${normalized}" ]]; then
+                log "ERROR" "normalize_planner_response: unable to parse planner output" "${raw}" >&2
+                return 1
+        fi
+
+        printf '%s' "${normalized}"
 }
 
 append_final_answer_step() {
@@ -114,4 +192,5 @@ append_final_answer_step() {
 }
 
 export -f normalize_planner_plan
+export -f normalize_planner_response
 export -f append_final_answer_step

--- a/src/lib/planning/planner.sh
+++ b/src/lib/planning/planner.sh
@@ -77,53 +77,72 @@ lowercase() {
 	printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
 
-generate_plan_json() {
-	# Arguments:
-	#   $1 - user query (string)
-	local user_query
-	local -a planner_tools=()
-	user_query="$1"
+generate_planner_response() {
+        # Arguments:
+        #   $1 - user query (string)
+        local user_query
+        local -a planner_tools=()
+        user_query="$1"
 
-	if ! require_llama_available "planner generation"; then
-		log "ERROR" "Planner cannot generate steps without llama.cpp" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}" >&2
-		return 1
-	fi
+        if ! require_llama_available "planner generation"; then
+                log "ERROR" "Planner cannot generate steps without llama.cpp" "LLAMA_AVAILABLE=${LLAMA_AVAILABLE}" >&2
+                local fallback
+                fallback="LLM unavailable. Request received: ${user_query}"
+                jq -nc \
+                        --arg answer "${fallback}" \
+                        --arg rationale "Respond directly; tools skipped because llama.cpp is unavailable." \
+                        '{mode:"quickdraw", plan: [], quickdraw:{final_answer:$answer, confidence:0, rationale:$rationale}}'
+                return 0
+        fi
 
-	local tools_decl
-	if tools_decl=$(declare -p TOOLS 2>/dev/null) && grep -q 'declare -a' <<<"${tools_decl}"; then
-		planner_tools=("${TOOLS[@]}")
-	else
-		planner_tools=()
-		while IFS= read -r tool_name; do
-			[[ -z "${tool_name}" ]] && continue
-			planner_tools+=("${tool_name}")
-		done < <(tool_names)
-	fi
+        local tools_decl
+        if tools_decl=$(declare -p TOOLS 2>/dev/null) && grep -q 'declare -a' <<<"${tools_decl}"; then
+                planner_tools=("${TOOLS[@]}")
+        else
+                planner_tools=()
+                while IFS= read -r tool_name; do
+                        [[ -z "${tool_name}" ]] && continue
+                        planner_tools+=("${tool_name}")
+                done < <(tool_names)
+        fi
 
-	local prompt raw_plan planner_schema_text plan_json planner_prompt_prefix planner_suffix tool_lines
-	planner_schema_text="$(load_schema_text planner_plan)"
+        local prompt raw_plan planner_schema_text planner_prompt_prefix planner_suffix tool_lines
+        planner_schema_text="$(load_schema_text planner_plan)"
 
-	tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${planner_tools[@]}")" format_tool_summary_line)"
-	planner_prompt_prefix="$(build_planner_prompt_static_prefix)"
-	planner_suffix="$(build_planner_prompt_dynamic_suffix "${user_query}" "${tool_lines}")"
-	prompt="${planner_prompt_prefix}${planner_suffix}"
-	log "DEBUG" "Generated planner prompt" "${prompt}" >&2
-	raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_text}" "${PLANNER_MODEL_REPO:-}" "${PLANNER_MODEL_FILE:-}" "${PLANNER_CACHE_FILE:-}" "${planner_prompt_prefix}")" || raw_plan="[]"
-	if ! plan_json="$(append_final_answer_step "${raw_plan}")"; then
-		log "ERROR" "Planner output failed validation; request regeneration" "${raw_plan}" >&2
-		return 1
-	fi
-	printf '%s' "${plan_json}"
+        tool_lines="$(format_tool_descriptions "$(printf '%s\n' "${planner_tools[@]}")" format_tool_summary_line)"
+        planner_prompt_prefix="$(build_planner_prompt_static_prefix)"
+        planner_suffix="$(build_planner_prompt_dynamic_suffix "${user_query}" "${tool_lines}")"
+        prompt="${planner_prompt_prefix}${planner_suffix}"
+        log "DEBUG" "Generated planner prompt" "${prompt}" >&2
+        raw_plan="$(llama_infer "${prompt}" '' 512 "${planner_schema_text}" "${PLANNER_MODEL_REPO:-}" "${PLANNER_MODEL_FILE:-}" "${PLANNER_CACHE_FILE:-}" "${planner_prompt_prefix}")" || raw_plan="[]"
+        if ! normalize_planner_response <<<"${raw_plan}"; then
+                log "ERROR" "Planner output failed validation; request regeneration" "${raw_plan}" >&2
+                return 1
+        fi
 }
 
 generate_plan_outline() {
-	# Arguments:
-	#   $1 - user query (string)
-	local plan_json
-	if ! plan_json="$(generate_plan_json "$1")"; then
-		return 1
-	fi
-	plan_json_to_outline "${plan_json}"
+        # Arguments:
+        #   $1 - user query (string)
+        local response_json
+        if ! response_json="$(generate_planner_response "$1")"; then
+                return 1
+        fi
+        plan_json_to_outline "${response_json}"
+}
+
+# Backwards compatibility wrapper; prefer generate_planner_response for new callers.
+generate_plan_json() {
+        local response_json
+        if ! response_json="$(generate_planner_response "$1")"; then
+                return 1
+        fi
+
+        if jq -e '.mode == "plan"' <<<"${response_json}" >/dev/null 2>&1; then
+                jq -c '.plan' <<<"${response_json}"
+        else
+                jq -c '.' <<<"${response_json}"
+        fi
 }
 
 tool_query_deriver() {
@@ -193,49 +212,63 @@ emit_plan_json() {
 }
 
 derive_allowed_tools_from_plan() {
-	# Arguments:
-	#   $1 - plan JSON array (string)
-	local plan_json tool seen
-	plan_json="${1:-[]}"
+        # Arguments:
+        #   $1 - planner response JSON (object or legacy plan array)
+        local plan_json tool seen
+        plan_json="${1:-[]}"
 
-	seen=""
-	local -a required=()
-	local plan_contains_fallback=false
-	if jq -e '.[] | select(.tool == "react_fallback")' <<<"${plan_json}" >/dev/null 2>&1; then
-		plan_contains_fallback=true
-	fi
+        if jq -e '.mode == "quickdraw"' <<<"${plan_json}" >/dev/null 2>&1; then
+                return 0
+        fi
 
-	if [[ "${plan_contains_fallback}" == true ]]; then
-		while IFS= read -r tool; do
-			[[ -z "${tool}" ]] && continue
-			if grep -Fxq "${tool}" <<<"${seen}"; then
-				continue
-			fi
-			required+=("${tool}")
-			seen+="${tool}"$'\n'
-		done < <(tool_names)
-	else
-		while IFS= read -r tool; do
-			[[ -z "${tool}" ]] && continue
-			if grep -Fxq "${tool}" <<<"${seen}"; then
-				continue
-			fi
-			required+=("${tool}")
-			seen+="${tool}"$'\n'
-		done < <(jq -r '.[] | .tool // empty' <<<"${plan_json}" 2>/dev/null || true)
-	fi
+        if jq -e '.mode == "plan" and (.plan | type == "array")' <<<"${plan_json}" >/dev/null 2>&1; then
+                plan_json="$(jq -c '.plan' <<<"${plan_json}")"
+        fi
 
-	if ! grep -Fxq "final_answer" <<<"${seen}"; then
-		required+=("final_answer")
-	fi
+        seen=""
+        local -a required=()
+        local plan_contains_fallback=false
+        if jq -e '.[] | select(.tool == "react_fallback")' <<<"${plan_json}" >/dev/null 2>&1; then
+                plan_contains_fallback=true
+        fi
 
-	printf '%s\n' "${required[@]}"
+        if [[ "${plan_contains_fallback}" == true ]]; then
+                while IFS= read -r tool; do
+                        [[ -z "${tool}" ]] && continue
+                        if grep -Fxq "${tool}" <<<"${seen}"; then
+                                continue
+                        fi
+                        required+=("${tool}")
+                        seen+="${tool}"$'\n'
+                done < <(tool_names)
+        else
+                while IFS= read -r tool; do
+                        [[ -z "${tool}" ]] && continue
+                        if grep -Fxq "${tool}" <<<"${seen}"; then
+                                continue
+                        fi
+                        required+=("${tool}")
+                        seen+="${tool}"$'\n'
+                done < <(jq -r '.[] | .tool // empty' <<<"${plan_json}" 2>/dev/null || true)
+        fi
+
+        if ! grep -Fxq "final_answer" <<<"${seen}"; then
+                required+=("final_answer")
+        fi
+
+        printf '%s\n' "${required[@]}"
 }
 
 plan_json_to_entries() {
-	local plan_json
-	plan_json="$1"
-	printf '%s' "${plan_json}" | jq -cr '.[]'
+        local plan_json
+        plan_json="$1"
+        if jq -e '.mode == "quickdraw"' <<<"${plan_json}" >/dev/null 2>&1; then
+                return 0
+        fi
+        if jq -e '.mode == "plan" and (.plan | type == "array")' <<<"${plan_json}" >/dev/null 2>&1; then
+                plan_json="$(jq -c '.plan' <<<"${plan_json}")"
+        fi
+        printf '%s' "${plan_json}" | jq -cr '.[]'
 }
 
 REACT_ENTRYPOINT=${REACT_ENTRYPOINT:-"${PLANNING_LIB_DIR}/../react/react.sh"}

--- a/src/lib/planning/prompting.sh
+++ b/src/lib/planning/prompting.sh
@@ -48,23 +48,30 @@ build_planner_prompt_with_tools() {
 }
 
 plan_json_to_outline() {
-	# Converts a JSON array of plan steps into a numbered outline string.
-	# Arguments:
-	#   $1 - plan JSON array (string)
-	local plan_json plan_clean
-	plan_json="${1:-[]}"
+        # Converts a planner response into a human-readable outline string.
+        # Arguments:
+        #   $1 - planner response JSON (object or legacy plan array)
+        local plan_json plan_clean
+        plan_json="${1:-[]}"
 
-	if jq -e 'type == "array"' <<<"${plan_json}" >/dev/null 2>&1; then
-		plan_clean="${plan_json}"
-	else
-		plan_clean="$(printf '%s' "$plan_json" | normalize_planner_plan)" || return 1
-	fi
+        if jq -e '.mode == "quickdraw"' <<<"${plan_json}" >/dev/null 2>&1; then
+                jq -r '"Quickdraw (confidence: " + ((.quickdraw.confidence // "n/a")|tostring) + ") - " + (.quickdraw.rationale // "")' <<<"${plan_json}" 2>/dev/null || return 1
+                return 0
+        fi
 
-	if [[ -z "${plan_clean}" ]]; then
-		return 1
-	fi
+        if jq -e '.mode == "plan" and (.plan | type == "array")' <<<"${plan_json}" >/dev/null 2>&1; then
+                plan_clean="$(jq -c '.plan' <<<"${plan_json}")"
+        elif jq -e 'type == "array"' <<<"${plan_json}" >/dev/null 2>&1; then
+                plan_clean="${plan_json}"
+        else
+                plan_clean="$(printf '%s' "$plan_json" | normalize_planner_plan)" || return 1
+        fi
 
-	jq -r 'to_entries | map("\(.key + 1). " + (if (.value.thought // "") != "" then (.value.thought // "") else "Use " + (.value.tool // "unknown") end)) | join("\n")' <<<"${plan_clean}"
+        if [[ -z "${plan_clean}" ]]; then
+                return 1
+        fi
+
+        jq -r 'to_entries | map("\(.key + 1). " + (if (.value.thought // "") != "" then (.value.thought // "") else "Use " + (.value.tool // "unknown") end)) | join("\n")' <<<"${plan_clean}"
 }
 
 export -f plan_json_to_outline

--- a/src/lib/runtime.sh
+++ b/src/lib/runtime.sh
@@ -242,25 +242,31 @@ prepare_environment_with_settings() {
 }
 # shellcheck disable=SC2034
 render_plan_outputs() {
-	# Arguments:
-	#   $1 - name of variable to receive action ("continue" or "exit")
-	#   $2 - settings namespace prefix
-	#   $3 - required tools list (newline delimited)
-	#   $4 - plan entries string
-	#   $5 - plan outline text
-	local action_var settings_prefix
-	action_var="$1"
-	settings_prefix="$2"
-	local required_tools plan_entries plan_outline
-	required_tools="$3"
-	plan_entries="$4"
-	plan_outline="$5"
+        # Arguments:
+        #   $1 - name of variable to receive action ("continue" or "exit")
+        #   $2 - settings namespace prefix
+        #   $3 - required tools list (newline delimited)
+        #   $4 - plan entries string
+        #   $5 - plan outline text
+        #   $6 - planner response JSON
+        local action_var settings_prefix
+        action_var="$1"
+        settings_prefix="$2"
+        local required_tools plan_entries plan_outline plan_response
+        required_tools="$3"
+        plan_entries="$4"
+        plan_outline="$5"
+        plan_response="$6"
 
 	set_by_name "${action_var}" "continue"
 
-	local plan_json tool_list_json
-	plan_json="$(emit_plan_json "${plan_entries}")"
-	tool_list_json="$(printf '%s' "${required_tools}" | jq -Rsc 'split("\n") | map(select(length>0))')"
+        local plan_json tool_list_json
+        if [[ -n "${plan_response}" ]]; then
+                plan_json="${plan_response}"
+        else
+                plan_json="$(emit_plan_json "${plan_entries}")"
+        fi
+        tool_list_json="$(printf '%s' "${required_tools}" | jq -Rsc 'split("\n") | map(select(length>0))')"
 
 	if [[ -z "${required_tools}" ]]; then
 		log "INFO" "Suggested tools" "none"
@@ -268,17 +274,21 @@ render_plan_outputs() {
 		log_pretty "INFO" "Suggested tools" "${tool_list_json}"
 	fi
 
-	if [[ -n "${plan_outline}" ]]; then
-		log_pretty "INFO" "Plan outline" "${plan_outline}"
-	fi
+        if [[ -n "${plan_outline}" ]]; then
+                log_pretty "INFO" "Plan outline" "${plan_outline}"
+        fi
+
+        if jq -e '.mode == "quickdraw"' <<<"${plan_json}" >/dev/null 2>&1; then
+                log_pretty "INFO" "Quickdraw summary" "${plan_json}"
+        fi
 
 	if [[ "$(settings_get "${settings_prefix}" "plan_only")" == true ]]; then
 		# plan-only short-circuits execution and dry-run emission; callers handle
 		# the resulting action_ref to exit early.
-		log_pretty "INFO" "Plan JSON" "${plan_json}"
-		set_by_name "${action_var}" "exit"
-		return 0
-	fi
+                log_pretty "INFO" "Plan JSON" "${plan_json}"
+                set_by_name "${action_var}" "exit"
+                return 0
+        fi
 
 	if [[ "$(settings_get "${settings_prefix}" "dry_run")" == true ]]; then
 		# Dry run prints the intended commands for operator inspection while still
@@ -297,32 +307,48 @@ render_plan_outputs() {
 }
 
 select_response_strategy() {
-	# Arguments:
-	#   $1 - settings namespace prefix
-	#   $2 - required tools string
-	#   $3 - plan entries string
-	#   $4 - plan outline text
-	local settings_prefix
-	settings_prefix="$1"
-	shift
-	local required_tools plan_entries plan_outline direct_response
-	required_tools="$1"
-	plan_entries="$2"
-	plan_outline="$3"
+        # Arguments:
+        #   $1 - settings namespace prefix
+        #   $2 - required tools string
+        #   $3 - plan entries string
+        #   $4 - plan outline text
+        #   $5 - planner response JSON
+        local settings_prefix
+        settings_prefix="$1"
+        shift
+        local required_tools plan_entries plan_outline plan_response direct_response
+        required_tools="$1"
+        plan_entries="$2"
+        plan_outline="$3"
+        plan_response="$4"
 
 	apply_settings_to_globals "${settings_prefix}"
 
-	if [[ -z "${required_tools}" ]]; then
-		# The planner may occasionally decline tools; fall back to direct text
-		# responses so the user still receives output.
-		log "ERROR" "No tools selected; responding directly" "${USER_QUERY}"
-		log "INFO" "Planner emitted no tools; using direct response" "${USER_QUERY}"
-		direct_response="$(respond_text "${USER_QUERY}" 256)"
-		log_pretty "INFO" "Final answer" "${direct_response}"
-		log "INFO" "Execution summary" "No tool runs"
-		emit_boxed_summary "${USER_QUERY}" "${plan_outline}" "" "${direct_response}"
-		return 0
-	fi
+        if jq -e '.mode == "quickdraw"' <<<"${plan_response}" >/dev/null 2>&1; then
+                local quickdraw_answer quickdraw_rationale quickdraw_confidence
+                quickdraw_answer="$(jq -r '.quickdraw.final_answer // ""' <<<"${plan_response}" 2>/dev/null || printf '')"
+                quickdraw_rationale="$(jq -r '.quickdraw.rationale // ""' <<<"${plan_response}" 2>/dev/null || printf '')"
+                quickdraw_confidence="$(jq -r '.quickdraw.confidence // "n/a"' <<<"${plan_response}" 2>/dev/null || printf '')"
 
-	react_loop "${USER_QUERY}" "${required_tools}" "${plan_entries}" "${plan_outline}"
+                log "INFO" "Planner quickdraw selected" "$(printf 'confidence=%s' "${quickdraw_confidence}")"
+                if [[ -n "${quickdraw_answer}" ]]; then
+                        user_output_line "${quickdraw_answer}"
+                fi
+                emit_boxed_summary "${USER_QUERY}" "${plan_outline}" "" "${quickdraw_answer}"
+                return 0
+        fi
+
+        if [[ -z "${required_tools}" ]]; then
+                # The planner may occasionally decline tools; fall back to direct text
+                # responses so the user still receives output.
+                log "ERROR" "No tools selected; responding directly" "${USER_QUERY}"
+                log "INFO" "Planner emitted no tools; using direct response" "${USER_QUERY}"
+                direct_response="$(respond_text "${USER_QUERY}" 256)"
+                log_pretty "INFO" "Final answer" "${direct_response}"
+                log "INFO" "Execution summary" "No tool runs"
+                emit_boxed_summary "${USER_QUERY}" "${plan_outline}" "" "${direct_response}"
+                return 0
+        fi
+
+        react_loop "${USER_QUERY}" "${required_tools}" "${plan_entries}" "${plan_outline}"
 }

--- a/src/prompts/planner.txt
+++ b/src/prompts/planner.txt
@@ -26,8 +26,10 @@ Current weekday: ${current_weekday}
 Use this temporal context when scheduling or sequencing tasks.
 
 # General Rules
-Format the output as a JSON array of objects with the following shape: {tool, args, thought}.
-Every step must choose a concrete tool from the allowed set and include structured args for that tool.
+Format the output as a JSON object that either:
+- Uses `{"mode": "plan", "plan": [...]}` for tool-based work (each step shaped as {tool, args, thought}), or
+- Uses `{"mode": "quickdraw", "quickdraw": {final_answer, confidence, rationale}}` only when tools are unnecessary.
+Block quickdraw and use tools whenever the request implies file/system mutations, searches/browsing/citations, or explicit verbs like create, edit, save, or run.
 If you are unsure, request a new plan rather than deferring to the ReAct agent.
 Do NOT include fully executable shell commands; keep the guidance conceptual.
 
@@ -38,7 +40,7 @@ If a query involves any kind of calculation, recommend a calculation tool.
 When describing tool usage, reference the structured argument fields each tool expects (for example terminal => {command, args}, notes_create => {title, body}, reminders_create => {title, time, notes}).
 
 # Output Format
-Respond ONLY with a JSON array of objects.
+Respond ONLY with a JSON object.
 Specifically, constrain your response using this JSON schema:
 ${planner_schema}
 

--- a/src/schemas/planner_plan.schema.json
+++ b/src/schemas/planner_plan.schema.json
@@ -1,62 +1,129 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "PlannerPlan",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "required": ["tool", "args"],
-    "additionalProperties": false,
-    "properties": {
-      "thought": {
-        "type": "string",
-        "description": "Short reasoning blurb about why the following tool and arguments are chosen.",
-        "minLength": 1
+  "type": "object",
+  "oneOf": [
+    {
+      "title": "Tool-based plan",
+      "required": ["mode", "plan"],
+      "properties": {
+        "mode": {
+          "const": "plan",
+          "description": "Planner expects downstream execution of tool steps."
+        },
+        "plan": {
+          "$ref": "#/definitions/plan_steps"
+        },
+        "quickdraw": {
+          "const": null,
+          "description": "Quickdraw payload must be null when mode=plan."
+        }
       },
-      "tool": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Name of the tool to invoke for this step."
+      "additionalProperties": false
+    },
+    {
+      "title": "Quickdraw response",
+      "required": ["mode", "quickdraw"],
+      "properties": {
+        "mode": {
+          "const": "quickdraw",
+          "description": "Planner is confident no tools are required."
+        },
+        "quickdraw": {
+          "$ref": "#/definitions/quickdraw_payload"
+        },
+        "plan": {
+          "type": "array",
+          "maxItems": 0,
+          "description": "No tool steps allowed in quickdraw mode."
+        }
       },
-      "args": {
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "plan_steps": {
+      "type": "array",
+      "items": {
         "type": "object",
-        "description": "Structured arguments for the tool. Provide the exact fields that the tool expects; use an empty object only when the tool accepts no arguments.",
-        "default": {},
-        "additionalProperties": true
+        "required": ["tool", "args"],
+        "additionalProperties": false,
+        "properties": {
+          "thought": {
+            "type": "string",
+            "description": "Short reasoning blurb about why the following tool and arguments are chosen.",
+            "minLength": 1
+          },
+          "tool": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the tool to invoke for this step."
+          },
+          "args": {
+            "type": "object",
+            "description": "Structured arguments for the tool. Provide the exact fields that the tool expects; use an empty object only when the tool accepts no arguments.",
+            "default": {},
+            "additionalProperties": true
+          }
+        }
+      },
+      "minItems": 1,
+      "description": "Ordered list of high-level plan steps represented as objects with tool, args, and thought fields.",
+      "examples": [
+        [
+          {
+            "thought": "Record the requested notes.",
+            "tool": "notes_create",
+            "args": {
+              "title": "Research notes",
+              "body": "The next delivery step for the research are..."
+            }
+          },
+          {
+            "thought": "Share the notes back to the user.",
+            "tool": "final_answer",
+            "args": {}
+          }
+        ],
+        [
+          {
+            "thought": "Inspect the current directory tree.",
+            "tool": "terminal",
+            "args": {
+              "command": "ls",
+              "args": ["-la"]
+            }
+          },
+          {
+            "thought": "Share the notes back to the user.",
+            "tool": "final_answer",
+            "args": {}
+          }
+        ]
+      ]
+    },
+    "quickdraw_payload": {
+      "type": "object",
+      "required": ["final_answer", "confidence", "rationale"],
+      "additionalProperties": false,
+      "properties": {
+        "final_answer": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The complete, ready-to-send response for the user."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Planner confidence in skipping tool use (0-1)."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Short explanation of why tools are unnecessary."
+        }
       }
     }
-  },
-  "minItems": 1,
-  "description": "Ordered list of high-level plan steps represented as objects with tool, args, and thought fields.",
-  "examples": [
-    [
-      {
-        "thought": "Record the requested notes.",
-        "tool": "notes_create",
-        "args": {
-          "title": "Research notes",
-          "body": "The next delivery step for the research are..."
-        }
-      },
-      {
-        "thought": "Share the notes back to the user.",
-        "tool": "final_answer",
-        "args": {}
-      }
-    ],
-    [
-      {
-        "thought": "Inspect the current directory tree.",
-        "tool": "terminal",
-        "args": {
-          "command": "ls",
-          "args": ["-la"]
-        }
-      },
-      {
-        "thought": "Share the notes back to the user.",
-        "tool": "final_answer",
-        "args": {}
-      }
-    ]
-  ]
+  }
 }

--- a/tests/planning/planner.bats
+++ b/tests/planning/planner.bats
@@ -8,18 +8,18 @@ setup() {
 }
 
 @test "generate_plan_json falls back when llama is unavailable" {
-	run env -i HOME="$HOME" PATH="$PATH" bash <<'SCRIPT'
+        run env -i HOME="$HOME" PATH="$PATH" bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/planner.sh
 LLAMA_AVAILABLE=false
 generate_plan_json "tell me a joke"
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	thought=$(printf '%s' "${output}" | jq -r '.[0].thought')
-	tool=$(printf '%s' "${output}" | jq -r '.[0].tool')
-	[ "${tool}" = "final_answer" ]
-	[[ "${thought}" == *"Respond directly"* ]]
+        [ "$status" -eq 0 ]
+        mode=$(printf '%s' "${output}" | jq -r '.mode')
+        answer=$(printf '%s' "${output}" | jq -r '.quickdraw.final_answer')
+        [ "${mode}" = "quickdraw" ]
+        [ -n "${answer}" ]
 }
 
 @test "generate_plan_json appends final step to llama output" {


### PR DESCRIPTION
## Summary
- allow planner responses to return either tool plans or quickdraw final answers via updated schema and prompt
- add normalization and runtime handling for quickdraw mode, including direct response bypass of ReAct
- document the quickdraw flow and cover planner behavior in tests

## Testing
- `bats tests/planning/planner.bats` *(fails/hangs; aborted during run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a6c7c770832586de017ee9c97f47)