### PR TITLE
Add web search capabilities to planner

### DIFF
--- a/src/prompts/planner.txt
+++ b/src/prompts/planner.txt
@@ -38,6 +38,10 @@ Select only from the provided list of available tools.
 Each action must clearly indicate which tool will be used.
 If a query involves any kind of calculation, recommend a calculation tool.
 When describing tool usage, reference the structured argument fields each tool expects (for example terminal => {command, args}, notes_create => {title, body}, reminders_create => {title, time, notes}).
+# Web search discipline (rationale: keeps planning deterministic and cost-bounded while still allowing lightweight fact checks)
+Use `web_search` only when the user request cannot be planned without fresh context or public facts.
+Cap `web_search` to one or two short, targeted queries.
+Summarize results deterministically and solely to shape the plan; do not execute tasks or actions based on the search output.
 
 # Output Format
 Respond ONLY with a JSON object.


### PR DESCRIPTION
## Summary
- add explicit web_search discipline to the planner template, limiting queries and requiring deterministic summarization
- ensure dynamic prompt builder injects the web_search guardrails so constraints are always present
- document rationale inline to align future edits with acceptance criteria

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694951fbd2488325b3b8e9b0e16d2555)