### PR TITLE
Fix web_fetch URL enum for arg infill

### DIFF
--- a/src/lib/executor/README.md
+++ b/src/lib/executor/README.md
@@ -38,6 +38,11 @@ the final argument payload, coerces `__context_controlled` into an array, ignore
 maps, and preserves original values when llama.cpp is unavailable. This keeps the executor prompt
 stable even when upstream planners emit inconsistent metadata.
 
+When `web_fetch` requires URL infill, the executor enriches the JSON schema passed to llama.cpp by
+extracting URLs from prior `web_search` observations in the execution history. This ensures the
+constrained decoder only allows URLs that were actually observed, while avoiding empty enum
+constraints when no URLs are available.
+
 ## Dependencies
 
 - bash 3.2+

--- a/src/lib/executor/loop.sh
+++ b/src/lib/executor/loop.sh
@@ -121,6 +121,72 @@ JQ
 	jq -c -n --argjson args "${args_obj}" --argjson planned "${plan_args}" --arg fill_marker "${fill_marker}" "${jq_filter}" 2>/dev/null
 }
 
+build_infill_schema() {
+	# Builds a constrained JSON schema for argument infill, enriched with execution context.
+	# Arguments:
+	#   $1 - tool name (string)
+	#   $2 - base args schema JSON (string)
+	#   $3 - serialized history text (string; newline-delimited JSON entries)
+	#   $4 - context fields JSON array (string)
+	# Returns:
+	#   JSON schema string.
+	local tool schema_json history_text context_fields_json url_enum
+	tool="$1"
+	schema_json="$2"
+	history_text="$3"
+	context_fields_json="$4"
+
+	if [[ -z "${schema_json}" ]]; then
+		schema_json="{}"
+	fi
+
+	if [[ "${tool}" != "web_fetch" ]]; then
+		printf '%s' "${schema_json}"
+		return 0
+	fi
+
+	if ! jq -e 'index("url")' <<<"${context_fields_json:-[]}" >/dev/null 2>&1; then
+		printf '%s' "${schema_json}"
+		return 0
+	fi
+
+	if [[ -z "${history_text}" ]]; then
+		jq -c 'if .properties.url? then .properties.url |= del(.enum) else . end' <<<"${schema_json}"
+		return 0
+	fi
+
+	url_enum=$(
+		printf '%s\n' "${history_text}" | jq -s '
+                  def parse_output($entry):
+                          if ($entry.observation | type) != "object" then null
+                          else ($entry.observation.output // empty) end
+                          | if type == "string" then (try fromjson catch null) else null end;
+                  [
+                          .[]
+                          | select(.action.tool == "web_search")
+                          | parse_output(.)
+                          | select(type == "object")
+                          | .items[]?.url
+                  ]
+                  | map(select(type == "string" and length > 0))
+                  | unique
+          ' 2>/dev/null
+	) || url_enum="[]"
+
+	if [[ "${url_enum}" == "[]" ]]; then
+		jq -c 'if .properties.url? then .properties.url |= del(.enum) else . end' <<<"${schema_json}"
+		return 0
+	fi
+
+	jq -c --argjson enum "${url_enum}" '
+                if .properties.url? then
+                        .properties.url |= (. + {enum: $enum})
+                else
+                        .
+                end
+        ' <<<"${schema_json}"
+}
+
 fill_missing_args_with_llm() {
 	# Fills planner-marked context arguments via a single LLM round-trip when possible.
 	# Arguments:
@@ -133,7 +199,7 @@ fill_missing_args_with_llm() {
 	#   $7 - JSON array of context-controlled fields
 	# Returns:
 	#   JSON string with filled args, or original args if LLM unavailable or fails.
-	local tool args_json user_query plan_outline planner_thought schema prompt response context_fields_json
+	local tool args_json user_query plan_outline planner_thought schema prompt response context_fields_json history_text
 	tool="$1"
 	args_json="$2"
 	user_query="$3"
@@ -142,6 +208,7 @@ fill_missing_args_with_llm() {
 	history_text="$6"
 	context_fields_json="$7"
 	schema="$(jq -c '.' <<<"$(tool_args_schema "${tool}")" 2>/dev/null || printf '{}')"
+	schema="$(build_infill_schema "${tool}" "${schema}" "${history_text}" "${context_fields_json}")"
 
 	if [[ "${LLAMA_AVAILABLE}" != true ]]; then
 		log "WARN" "LLM unavailable; context args remain unchanged" "${tool}" || true

--- a/tests/executor/llm_arg_fill_validation.bats
+++ b/tests/executor/llm_arg_fill_validation.bats
@@ -35,3 +35,33 @@ SCRIPT
 	echo "$json_output" | jq -e '.count == "<<FILL_DURING_EXECUTION>>"' >/dev/null
 	echo "$json_output" | jq -e '.note == "keep"' >/dev/null
 }
+
+@test "build_infill_schema constrains web_fetch url enum from web_search history" {
+	run env -i PATH="$PATH" HOME="$HOME" VERBOSITY=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/executor/loop.sh
+schema='{"type":"object","required":["url"],"properties":{"url":{"type":"string","format":"uri","minLength":1},"max_bytes":{"type":"integer","minimum":1,"maximum":10}}}'
+entry=$(jq -nc '{step:1,thought:"search",action:{tool:"web_search",args:{query:"steelers next game"}},observation:{output:"{\"items\":[{\"url\":\"https://example.com\"},{\"url\":\"https://example.org\"}]}",error:"",exit_code:0}}')
+history_text="${entry}"
+output="$(build_infill_schema "web_fetch" "${schema}" "${history_text}" '["url"]')"
+echo "${output}"
+SCRIPT
+
+	[ "$status" -eq 0 ]
+	json_output="$(printf '%s\n' "$output" | tail -n 1)"
+	echo "$json_output" | jq -e '.properties.url.enum | sort == ["https://example.com","https://example.org"]' >/dev/null
+}
+
+@test "build_infill_schema removes empty url enum when history is missing" {
+	run env -i PATH="$PATH" HOME="$HOME" VERBOSITY=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/executor/loop.sh
+schema='{"type":"object","required":["url"],"properties":{"url":{"type":"string","format":"uri","minLength":1,"enum":[]}}}'
+output="$(build_infill_schema "web_fetch" "${schema}" "" '["url"]')"
+echo "${output}"
+SCRIPT
+
+	[ "$status" -eq 0 ]
+	json_output="$(printf '%s\n' "$output" | tail -n 1)"
+	echo "$json_output" | jq -e '(.properties.url | has("enum")) | not' >/dev/null
+}


### PR DESCRIPTION
### Motivation
- The executor LLM arg-filling schema left the `web_fetch` `url` enum empty even when prior `web_search` results contained URLs, preventing constrained decoding from working.
- The change aims to populate the `url` enum from execution history so the constrained decoder has valid choices and to avoid leaving an empty enum when no URLs exist.

### Description
- Added `build_infill_schema` in `src/lib/executor/loop.sh` which parses executor history entries, extracts `items[].url` from prior `web_search` observations, uniquifies them, and injects them as the `properties.url.enum` for `web_fetch` schemas.
- Integrated the schema enrichment into the arg-fill path by calling `build_infill_schema` from `fill_missing_args_with_llm` so the prompt/schema passed to the LLM is constrained when appropriate.
- Ensures safe fallbacks: when no history or no URLs are found the function removes any empty `enum` to avoid an unusable constraint.
- Documented the behavior in `src/lib/executor/README.md` and added regression tests in `tests/executor/llm_arg_fill_validation.bats` covering both populated and missing-history cases.

### Testing
- Ran `bats tests/executor/llm_arg_fill_validation.bats` which executed 4 tests and reported `4 tests, 0 failures`.
- The new tests verify that `build_infill_schema` correctly populates the `url` enum from `web_search` output and that an empty enum is removed when history is absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed7e807d08325a6669bcc28c5c889)