### PR TITLE
Fix web_fetch allowlist parsing from web_search output

### DIFF
--- a/src/lib/executor/loop.sh
+++ b/src/lib/executor/loop.sh
@@ -73,6 +73,7 @@ extract_urls_from_text() {
 
 collect_web_fetch_allowlist() {
 	# Builds a JSON array of allowed URLs for web_fetch.
+	# Handles web_search observations stored directly or wrapped in tool output metadata.
 	# Arguments:
 	#   $1 - history text (newline-delimited JSON entries)
 	#   $2 - user query
@@ -88,11 +89,33 @@ collect_web_fetch_allowlist() {
 		{
 			if [[ -n "${history_text}" ]]; then
 				jq -n -r '
-                        [inputs | select(length > 0) | try (fromjson) catch empty]
+                        def parse_entry:
+                          if type == "string" then
+                            try (fromjson) catch empty
+                          elif type == "object" then
+                            .
+                          else
+                            empty
+                          end;
+
+                        def search_items:
+                          if (.observation | type) != "object" then
+                            []
+                          elif (.observation.items? | type) == "array" then
+                            .observation.items
+                          elif (.observation.output? | type) == "string" then
+                            (try (.observation.output | fromjson) catch empty | .items? // [])
+                          else
+                            []
+                          end;
+
+                        [inputs | select(length > 0) | parse_entry]
                         | map(select(type == "object"))
                         | .[]
                         | select(.action.tool == "web_search")
-                        | .observation.items[]?.url
+                        | search_items
+                        | .[]?
+                        | .url
                 ' <<<"${history_text}" 2>/dev/null || true
 			fi
 			extract_urls_from_text "${user_query}"

--- a/tests/executor/web_fetch_allowlist.bats
+++ b/tests/executor/web_fetch_allowlist.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+	unset -f chpwd _mise_hook 2>/dev/null || true
+	unset -f __zsh_like_cd cd 2>/dev/null || true
+	# shellcheck disable=SC2034
+	chpwd_functions=()
+}
+
+@test "collect_web_fetch_allowlist extracts urls from web_search tool output metadata" {
+	run env -i HOME="$HOME" PATH="$PATH" bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source ./src/lib/executor/loop.sh
+
+history_entry=$(
+	jq -nc \
+		--arg url "https://www.steelers.com/schedule/" \
+		'{
+                  step: 1,
+                  thought: "Use web_search to find schedule",
+                  action: {tool: "web_search", args: {query: "steelers schedule"}},
+                  observation: {output: ({"items":[{"url": $url}]} | tojson), error: "", exit_code: 0}
+                }'
+)
+
+allowlist="$(collect_web_fetch_allowlist "${history_entry}" "" "" "")"
+jq -e 'index("https://www.steelers.com/schedule/") != null' <<<"${allowlist}" >/dev/null
+SCRIPT
+
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Motivation
- The `web_fetch` URL `enum` was ending up empty because history entries from `web_search` were sometimes wrapped in tool output metadata or stored as JSON strings and not being parsed. 
- The executor needs a reliable allowlist to populate the `web_fetch` args schema so LLM arg-filling can supply valid `url` values.

### Description
- Update `collect_web_fetch_allowlist` in `src/lib/executor/loop.sh` to parse history entries that may be JSON strings or objects using a `parse_entry` jq helper. 
- Extract candidate URLs from both `observation.items` and from JSON encoded `observation.output` by adding a `search_items` jq helper and iterating `.items[].url` when present. 
- Preserve the existing fallback extraction from free text (`extract_urls_from_text`) and normalize the final list into a JSON array for the `web_fetch` schema. 
- Add a regression test `tests/executor/web_fetch_allowlist.bats` that verifies extraction from wrapped `web_search` output metadata.

### Testing
- Ran `bats tests/executor/web_fetch_allowlist.bats` which passed (1 test, 0 failures). 
- The new test covers the case where `web_search` observations are stored as `observation.output` JSON and confirms the allowlist includes the expected URL. 
- No other automated tests were modified or added in this change. 
- All changes were committed and the repository state is clean after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ee776dc148325978ffc8422b3c5f3)