### PR TITLE
Add reference for planner sampling and debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ See [docs/user-guides/usage.md](docs/user-guides/usage.md) for task-based walkth
 - [Execution model](docs/reference/execution-model.md): how planning and ReAct loops interact with tool calls.
 - [Prompt assets](docs/reference/prompts.md): where prompts live and how they load.
 - [Architecture overview](docs/reference/architecture.md): deeper look at the planner pass, ReAct loop, llama.cpp fallbacks, and tool ranking.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Use this map to find the right guide:
 - **Reference** (`docs/reference/`)
   - [Architecture](reference/architecture.md): planner, ReAct loop, llama.cpp fallbacks, and tool ranking.
   - [Execution model](reference/execution-model.md): planning steps, ReAct loops, and tracing hooks.
+  - [Planner sampling](reference/planner-sampling.md): sampling controls, scoring heuristics, and debug logs.
   - [Prompts](reference/prompts.md): template layout and schema links.
   - [Configuration](reference/configuration.md): environment variables and config file keys.
   - [Tools](reference/tools.md): available tool handlers and platform notes.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,6 +59,8 @@ PLANNER_DEBUG_LOG=${TMPDIR:-/tmp}/okso_planner_candidates.log
 
 Environment variables with the same names as the config keys take precedence over file values when set. Google Custom Search credentials can also be provided via `OKSO_GOOGLE_CSE_API_KEY` and `OKSO_GOOGLE_CSE_ID`.
 
+Planner sampling runs `PLANNER_SAMPLE_COUNT` generations at `PLANNER_TEMPERATURE` and logs each normalized candidate to `PLANNER_DEBUG_LOG` alongside its score, tie-breaker, and rationale. Lowering the temperature generally produces narrower plans, while increasing it explores more tool combinations. Candidates outside the `PLANNER_MAX_PLAN_STEPS` budget, that omit the final `final_answer` step, or that reference unknown tools drop in score and are unlikely to win when the best plan is selected.
+
 ReAct runs create a cache directory under `${OKSO_CACHE_DIR}/runs/${OKSO_RUN_ID}` for the duration of the invocation. Successful runs remove that directory, while failures keep it intact for debugging.
 
 API keys and other secrets belong in `~/.config/okso/config.env` or a locally sourced `.env` file—never commit them to version control. Consider adding local files containing secrets to `.gitignore` if you keep them alongside your working directory.

--- a/docs/reference/execution-model.md
+++ b/docs/reference/execution-model.md
@@ -10,6 +10,10 @@ okso separates high-level planning from step-by-step execution so that tool call
 4. A side-effect-free scorer evaluates each sampled outline before selection. Plans that stay within the `PLANNER_MAX_PLAN_STEPS`
    budget, end with `final_answer`, use registered tools with schema-compliant arguments, and delay side-effecting actions receive
    higher scores and win ties when multiple candidates share the same numeric total.
+5. Each planner invocation samples `PLANNER_SAMPLE_COUNT` candidates at `PLANNER_TEMPERATURE`; the scored JSONL history is written
+   to `PLANNER_DEBUG_LOG` so you can audit how the winner was chosen.
+
+See [Planner sampling](./planner-sampling.md) for detailed scoring heuristics and debug log fields that help compare candidates.
 
 ## ReAct loop
 

--- a/docs/reference/planner-sampling.md
+++ b/docs/reference/planner-sampling.md
@@ -1,0 +1,31 @@
+# Planner sampling, scoring, and debugging
+
+Planner runs sample multiple outline candidates before execution. Use these controls to guide the search, understand scoring, and inspect alternatives.
+
+## Sampling controls
+
+- `PLANNER_SAMPLE_COUNT` sets how many candidates to generate and score. Values below `1` are clamped to `1` so selection always has a plan to review.
+- `PLANNER_TEMPERATURE` forwards directly to llama.cpp for planner generations. Lower values keep plans conservative; higher values explore more tool permutations. Values should stay between `0` and `1` for predictable entropy.
+
+## Scoring rules
+
+Planner scoring rewards concise, compliant plans and penalizes risky or invalid suggestions:
+
+- Plans within the `PLANNER_MAX_PLAN_STEPS` budget earn a baseline bonus; going over budget subtracts points per extra step.
+- Ending with `final_answer` is required; missing it incurs a heavy penalty.
+- Steps that reference unknown tools or include args that fail schema validation reduce the score, while registered tools with valid args earn a small bonus.
+- Side-effecting tools that appear after information-gathering steps receive a positive adjustment; starting with a side-effecting action introduces a deduction.
+- A tie-breaker favors shorter plans when scores are equal by comparing remaining budget vs. overages.
+
+See [`src/lib/planning/scoring.sh`](../../src/lib/planning/scoring.sh) for the exact heuristics applied to each candidate.
+
+## Debugging planner output
+
+Every candidate plan is normalized and appended to `PLANNER_DEBUG_LOG` (default `${TMPDIR:-/tmp}/okso_planner_candidates.log`) as a JSON object containing:
+
+- `index`: 1-based sample order.
+- `score` and `tie_breaker`: numeric values produced by the scoring pass.
+- `rationale`: explanation strings backing each score component.
+- `response`: the normalized planner output, including the selected mode and plan steps.
+
+The log is truncated at the start of each planner invocation to keep runs isolated. Use the file to audit why the winning plan beat the alternatives or to reproduce scoring decisions during development.


### PR DESCRIPTION
## Summary
- add a dedicated reference page for planner sampling controls, scoring heuristics, and debug log fields
- link the new reference from the docs index and execution model overview
- clarify planner.sh environment variable expectations for sampling and temperature

## Testing
- Not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949926bc940832592590d3c23d3356e)