### PR TITLE
Add planner arg control metadata and context resolution

### DIFF
--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -4,7 +4,7 @@ Structured outputs keep planner interactions predictable. Schema files live in `
 
 ## Available schemas
 
-- `planner_plan.schema.json`: numbered outline that proposes tools and ends with `final_answer`; loaded at runtime by `planner.sh` before plan validation.
+- `planner_plan.schema.json`: numbered outline that proposes tools and ends with `final_answer`; each step can set `args_control` to mark arguments as locked or to be filled from executor context; loaded at runtime by `planner.sh` before plan validation.
 - `react_action.schema.json`: executor action template; tool enums, per-tool args, and missing-value sentinels are injected during schema generation and consumed by the executor in `react/loop.sh` for validation and fallback selection.
 - `concise_response.schema.json`: short direct answers when no tools should run; used by `respond.sh` to constrain final-answer fallback summaries.
 

--- a/src/prompts/planner.txt
+++ b/src/prompts/planner.txt
@@ -26,7 +26,7 @@ Current weekday: ${current_weekday}
 Use this temporal context when scheduling or sequencing tasks.
 
 # General Rules
-Format the output as a JSON object shaped as `{"mode": "plan", "plan": [...]}` (each step shaped as {tool, args, thought}).
+Format the output as a JSON object shaped as `{"mode": "plan", "plan": [...]}` (each step shaped as {tool, args, args_control, thought}).
 Always return at least one plan step; the final step must use the `final_answer` tool.
 
 # Tool Selection Rules
@@ -34,6 +34,7 @@ Select only from the provided list of available tools.
 Each action must clearly indicate which tool will be used.
 If a query involves any kind of calculation or mathematical operation, recommend the python_repl tool.
 When describing tool usage, reference the structured argument fields each tool expects (for example terminal => {command, args}, notes_create => {title, body}, reminders_create => {title, time, notes}).
+For every argument, set an entry in `args_control` indicating whether the executor should fill it from context (`"context"`) or preserve the planner-specified value (`"locked"`).
 All free-form natural language or code payloads must be provided as strings under `args.input` (never `args.code` or other aliases).
 
 # Tool Argument Discipline

--- a/src/schemas/planner_plan.schema.json
+++ b/src/schemas/planner_plan.schema.json
@@ -37,6 +37,15 @@
             "description": "Structured arguments for the tool. Provide the exact fields that the tool expects; use an empty object only when the tool accepts no arguments.",
             "default": {},
             "additionalProperties": true
+          },
+          "args_control": {
+            "type": "object",
+            "description": "Per-argument fill strategy. Use \"context\" to have the executor derive values from conversation context or \"locked\" to keep the planner-provided value immutable.",
+            "default": {},
+            "additionalProperties": {
+              "type": "string",
+              "enum": ["context", "locked"]
+            }
           }
         }
       },

--- a/tests/planning/normalization.bats
+++ b/tests/planning/normalization.bats
@@ -35,7 +35,7 @@ SCRIPT
 }
 
 @test "normalize_planner_plan maps code alias to args.input" {
-	run bash <<'SCRIPT'
+        run bash <<'SCRIPT'
 set -euo pipefail
 source ./src/lib/planning/normalization.sh
 raw_plan='[{"tool":"python_repl","args":{"code":"print(1)"},"thought":"run code"}]'
@@ -44,7 +44,20 @@ SCRIPT
 
 	[ "$status" -eq 0 ]
 	[ "${lines[0]}" = "print(1)" ]
-	[ "${lines[1]}" = "false" ]
+        [ "${lines[1]}" = "false" ]
+}
+
+@test "normalize_planner_plan preserves valid arg controls" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/planning/normalization.sh
+raw_plan='[{"tool":"notes_create","args":{"title":"t","body":"b"},"args_control":{"title":"context","body":"locked"}}]'
+normalize_planner_plan <<<"${raw_plan}" | jq -r '.[0].args_control.title,.[0].args_control.body'
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "context" ]
+        [ "${lines[1]}" = "locked" ]
 }
 
 @test "normalize_planner_response normalizes code alias inside plan" {

--- a/tests/react/arg_controls.bats
+++ b/tests/react/arg_controls.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+setup() {
+        unset -f chpwd _mise_hook 2>/dev/null || true
+}
+
+@test "apply_plan_arg_controls fills context args and locks planner values" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/react/loop.sh
+
+tool_args_schema() {
+        printf '{"properties":{"title":{"type":"string"},"body":{"type":"string"}}}'
+}
+
+plan_entry='{"tool":"notes_create","args":{"title":"Planner Title","body":"Original body"},"args_control":{"title":"locked","body":"context"}}'
+executor_args='{"title":"User Title","body":"__MISSING__"}'
+user_query='Provide meeting summary'
+resolved=$(apply_plan_arg_controls "notes_create" "${executor_args}" "${plan_entry}" "${user_query}" "__MISSING__")
+jq -r '.title,.body' <<<"${resolved}"
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "Planner Title" ]
+        [ "${lines[1]}" = "Provide meeting summary" ]
+}
+


### PR DESCRIPTION
## Summary
- add `args_control` metadata to planner schema, prompt text, and normalization so planners flag context-fillable versus locked arguments
- have the executor apply planner controls to resolve missing/contextual arguments while preserving locked values
- extend test coverage for planner normalization and mixed locked/fillable argument handling

## Testing
- bats tests/planning/normalization.bats tests/core/planner.sh tests/react/arg_controls.bats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dba5966b88325843e90759ee4a79e)