### PR TITLE
Clarify ReAct schema prompt and add coverage

### DIFF
--- a/src/lib/prompt/build_react.sh
+++ b/src/lib/prompt/build_react.sh
@@ -22,9 +22,9 @@ source "${PROMPT_BUILD_REACT_DIR}/../time/time.sh"
 
 build_react_prompt_static_prefix() {
 	# Returns the deterministic ReAct prompt prefix that excludes runtime fields.
-	local template anchor
-	template="$(load_prompt_template "react")" || return 1
-	anchor="\${current_date}"
+        local template anchor
+        template="$(load_prompt_template "react")" || return 1
+        anchor="Current date: \${current_date}"
 
 	if [[ "${template}" != *"${anchor}"* ]]; then
 		printf '%s' "${template}"

--- a/src/prompts/react.txt
+++ b/src/prompts/react.txt
@@ -38,7 +38,8 @@ Observations may contain the output of the tool, but also errors and exit codes 
 Use these observations to decide if you need to retry an action or try a different approach.
 If a tool fails, look at the "Error" field in the observation to understand why.
 
-Specifically, your response must follow the format:
+# Response Schema
+Always respond with JSON only. Match this schema exactly (no Markdown, no additional keys):
 ${react_schema}
 
 You have access to the following tools:

--- a/tests/planning/prompting.bats
+++ b/tests/planning/prompting.bats
@@ -131,30 +131,34 @@ SCRIPT
 }
 
 @test "react prompt segments recombine into full prompt" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 real_date="$(command -v date)"
 mock_bin_dir="$(mktemp -d)"
+  REAL_DATE_PATH="$(command -v date)"
+  export REAL_DATE_PATH
   cat >"${mock_bin_dir}/date" <<'DATE'
-  #!/usr/bin/env bash
-  fmt="${1-}"
-  if [[ "${fmt}" == "-u" ]]; then
-          fmt="${2-}"
-  fi
+#!/usr/bin/env bash
+real_date="${REAL_DATE_PATH}"
+fmt="${1:-}"
+if [[ "${fmt}" == "-u" ]]; then
+        fmt="${2:-}"
+fi
 
-  if [[ "${fmt}" == "+%Y-%m-%d" ]]; then
-          printf '2024-01-01\n'
-  elif [[ "${fmt}" == "+%H:%M:%S" ]]; then
-          printf '00:00:01\n'
-  elif [[ "${fmt}" == "+%A" ]]; then
-          printf 'Monday\n'
-  else
-          exec "${real_date}" "$@"
-  fi
+if [[ "${fmt}" == "+%Y-%m-%d" ]]; then
+        printf '2024-01-01\n'
+elif [[ "${fmt}" == "+%H:%M:%S" ]]; then
+        printf '00:00:01\n'
+elif [[ "${fmt}" == "+%A" ]]; then
+        printf 'Monday\n'
+else
+        exec "${real_date}" "$@"
+fi
 DATE
 chmod +x "${mock_bin_dir}/date"
 export PATH="${mock_bin_dir}:${PATH}"
 source ./src/lib/prompt/build_react.sh
+source ./src/lib/react/schema.sh
 prefix="$(build_react_prompt_static_prefix)"
 suffix="$(build_react_prompt_dynamic_suffix "query" "tool list" "outline" "history" "{}" "step")"
 full="$(build_react_prompt "query" "tool list" "outline" "history" "{}" "step")"
@@ -164,6 +168,91 @@ fi
 printf 'ok\n'
 SCRIPT
 
-	[ "$status" -eq 0 ]
-	[ "${output}" = "ok" ]
+        [ "$status" -eq 0 ]
+        [ "${output}" = "ok" ]
+}
+
+@test "react prompt sets current date once" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+real_date="$(command -v date)"
+mock_bin_dir="$(mktemp -d)"
+  REAL_DATE_PATH="$(command -v date)"
+  export REAL_DATE_PATH
+  cat >"${mock_bin_dir}/date" <<'DATE'
+#!/usr/bin/env bash
+real_date="${REAL_DATE_PATH}"
+fmt="${1:-}"
+if [[ "${fmt}" == "-u" ]]; then
+        fmt="${2:-}"
+fi
+
+case "${fmt}" in
+        "+%Y-%m-%d") printf '2024-01-01\n' ;;
+        "+%H:%M:%S") printf '00:00:01\n' ;;
+        "+%A") printf 'Monday\n' ;;
+        *) exec "${real_date}" "$@" ;;
+esac
+DATE
+chmod +x "${mock_bin_dir}/date"
+export PATH="${mock_bin_dir}:${PATH}"
+source ./src/lib/prompt/build_react.sh
+source ./src/lib/react/schema.sh
+
+allowed_tools=$'python_repl\nfinal_answer'
+react_schema_path="$(build_react_action_schema "${allowed_tools}")"
+react_schema_text="$(cat "${react_schema_path}")"
+
+prompt="$(build_react_prompt "query" "Available tools:" "outline" "history" "${react_schema_text}" "step")"
+
+rm -f "${react_schema_path}"
+
+[[ "$(grep -c 'Current date:' <<<"${prompt}")" -eq 1 ]]
+SCRIPT
+
+        [ "$status" -eq 0 ]
+}
+
+@test "react prompt respects default token budget" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+real_date="$(command -v date)"
+mock_bin_dir="$(mktemp -d)"
+  REAL_DATE_PATH="$(command -v date)"
+  export REAL_DATE_PATH
+  cat >"${mock_bin_dir}/date" <<'DATE'
+#!/usr/bin/env bash
+real_date="${REAL_DATE_PATH}"
+fmt="${1:-}"
+if [[ "${fmt}" == "-u" ]]; then
+        fmt="${2:-}"
+fi
+
+case "${fmt}" in
+        "+%Y-%m-%d") printf '2024-01-01\n' ;;
+        "+%H:%M:%S") printf '00:00:01\n' ;;
+        "+%A") printf 'Monday\n' ;;
+        *) exec "${real_date}" "$@" ;;
+esac
+DATE
+chmod +x "${mock_bin_dir}/date"
+export PATH="${mock_bin_dir}:${PATH}"
+export PROMPT_TOKEN_BUDGET=4096
+source ./src/lib/prompt/build_react.sh
+source ./src/lib/react/schema.sh
+source ./src/lib/llm/context_budget.sh
+
+allowed_tools=$'python_repl\nfinal_answer'
+react_schema_path="$(build_react_action_schema "${allowed_tools}")"
+react_schema_text="$(cat "${react_schema_path}")"
+
+prompt="$(build_react_prompt "query" "Available tools:" "outline" "history" "${react_schema_text}" "step")"
+total_tokens="$(estimate_total_tokens "${prompt}" 256)"
+
+rm -f "${react_schema_path}"
+
+(( total_tokens <= PROMPT_TOKEN_BUDGET ))
+SCRIPT
+
+        [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary
- clarify the ReAct prompt template with an explicit response schema section and adjust the prefix anchor
- strengthen date/time mocks and add regression tests for single current-date rendering and token budget safety

## Testing
- bats tests/planning/prompting.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d9b8c223083258d3ba1c31b0d10a2)