### PR TITLE
Clarify executor argument expectations and remove sentinel references

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -41,7 +41,7 @@ Use `--dry-run` to stop after plan generation and approvals if you want to inspe
 ## Executor
 
 - Requests one schema-constrained tool call from llama.cpp using the executor prompt (no persona or interaction transcript).
-- Executes the chosen tool and streams observations; planner-specified context-controlled fields may be enriched by the executor LLM while other required fields must already be present.
+- Executes the chosen tool and streams observations; planner-specified context-controlled fields may be enriched by the executor LLM while all other required fields must be fully populated by the planner.
 - When `USE_REACT_LLAMA=false` or llama.cpp is unavailable, replays each planned tool deterministically using the original user query and the step context.
 - Stops after `final_answer` emits the user-facing result or when a tool returns a fatal error.
 

--- a/docs/reference/execution-model.md
+++ b/docs/reference/execution-model.md
@@ -21,7 +21,7 @@ See [Planner sampling](./planner-sampling.md) for detailed scoring heuristics an
 
 After the plan is approved, the runtime requests a single structured tool call:
 
-- **Default behaviour:** llama.cpp receives the executor prompt (no persona or transcript) and must emit one JSON action that matches the executor schema. Planner output must fully populate required arguments; only planner-marked context-controlled fields are eligible for executor enrichment, and missing required values outside that list result in validation errors.
+- **Default behaviour:** llama.cpp receives the executor prompt (no persona or transcript) and must emit one JSON action that matches the executor schema. Planner output must fully populate required arguments; only planner-marked context-controlled fields are eligible for executor enrichment, and missing required values outside that list result in validation errors that stop execution.
 - **Fallback behaviour:** if llama.cpp is unavailable or `USE_REACT_LLAMA=false` is set, okso replays the planned tool calls deterministically using the planner-provided arguments.
 
 Each executor decision and observation is streamed to the terminal. Use `--dry-run` when you want to inspect the generated plan and tool calls without executing anything.

