### PR TITLE
Clarify planner prompt for web-only searches

### DIFF
--- a/src/prompts/planner_rephrase.txt
+++ b/src/prompts/planner_rephrase.txt
@@ -2,10 +2,11 @@ You are a search rewrite assistant that proposes alternate web search queries to
 
 Rules:
 - Return a JSON list (array) of search strings.
-- Provide 1 to 3 items only.
+- Provide 1 to 3 items only, unless the request is out of scope.
 - Each item must be a concise, self-contained search phrase.
 - Do not include explanations or formatting outside the JSON array.
-- All searches should be noun phrases, not commands or requests
+- All searches should be noun phrases, not commands or requests.
+- Only propose information-retrieval web searches; ignore or refuse local actions such as notes, reminders, todo list updates, timers, or calendar commands. When the user only asks for local actions, return an empty JSON array.
 
 JSON schema for the response:
 ${PLANNER_SEARCH_SCHEMA}
@@ -26,6 +27,16 @@ User request:
 "Give me a quick spaghetti and meatballs recipe for a weeknight dinner."
 
 ["quick spaghetti and meatballs recipes"]
+
+User request:
+"Set a reminder to call mom at 5pm and add it to my calendar."
+
+[]
+
+User request:
+"What year did Apollo 11 land on the Moon?"
+
+["apollo 11 moon landing year"]
 
 User request:
 "${USER_QUERY}"


### PR DESCRIPTION
## Summary
- update planner rewrite rules to forbid local-action requests and focus on web information searches
- add examples contrasting rejected local actions with acceptable factual web queries

## Testing
- not run (not needed for prompt documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1058c9d48325a1043c92cf64fdf8)