### PR TITLE
Add observation summaries to ReAct history

### DIFF
--- a/src/lib/react/loop.sh
+++ b/src/lib/react/loop.sh
@@ -595,11 +595,11 @@ react_loop() {
 
 		if is_duplicate_action "${last_action}" "${tool}" "${normalized_args_json}"; then
 			log "WARN" "Duplicate action detected" "${tool}"
-			observation="Duplicate action detected. Please try a different approach or call final_answer if you are stuck."
-			record_tool_execution "${state_prefix}" "${tool}" "${thought} (REPEATED)" "${normalized_args_json}" "${observation}" "${current_step}"
-			record_plan_skip_without_progress "${state_prefix}" "duplicate_action"
-			increment_retry_count "${state_prefix}"
-			continue
+                        observation="Duplicate action detected. Please try a different approach or call final_answer if you are stuck."
+                        record_tool_execution "${state_prefix}" "${tool}" "${thought} (REPEATED)" "${normalized_args_json}" "${observation}" "${observation}" "${current_step}"
+                        record_plan_skip_without_progress "${state_prefix}" "duplicate_action"
+                        increment_retry_count "${state_prefix}"
+                        continue
 		fi
 
 		# Track whether the selected action fulfills the pending planned step.
@@ -675,12 +675,15 @@ react_loop() {
 				'{output:$output,error:$error,exit_code:$exit_code}')
 		fi
 
-		if [[ "${tool}" == "final_answer" && ${exit_code} -eq 0 && -n "${final_answer_payload}" ]]; then
-			observation="${final_answer_payload}"
-		fi
+                if [[ "${tool}" == "final_answer" && ${exit_code} -eq 0 && -n "${final_answer_payload}" ]]; then
+                        observation="${final_answer_payload}"
+                fi
 
-		local failure_record failure_error
-		failure_error=$(printf '%s' "${observation}" | jq -r '.error // empty' 2>/dev/null || printf '')
+                local observation_summary
+                observation_summary="$(render_observation_text "${tool}" "${observation}")"
+
+                local failure_record failure_error
+                failure_error=$(printf '%s' "${observation}" | jq -r '.error // empty' 2>/dev/null || printf '')
 		if ((exit_code != 0)); then
 			failure_record=$(jq -nc \
 				--arg tool "${tool}" \
@@ -710,7 +713,7 @@ react_loop() {
 			fi
 		fi
 
-		record_tool_execution "${state_prefix}" "${tool}" "${thought}" "${normalized_args_json}" "${observation}" "${current_step}"
+                record_tool_execution "${state_prefix}" "${tool}" "${thought}" "${normalized_args_json}" "${observation}" "${observation_summary}" "${current_step}"
 		if ((exit_code != 0)); then
 			local plan_entries_text
 			plan_entries_text="$(state_get "${state_prefix}" "plan_entries")"


### PR DESCRIPTION
## Summary
- persist both raw and summarized observations when recording ReAct tool history
- expose summarized history to formatters and prompt builders while surfacing raw details for the most recent step
- add regression coverage for history summarization behavior

## Testing
- bats tests/planning/react_loop.bats *(fails: duplicate test names in suite)*
- bats -f "state_get_history_lines prefers summaries" tests/planning/react_loop.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b2c8405f883258740c3dba9914701)