### PR TITLE
Refactor react action validation through schema

### DIFF
--- a/tests/planner/test_react_action.sh
+++ b/tests/planner/test_react_action.sh
@@ -136,9 +136,9 @@ INNERSCRIPT
 	[ "$status" -eq 0 ]
 }
 
-@test "validate_react_action enforces argument type schemas" {
-	script=$(
-		cat <<'INNERSCRIPT'
+@test "validate_react_action surfaces schema validation errors" {
+        script=$(
+                cat <<'INNERSCRIPT'
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 
@@ -188,10 +188,10 @@ if [[ ${status} -eq 0 ]]; then
         exit 1
 fi
 
-grep -F "Arg count must be a integer" err.log
+grep -F "action/args/count: 'oops' is not of type 'integer'" err.log
 rm -f "${schema_path}" err.log
 INNERSCRIPT
-	)
+        )
 
 	run bash -lc "${script}"
 	[ "$status" -eq 0 ]

--- a/tests/react/schema_validation.bats
+++ b/tests/react/schema_validation.bats
@@ -55,3 +55,79 @@ SCRIPT
         [[ "${output}" == *'"needed":"value"'* ]]
         [[ "${output}" == *'"inner":5'* ]]
 }
+
+@test "react schema rejects unexpected fields with clear error" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/react/schema.sh
+
+tool_registry_json() {
+        cat <<'JSON'
+{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","properties":{"input":{"type":"string"}},"required":["input"],"additionalProperties":false}}}}
+JSON
+}
+
+tool_names() {
+        printf 'alpha\n'
+}
+
+schema_path=$(build_react_action_schema "alpha")
+invalid_action='{"action":{"tool":"alpha","args":{"input":"value","extra":"nope"},"unexpected":true}}'
+
+set +e
+validate_react_action "${invalid_action}" "${schema_path}" 2>err.log
+status=$?
+set -e
+
+rm -f "${schema_path}"
+
+if [[ ${status} -eq 0 ]]; then
+        echo "validation unexpectedly succeeded"
+        exit 1
+fi
+
+cat err.log
+grep -F "action/args: Additional properties are not allowed ('extra' was unexpected)" err.log
+rm -f err.log
+SCRIPT
+
+        [ "$status" -eq 0 ]
+}
+
+@test "react schema surfaces argument type failures" {
+        run bash <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/react/schema.sh
+
+tool_registry_json() {
+        cat <<'JSON'
+{"names":["alpha"],"registry":{"alpha":{"args_schema":{"type":"object","properties":{"count":{"type":"integer"}},"required":["count"],"additionalProperties":false}}}}
+JSON
+}
+
+tool_names() {
+        printf 'alpha\n'
+}
+
+schema_path=$(build_react_action_schema "alpha")
+invalid_action='{"action":{"tool":"alpha","args":{"count":"oops"}}}'
+
+set +e
+validate_react_action "${invalid_action}" "${schema_path}" 2>err.log
+status=$?
+set -e
+
+rm -f "${schema_path}"
+
+if [[ ${status} -eq 0 ]]; then
+        echo "validation unexpectedly succeeded"
+        exit 1
+fi
+
+cat err.log
+grep -F "action/args/count: 'oops' is not of type 'integer'" err.log
+rm -f err.log
+SCRIPT
+
+        [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- switch validate_react_action to JSON Schema-based validation with clearer error reporting
- keep allowlist/top-level guards while deferring field/type checks to the schema
- extend bats coverage for valid and invalid react actions and update planner expectations

## Testing
- bats tests/react
- bats tests/planner/test_react_action.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e9416b76c832598d5eb247ebe303b)