### PR TITLE
Handle malformed planner responses in CLI

### DIFF
--- a/src/bin/okso
+++ b/src/bin/okso
@@ -119,12 +119,28 @@ main() {
 	# Planner flow:
 	# 1. Generate an outline, 2. identify tools, 3. build concrete plan entries
 	# for execution, then 4. render plan outputs before proceeding.
-	log "INFO" "Starting plan generation" "$(settings_get "${settings_prefix}" "user_query")"
-	plan_response="$(generate_planner_response "$(settings_get "${settings_prefix}" "user_query")")"
-	plan_outline="$(plan_json_to_outline "${plan_response}")"
-	required_tools="$(derive_allowed_tools_from_plan "${plan_response}")"
-	log "INFO" "Planner identified tools" "${required_tools}"
-	plan_entries="$(plan_json_to_entries "${plan_response}")"
+        log "INFO" "Starting plan generation" "$(settings_get "${settings_prefix}" "user_query")"
+        if [[ -n "${OKSO_PLANNER_RESPONSE:-}" ]]; then
+                plan_response="${OKSO_PLANNER_RESPONSE}"
+        else
+                plan_response="$(generate_planner_response "$(settings_get "${settings_prefix}" "user_query")")"
+        fi
+
+        if ! plan_outline="$(plan_json_to_outline "${plan_response}")"; then
+                plan_outline=""
+        fi
+
+        if ! required_tools="$(derive_allowed_tools_from_plan "${plan_response}")"; then
+                printf 'Planner response was invalid; unable to determine required tools. Please retry with --verbose for detail.\n' >&2
+                return 1
+        fi
+
+        log "INFO" "Planner identified tools" "${required_tools}"
+
+        if ! plan_entries="$(plan_json_to_entries "${plan_response}")"; then
+                printf 'Planner response was invalid; unable to prepare execution plan. Please retry with --verbose for detail.\n' >&2
+                return 1
+        fi
 
 	render_plan_outputs plan_action "${settings_prefix}" "${required_tools}" "${plan_entries}" "${plan_outline}" "${plan_response}"
 	if [[ "${plan_action}" == "exit" ]]; then


### PR DESCRIPTION
## Summary
- add explicit logging when planner plan extraction fails, including payload snippets
- stop the CLI when planner responses cannot be normalized and allow test injection of planner output
- add regression coverage for malformed planner JSON and deterministic plan action selection

## Testing
- bats tests/core/planner.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dcb755f688325bd1f98a8c2c4f3f1)