### PR TITLE
Simplify executor schema missing handling

### DIFF
--- a/docs/reference/execution-model.md
+++ b/docs/reference/execution-model.md
@@ -21,7 +21,7 @@ See [Planner sampling](./planner-sampling.md) for detailed scoring heuristics an
 
 After the plan is approved, the runtime requests a single structured tool call:
 
-- **Default behaviour:** llama.cpp receives the executor prompt (no persona or transcript) and must emit one JSON action that matches the executor schema. Missing details are surfaced explicitly via the `__MISSING__` sentinel so gaps are auditable.
+- **Default behaviour:** llama.cpp receives the executor prompt (no persona or transcript) and must emit one JSON action that matches the executor schema. Missing details are surfaced explicitly via the `__MISSING__` sentinel so gaps are auditable, and validation only tolerates that sentinel on required fields or the top-level `action` wrapper to keep schemas lean.
 - **Fallback behaviour:** if llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso replays the planned tool calls deterministically using the planner-provided arguments.
 
 Each executor decision and observation is streamed to the terminal. Use `--dry-run` when you want to inspect the generated plan and tool calls without executing anything.

--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -5,7 +5,7 @@ Structured outputs keep planner interactions predictable. Schema files live in `
 ## Available schemas
 
 - `planner_plan.schema.json`: JSON object with a `plan` array of tool steps and rationales; each step requires `tool`, `args`, and `thought`, and may set `args_control` entries (matching `args` keys) to lock values or request executor-provided context; loaded at runtime by `planner.sh` before plan validation.
-- `react_action.schema.json`: executor action template; tool enums, per-tool args, and missing-value sentinels are injected during schema generation and consumed by the executor in `react/loop.sh` for validation and fallback selection.
+- `react_action.schema.json`: executor action template; tool enums, per-tool args, and missing-value sentinels are injected during schema generation and consumed by the executor in `react/loop.sh` for validation and fallback selection. Missing sentinels are scoped to required fields so optional arguments use their native types without `anyOf` wrappers.
 - `concise_response.schema.json`: short direct answers when no tools should run; used by `respond.sh` to constrain final-answer fallback summaries.
 
 Free-form text arguments always appear under `args.input` in planner payloads, keeping prompt templates and registry-driven

--- a/tests/react/schema_validation.bats
+++ b/tests/react/schema_validation.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+setup() {
+        unset -f chpwd _mise_hook 2>/dev/null || true
+}
+
+@test "react schema accepts required args marked missing" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/react/schema.sh
+
+tool_registry_json() {
+        cat <<'JSON'
+{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","properties":{"needed":{"type":"string"},"optional":{"type":"string"},"nested":{"type":"object","properties":{"inner":{"type":"integer"}},"required":["inner"]}},"required":["needed","nested"],"additionalProperties":false}}}}
+JSON
+}
+
+tool_names() {
+        printf 'alpha\n'
+}
+
+schema_path=$(build_react_action_schema "alpha")
+action_missing='{"action":{"tool":"alpha","args":{"needed":"__MISSING__","nested":{"inner":"__MISSING__"},"optional":"ok"}}}'
+validate_react_action "${action_missing}" "${schema_path}" >/tmp/validated_action.json
+cat /tmp/validated_action.json
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [[ "${output}" == *'"needed":"__MISSING__"'* ]]
+        [[ "${output}" == *'"inner":"__MISSING__"'* ]]
+}
+
+@test "react schema accepts fully specified payloads" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/react/schema.sh
+
+tool_registry_json() {
+        cat <<'JSON'
+{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","properties":{"needed":{"type":"string"},"optional":{"type":"string"},"nested":{"type":"object","properties":{"inner":{"type":"integer"}},"required":["inner"]}},"required":["needed","nested"],"additionalProperties":false}}}}
+JSON
+}
+
+tool_names() {
+        printf 'alpha\n'
+}
+
+schema_path=$(build_react_action_schema "alpha")
+action_full='{"action":{"tool":"alpha","args":{"needed":"value","optional":"skip","nested":{"inner":5}}}}'
+validate_react_action "${action_full}" "${schema_path}" >/tmp/validated_action.json
+cat /tmp/validated_action.json
+SCRIPT
+
+        [ "$status" -eq 0 ]
+        [[ "${output}" == *'"needed":"value"'* ]]
+        [[ "${output}" == *'"inner":5'* ]]
+}


### PR DESCRIPTION
## Summary
- limit missing-value allowances in the executor schema to required fields and the top-level action wrapper
- document the lighter validation approach in executor references
- add regression tests covering missing-sentinel and fully specified executor payloads

## Testing
- bats tests/react

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e93229bc88325bf81b9b731165478)