### PR TITLE
Relax settings default model assertions

### DIFF
--- a/tests/core/test_settings.sh
+++ b/tests/core/test_settings.sh
@@ -1,35 +1,37 @@
 #!/usr/bin/env bats
 
-@test "create_default_settings seeds derived defaults" {
-	run bash -lc '
+@test "create_default_settings seeds derived defaults without hardcoded models" {
+        run bash -lc '
                 set -e
                 source ./src/lib/core/settings.sh
                 create_default_settings compat
                 doc="$(settings_get_json_document compat)"
+                # string: planner_spec derived planner model reference
+                planner_spec="$(jq -r ".planner_model_spec" <<<"${doc}")"
+                # string: react_spec derived react model reference
+                react_spec="$(jq -r ".react_model_spec" <<<"${doc}")"
                 cache_dir="$(jq -r ".cache_dir" <<<"${doc}")"
                 run_id="$(jq -r ".run_id" <<<"${doc}")"
-                printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
+                [ -n "${planner_spec}" ]
+                [ -n "${react_spec}" ]
+                printf "%s\n%s\n%s\n%s\n%s\n%s\n%s" \
                         "$(jq -r ".config_dir" <<<"${doc}")" \
                         "$(jq -r ".config_file" <<<"${doc}")" \
-                        "$(jq -r ".planner_model_spec" <<<"${doc}")" \
-                        "$(jq -r ".react_model_spec" <<<"${doc}")" \
                         "$(jq -r ".use_react_llama" <<<"${doc}")" \
                         "${cache_dir}" \
                         "$(jq -r ".planner_cache_file" <<<"${doc}")" \
                         "$(jq -r ".react_cache_file" <<<"${doc}")" \
                         "${run_id}"
         '
-	[ "$status" -eq 0 ]
-	config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
-	[ "${lines[0]}" = "${config_dir_expected}" ]
-	[ "${lines[1]}" = "${config_dir_expected}/config.env" ]
-	[ "${lines[2]}" = "bartowski/Qwen_Qwen3-8B-GGUF:Qwen_Qwen3-8B-Q4_K_M.gguf" ]
-	[ "${lines[3]}" = "bartowski/Qwen_Qwen3-4B-GGUF:Qwen_Qwen3-4B-Q4_K_M.gguf" ]
-	[ "${lines[4]}" = "true" ]
-	cache_dir_expected="${XDG_CACHE_HOME:-${HOME}/.cache}/okso"
-	[ "${lines[5]}" = "${cache_dir_expected}" ]
-	[ "${lines[6]}" = "${cache_dir_expected}/planner.prompt-cache" ]
-	[[ "${lines[7]}" = "${cache_dir_expected}/runs/${lines[8]}/react.prompt-cache" ]]
+        [ "$status" -eq 0 ]
+        config_dir_expected="${XDG_CONFIG_HOME:-${HOME}/.config}/okso"
+        [ "${lines[0]}" = "${config_dir_expected}" ]
+        [ "${lines[1]}" = "${config_dir_expected}/config.env" ]
+        [ "${lines[2]}" = "true" ]
+        cache_dir_expected="${XDG_CACHE_HOME:-${HOME}/.cache}/okso"
+        [ "${lines[3]}" = "${cache_dir_expected}" ]
+        [ "${lines[4]}" = "${cache_dir_expected}/planner.prompt-cache" ]
+        [[ "${lines[5]}" = "${cache_dir_expected}/runs/${lines[6]}/react.prompt-cache" ]]
 }
 
 @test "settings persist across shells using cache" {


### PR DESCRIPTION
## Summary
- adjust default settings test to avoid hardcoded model spec assertions while still validating derived paths and cache usage
- ensure planner and react model specs are present without coupling to specific default strings

## Testing
- bats tests/core/test_settings.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ed1c3bc448325b45978a97bfbf2a4)