--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -5,7 +5,7 @@ Structured outputs keep planner interactions predictable. Schema files live in `
 ## Available schemas
 
 - `planner_plan.schema.json`: JSON object with a `plan` array of tool steps and rationales; each step requires `tool`, `args`, and `thought`, and may set `args_control` entries (matching `args` keys) to lock values or request executor-provided context; loaded at runtime by `planner.sh` before plan validation.
-- `react_action.schema.json`: executor action template; tool enums, per-tool args, and missing-value sentinels are injected during schema generation and consumed by the executor in `react/loop.sh` for validation and fallback selection. Missing sentinels are scoped to required fields so optional arguments use their native types without `anyOf` wrappers.
+- `react_action.schema.json`: executor action template; tool enums and per-tool args are injected during schema generation and consumed by the executor in `react/loop.sh` for validation and fallback selection. Planner output must include every required argument up front while planner-marked context-controlled fields can be enriched by the executor LLM when available.
 - `concise_response.schema.json`: short direct answers when no tools should run; used by `respond.sh` to constrain final-answer fallback summaries.
 
 Free-form text arguments always appear under `args.input` in planner payloads, keeping prompt templates and registry-driven

--- a/src/lib/react/README.md
+++ b/src/lib/react/README.md
@@ -1,6 +1,6 @@
 # Executor library
 
-This package hosts the executor that runs after planning. The planner populates allowed tools, plan entries, and llama.cpp wiring, then delegates tool validation and execution to `react_loop`. The loop is deterministic: it iterates through planner actions, validates each tool against the allowlist, fills missing arguments in a single LLM round-trip when needed, retries safely, and records enriched error details rather than depending on multi-turn interactions. Callers that previously sourced `planning/react.sh` remain supported via the shim in that directory, but new entry points should source `react/react.sh` directly.
+This package hosts the executor that runs after planning. The planner populates allowed tools, plan entries, and llama.cpp wiring, then delegates tool validation and execution to `react_loop`. The loop is deterministic: it iterates through planner actions, validates each tool against the allowlist, retries safely, and records enriched error details rather than depending on multi-turn interactions. Planner output must already include every required argument; only planner-marked context-controlled fields are eligible for a single LLM enrichment pass. Callers that previously sourced `planning/react.sh` remain supported via the shim in that directory, but new entry points should source `react/react.sh` directly.
 
 ## Usage
 
@@ -18,9 +18,9 @@ react_loop "${user_query}" "${allowed_tools}" "${plan_entries}" "${plan_outline}
 
 The executor honours planner `args_control` metadata. When a tool argument is marked as `context`,
 the loop flags it for LLM completion instead of copying history directly into the arg list. The
-missing-arg prompt shares the serialized history from `state_get_history_lines`, the planner
+context-enrichment prompt shares the serialized history from `state_get_history_lines`, the planner
 thought, plan outline, and any partial arg text so llama.cpp can compose a response rooted in the
-latest context rather than relying on the original `user_query` alone.
+latest context while leaving planner-provided required arguments untouched.
 
 ## Dependencies
 

--- a/src/lib/react/loop.sh
+++ b/src/lib/react/loop.sh
@@ -13,7 +13,7 @@
 # Dependencies:
 #   - bash 3.2+
 #   - jq
-#   - llama.cpp binaries for optional arg infill
+#   - llama.cpp binaries for context arg infill
 #
 # Exit codes:
 #   Functions return non-zero on validation or execution failures.
@@ -250,7 +250,7 @@ PY
 }
 
 fill_missing_args_with_llm() {
-	# Fills missing arguments via a single LLM round-trip when possible.
+        # Fills planner-marked context arguments via a single LLM round-trip when possible.
 	# Arguments:
 	#   $1 - tool name
 	#   $2 - args JSON

--- a/tests/lib/test_llama_client.sh
+++ b/tests/lib/test_llama_client.sh
@@ -40,7 +40,7 @@ setup() {
                 args_file="${args_dir}/args.txt"
                 mock_binary="${args_dir}/mock_llama.sh"
                 json_schema="${args_dir}/schema.json"
-                printf "{\"title\":\"sentinel-schema\"}" >"${json_schema}"
+                printf "{\"title\":\"forwarded-schema\"}" >"${json_schema}"
                 cat >"${mock_binary}" <<SCRIPT
 #!/usr/bin/env bash
 printf "%s\n" "\$@" >"${args_file}"
@@ -57,7 +57,7 @@ SCRIPT
                         args+=("$line")
                 done <"${args_file}"
                 [[ "${args[*]}" == *"--json-schema"* ]]
-                [[ "${args[*]}" == *"sentinel-schema"* ]]
+                [[ "${args[*]}" == *"forwarded-schema"* ]]
                 [[ "${args[*]}" == *"-r"* ]]
                 [[ "${args[*]}" == *"STOP"* ]]
         '

--- a/tests/lib/test_runtime_react_cache.sh
+++ b/tests/lib/test_runtime_react_cache.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)" || exit 1
 export CACHE_DIR="${TMPDIR:-/tmp}/okso_cache_scope"
-export RUN_ID="run-sentinel"
+export RUN_ID="run-cache-scope"
 export REACT_CACHE_FILE="/custom/location/react.prompt-cache"
 source ./src/lib/runtime.sh
 create_default_settings cache_scope
@@ -28,7 +28,7 @@ printf "%s\n%s" \
         "$(settings_get cache_scope react_cache_file)"
 SCRIPT
 	[ "$status" -eq 0 ]
-	expected_path="${TMPDIR:-/tmp}/okso_cache_scope/runs/run-sentinel/react.prompt-cache"
+expected_path="${TMPDIR:-/tmp}/okso_cache_scope/runs/run-cache-scope/react.prompt-cache"
 	[ "${lines[0]}" = "${expected_path}" ]
 	[ "${lines[1]}" = "${expected_path}" ]
 }


### PR DESCRIPTION
## Summary
- update executor documentation and comments to emphasize planner-complete arguments and context-only LLM enrichment while removing sentinel guidance
- adjust react loop help text to reflect context infill defaults
- refresh Bats tests to drop sentinel-specific expectations

## Testing
- bats tests/lib/test_llama_client.sh tests/lib/test_runtime_react_cache.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec2f2f7d08325b45e261293c3ca32)